### PR TITLE
Add value_range support to MachineStateEvents for numeric signals

### DIFF
--- a/src/ts_shape/events/production/machine_state.py
+++ b/src/ts_shape/events/production/machine_state.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 from ts_shape.utils.base import Base
 
@@ -27,12 +27,14 @@ class MachineStateEvents(Base):
         event_uuid: str = "prod:run_idle",
         value_column: str = "value_bool",
         time_column: str = "systime",
+        value_range: Optional[Tuple[Optional[float], Optional[float]]] = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.run_state_uuid = run_state_uuid
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self.value_range = value_range
         if "uuid" in self.dataframe.columns and run_state_uuid not in self.dataframe["uuid"].values:
             raise ValueError(
                 f"UUID '{run_state_uuid}' not found in dataframe. "
@@ -47,6 +49,21 @@ class MachineStateEvents(Base):
         self._state_groups: Optional[pd.Series] = None
         self._compute_state_groups()
 
+    def _as_state(self, col: pd.Series) -> pd.Series:
+        """Convert a value series to a boolean running/idle state.
+
+        Uses value_range when set (inclusive on both ends); otherwise casts to bool.
+        """
+        if self.value_range is not None:
+            lower, upper = self.value_range
+            mask = pd.Series(True, index=col.index)
+            if lower is not None:
+                mask &= col >= lower
+            if upper is not None:
+                mask &= col <= upper
+            return mask
+        return col.fillna(False).astype(bool)
+
     def detect_run_idle(self, min_duration: str = "0s") -> pd.DataFrame:
         """Return intervals labeled as 'run' or 'idle'.
 
@@ -58,7 +75,7 @@ class MachineStateEvents(Base):
                 columns=["start", "end", "uuid", "source_uuid", "is_delta", "state", "duration_seconds"]
             )
         s = self.series[[self.time_column, self.value_column]].copy()
-        s["state"] = s[self.value_column].fillna(False).astype(bool)
+        s["state"] = self._as_state(s[self.value_column])
         state_change = (s["state"] != s["state"].shift()).cumsum()
         min_td = pd.to_timedelta(min_duration)
         rows: List[Dict[str, Any]] = []
@@ -91,7 +108,7 @@ class MachineStateEvents(Base):
                 columns=["systime", "uuid", "source_uuid", "is_delta", "transition", "time_since_last_transition_seconds"]
             )
         s = self.series[[self.time_column, self.value_column]].copy()
-        s["state"] = s[self.value_column].fillna(False).astype(bool)
+        s["state"] = self._as_state(s[self.value_column])
         s["prev"] = s["state"].shift()
         changes = s[s["state"] != s["prev"]].dropna(subset=["prev"])  # ignore first row
         if changes.empty:
@@ -122,7 +139,7 @@ class MachineStateEvents(Base):
             self._state_groups = None
             return
         s = self.series[[self.time_column, self.value_column]].copy()
-        s["state"] = s[self.value_column].fillna(False).astype(bool)
+        s["state"] = self._as_state(s[self.value_column])
         self._state_groups = (s["state"] != s["state"].shift()).cumsum()
 
     def detect_rapid_transitions(self, threshold: str = "5s", min_count: int = 3) -> pd.DataFrame:

--- a/tests/test_production_events.py
+++ b/tests/test_production_events.py
@@ -28,6 +28,82 @@ def test_machine_state_intervals_and_transitions():
     assert set(transitions['transition'].unique()) == {'idle_to_run', 'run_to_idle'}
 
 
+def test_machine_state_integer_range():
+    t = pd.date_range('2024-01-01 00:00:00', periods=6, freq='30s')
+    rpm = [0, 50, 150, 200, 80, 0]
+    df = pd.DataFrame({
+        'uuid': ['rpm'] * len(t),
+        'systime': t,
+        'value_integer': rpm,
+        'is_delta': [True] * len(t),
+    })
+
+    # running when rpm >= 100
+    mse = MachineStateEvents(df, run_state_uuid='rpm', value_column='value_integer', value_range=(100, None))
+    intervals = mse.detect_run_idle()
+    assert not intervals.empty
+    run_intervals = intervals[intervals['state'] == 'run']
+    assert not run_intervals.empty
+    # only the two points at rpm=150 and rpm=200 are "run"
+    assert all(run_intervals['duration_seconds'] >= 0)
+
+    transitions = mse.transition_events()
+    assert not transitions.empty
+    assert 'idle_to_run' in transitions['transition'].values
+    assert 'run_to_idle' in transitions['transition'].values
+
+
+def test_machine_state_double_range():
+    t = pd.date_range('2024-01-01 00:00:00', periods=6, freq='30s')
+    current = [0.1, 0.3, 1.5, 2.0, 0.4, 0.2]
+    df = pd.DataFrame({
+        'uuid': ['cur'] * len(t),
+        'systime': t,
+        'value_double': current,
+        'is_delta': [True] * len(t),
+    })
+
+    # running when 0.5 <= current <= 3.0
+    mse = MachineStateEvents(df, run_state_uuid='cur', value_column='value_double', value_range=(0.5, 3.0))
+    intervals = mse.detect_run_idle()
+    assert not intervals.empty
+    states = set(intervals['state'].unique())
+    assert 'run' in states
+    assert 'idle' in states
+
+
+def test_machine_state_open_upper_range():
+    t = pd.date_range('2024-01-01 00:00:00', periods=4, freq='30s')
+    df = pd.DataFrame({
+        'uuid': ['s'] * len(t),
+        'systime': t,
+        'value_double': [0.0, 5.0, 10.0, 0.0],
+        'is_delta': [True] * len(t),
+    })
+
+    # running when value >= 5.0 (no upper bound)
+    mse = MachineStateEvents(df, run_state_uuid='s', value_column='value_double', value_range=(5.0, None))
+    intervals = mse.detect_run_idle()
+    run_intervals = intervals[intervals['state'] == 'run']
+    idle_intervals = intervals[intervals['state'] == 'idle']
+    assert not run_intervals.empty
+    assert not idle_intervals.empty
+
+
+def test_machine_state_range_backward_compat():
+    # value_range=None must behave identically to the original boolean path
+    t = pd.date_range('2024-01-01 00:00:00', periods=4, freq='30s')
+    df = pd.DataFrame({
+        'uuid': ['b'] * len(t),
+        'systime': t,
+        'value_bool': [False, True, True, False],
+        'is_delta': [True] * len(t),
+    })
+    mse = MachineStateEvents(df, run_state_uuid='b', value_range=None)
+    intervals = mse.detect_run_idle()
+    assert set(intervals['state'].unique()) == {'run', 'idle'}
+
+
 def test_line_throughput_count_and_takt():
     # Counter increments every minute by 5 parts
     t = pd.date_range('2024-01-01 00:00:00', periods=6, freq='1min')


### PR DESCRIPTION
Introduces an optional value_range=(lower, upper) parameter so callers can identify run/idle state from value_integer or value_double columns using inclusive threshold comparisons instead of a boolean cast. Either bound may be None for open-ended ranges. Existing boolean behaviour is fully preserved when value_range is omitted.

https://claude.ai/code/session_01BqWMuNgHaQiAKHxUB27hxJ