### PR TITLE
Add eventlog package: pm4py-shaped event model with XES + OCEL columns

### DIFF
--- a/docs/examples/eventlog.md
+++ b/docs/examples/eventlog.md
@@ -1,0 +1,15 @@
+# Event Log Demo
+
+Demonstrates the canonical OCEL 2.0 / XES-shaped event log produced by the `ts_shape.eventlog` package. Two detectors (machine state + outlier) are normalized into one `EventLog`, concatenated, and exported to both XES-flat and OCEL 2.0 tables.
+
+**Run it:** `python examples/eventlog_demo.py`
+
+**Modules demonstrated:** `to_event_log`, `concat`, `to_flat_df`, `to_ocel_tables`, `MachineStateEvents`, `OutlierDetectionEvents`
+
+**Related guides:** [Event Log: pm4py-shaped output for process mining](../guides/eventlog.md)
+
+---
+
+```python
+--8<-- "examples/eventlog_demo.py"
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -27,3 +27,4 @@ Runnable demo scripts covering every ts-shape module. Each example generates syn
 | [Cycle Extractor](cycle-extractor.md) | `CycleExtractor` (6 detection methods) | `python examples/cycle_extractor_enhancements_demo.py` |
 | [Context Enricher](context-enricher.md) | `ContextEnricher`, `ValueMapping` | `python examples/context_enricher_demo.py` |
 | [Statistics (Basic)](statistics-basic.md) | `NumericStatistics`, `StringStatistics`, `BooleanStatistics` | `python examples/statistics_demo.py` |
+| [Event Log (XES & OCEL)](eventlog.md) | `to_event_log`, `concat`, `to_flat_df`, `to_ocel_tables` | `python examples/eventlog_demo.py` |

--- a/docs/guides/eventlog.md
+++ b/docs/guides/eventlog.md
@@ -1,0 +1,181 @@
+# Event Log: pm4py-shaped output for process mining
+
+Every ts-shape detector returns a pandas DataFrame, but the column names differ between detectors — `systime` vs. `start`/`end`, ad-hoc label columns like `state`, `transition`, `rule_violated`. That makes it hard to feed multiple detectors' output into a single process-mining tool without bespoke glue code.
+
+The `ts_shape.eventlog` package solves this with a **canonical event log** whose column names match the [XES](https://xes-standard.org/) and [OCEL 2.0](https://www.ocel-standard.org/) specs verbatim. ts-shape itself imports no process-mining libraries — the resulting DataFrames can be handed to pm4py / Disco / Celonis / OCEL viewers directly.
+
+---
+
+## At a glance
+
+```mermaid
+flowchart LR
+    LD1["Detector A<br/><i>legacy DataFrame</i>"]
+    LD2["Detector B<br/><i>legacy DataFrame</i>"]
+    NORM["to_event_log(...)<br/><i>shape-driven adapter</i>"]
+    LOG["EventLog<br/><i>events / objects / relations</i>"]
+    XES["to_flat_df(...)<br/><i>XES style</i>"]
+    OCEL["to_ocel_tables(...)<br/><i>OCEL 2.0 style</i>"]
+
+    LD1 --> NORM --> LOG
+    LD2 --> NORM
+    LOG --> XES
+    LOG --> OCEL
+
+    style LOG fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style NORM fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+```
+
+- One adapter layer normalizes **all 264** public DataFrame-returning detector methods into the same schema.
+- The event log keeps OCEL's separation of **events**, **objects**, and **event-to-object relations** — no single "case" is forced.
+- `to_flat_df(case_object_type=...)` defers the case-id question to export time: flatten the same log per asset, per batch, per cycle, etc.
+
+---
+
+## The canonical schema
+
+An :class:`EventLog` holds three pandas DataFrames.
+
+### Events
+
+| Column | Type | Notes |
+|---|---|---|
+| `ocel:eid` | string | Stable UUIDv5 of `(detector, timestamp, row-key)`. |
+| `ocel:activity` | string | Dotted activity label, e.g. `production.machine_state.run`. Aliased to `concept:name` on XES export. |
+| `ocel:timestamp` | `datetime64[ns, UTC]` | Event time (interval **end** for intervals). Aliased to `time:timestamp`. |
+| `ts_shape:start_timestamp` | `datetime64[ns, UTC]` | Interval start; `NaT` for point events. |
+| `ts_shape:duration_s` | float | Interval duration in seconds. |
+| `ts_shape:detector` | string | `"ClassName.method_name"` — what produced this event. |
+| `ts_shape:pack` | string | One of: `quality`, `production`, `engineering`, `maintenance`, `supplychain`, `energy`, `correlation`. |
+| `ts_shape:severity` | string | `info` / `warn` / `critical`, mapped from numeric severity scores. |
+| `ts_shape:value` | float | Primary numeric measurement, when applicable. |
+| `<pack>:<col>` | various | Detector-specific attributes, prefixed with the pack name. |
+
+### Objects
+
+| Column | Type | Notes |
+|---|---|---|
+| `ocel:oid` | string | Object id (asset uuid, batch id, serial, ...). |
+| `ocel:type` | string | One of the registered object types: `asset`, `cycle`, `batch`, `lot`, `material`, `serial`, `article`, `part`, `work_order`, `shift`, `operator`, `tool`, `recipe`, `station`, `signal`, `sensor` (extensible via `register_object_type`). |
+
+### Relations (event ↔ object)
+
+| Column | Type | Notes |
+|---|---|---|
+| `ocel:eid` | string | The event. |
+| `ocel:oid` | string | The object. |
+| `ocel:type` | string | Denormalized for convenience. |
+| `ocel:qualifier` | string \| `<NA>` | Role of the object in the event, e.g. `produced_on`, `during_batch`. |
+
+---
+
+## Activity-name taxonomy
+
+Every activity name follows `pack.family.specifier[.subtype]`, lowercase, snake_case. Templated specifiers (e.g. `{state}`) get substituted from legacy DataFrame columns.
+
+| Detector method | `ocel:activity` |
+|---|---|
+| `OutlierDetectionEvents.detect_outliers_zscore` | `quality.outlier.zscore` |
+| `StatisticalProcessControlRuleBased.process` | `quality.spc.rule_violation` |
+| `MachineStateEvents.detect_run_idle` | `production.machine_state.{state}` |
+| `MachineStateEvents.transition_events` | `production.machine_state.transition_{transition}` |
+| `SetpointChangeEvents.detect_setpoint_steps` | `engineering.setpoint.step_{change_type}` |
+| `DegradationDetectionEvents.detect_trend_degradation` | `maintenance.degradation.trend` |
+
+The full registry lives in `ts_shape.eventlog.taxonomy.REGISTRY` and is enforced by `tests/eventlog/test_adapter_coverage.py` — adding a new detector method without registering a label rule fails CI.
+
+---
+
+## Object bindings
+
+OCEL is multi-object: an event can be linked to *several* objects of *several* types. ts-shape distinguishes two ways an object ends up on an event:
+
+1. **Auto-extracted** by the adapter from a standard legacy column. Each `LabelRule` declares `produces_objects` (e.g. `("asset",)`); when the legacy DataFrame contains the matching column (e.g. `source_uuid`), the asset object is created automatically.
+2. **Caller-supplied** via the `objects=` argument. This is for *contextual* annotations — "this outlier happened during batch B-2026-117 on shift A". Caller-supplied bindings can use any object type.
+
+```python
+to_event_log(
+    legacy_df,
+    detector="OutlierDetectionEvents.detect_outliers_zscore",
+    objects={
+        "batch":    "batch_id",                 # column name
+        "operator": lambda r: r["op_id"][:6],   # callable
+        "shift":    "A",                        # scalar broadcast
+    },
+    qualifiers={"asset": "produced_on", "batch": "during_batch"},
+)
+```
+
+If a method has no natural object association at all (e.g. a global cross-signal correlation statistic), the adapter declares `produces_objects = ()` and the resulting `EventLog` has empty `objects` and `relations` tables. Calling `to_flat_df(...)` on such a log raises a clear error rather than fabricating object ids.
+
+---
+
+## Quick start
+
+```python
+from ts_shape.events.production.machine_state import MachineStateEvents
+from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+from ts_shape.eventlog import to_event_log, concat, to_flat_df, to_ocel_tables
+
+# 1. Run two detectors on the same input.
+state_legacy = MachineStateEvents(df, run_state_uuid="asset-A").detect_run_idle()
+outlier_legacy = OutlierDetectionEvents(df2, value_column="torque").detect_outliers_zscore()
+
+# 2. Normalize each into a canonical EventLog.
+state_log = to_event_log(state_legacy, detector="MachineStateEvents.detect_run_idle")
+outlier_log = to_event_log(
+    outlier_legacy,
+    detector="OutlierDetectionEvents.detect_outliers_zscore",
+    objects={"batch": "batch_id"},
+)
+
+# 3. Combine; sorted by timestamp, objects deduped.
+log = concat(state_log, outlier_log)
+
+# 4a. Flatten for XES tools (pm4py, Disco, Celonis).
+xes_df = to_flat_df(log, case_object_type="asset")
+# Now xes_df has case:concept:name / concept:name / time:timestamp columns.
+
+# 4b. Or hand the OCEL tables to pm4py directly.
+events_df, objects_df, relations_df = to_ocel_tables(log)
+# import pm4py; pm4py.write_ocel2_json(...)
+```
+
+---
+
+## Interval encoding
+
+OCEL events have a single timestamp; XES traces care about start/complete pairs. The canonical event log keeps **one row per event** with `ocel:timestamp` = interval end and `ts_shape:start_timestamp` = interval start. The XES exporter then offers two lifecycle modes:
+
+- `lifecycle="single"` (default): one row, `lifecycle:transition="complete"`.
+- `lifecycle="two_row"`: expands intervals into a `start` row + `complete` row, paired by `concept:instance` for strict XES-compliance.
+
+```python
+xes_complete_only = to_flat_df(log, case_object_type="asset", lifecycle="single")
+xes_with_starts = to_flat_df(log, case_object_type="asset", lifecycle="two_row")
+```
+
+---
+
+## Custom adapters
+
+For the rare detector whose output doesn't fit any of the four shapes (`point`, `interval`, `summary`, `static`), register a custom adapter:
+
+```python
+from ts_shape.eventlog import register_adapter, EventLog
+
+@register_adapter("MyDetector", "weird_method")
+def my_adapter(legacy_df, *, rule, detector, objects, qualifiers):
+    # build events / objects / relations DataFrames yourself
+    return EventLog(events=..., objects=..., relations=...)
+```
+
+The override is consulted before the shape-driven generic adapter.
+
+---
+
+## What ts-shape does *not* do
+
+The package writes no XES files, no OCEL JSON, no SQLite — those are pm4py's job. ts-shape's responsibility ends at producing DataFrames whose column names match the specs. This keeps the dependency footprint small and lets users pick whichever process-mining stack they prefer.
+
+A worked end-to-end example (with output) is in [examples/eventlog](../examples/eventlog.md).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -161,6 +161,14 @@ Pick the stage that matches where you are in your analysis.
 
     `PerformanceLossTracking` | `ScrapTracking` | `TargetTracking` | `SetupTimeTracking` | +4 more
 
+-   :material-graph-outline:{ .lg .middle } **[Event Log (XES & OCEL)](eventlog.md)**
+
+    ---
+
+    Normalize any detector's output into a canonical event log with OCEL 2.0 / XES column names. Concatenate logs across detectors, then export per-asset / per-batch / per-cycle traces for pm4py, Disco, or Celonis.
+
+    `to_event_log` | `concat` | `to_flat_df` | `to_ocel_tables`
+
 </div>
 
 ---

--- a/examples/eventlog_demo.py
+++ b/examples/eventlog_demo.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+EventLog Demo for ts-shape
+==========================
+
+Demonstrates the canonical OCEL 2.0 / XES-shaped event log produced by the
+``ts_shape.eventlog`` package:
+
+1. Run two detectors on a synthetic timeseries.
+2. Normalize each detector's legacy DataFrame into an :class:`EventLog`.
+3. Concatenate the logs and inspect the events / objects / relations tables.
+4. Export to a flat XES-style DataFrame (one row per event, with
+   ``case:concept:name``, ``concept:name``, ``time:timestamp``, ...).
+5. Export to OCEL 2.0 tables — ready for ``pm4py.write_ocel2_json``.
+
+Scenario: a packaging line asset (``asset-A``) cycles between run/idle and
+produces occasional outlier readings on its torque sensor. We want a single
+event log spanning both quality and production events, keyed by asset.
+
+Run it:  ``python examples/eventlog_demo.py``
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+from ts_shape.events.production.machine_state import MachineStateEvents
+from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+from ts_shape.eventlog import (
+    concat,
+    to_event_log,
+    to_flat_df,
+    to_ocel_tables,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Synthesize a 30-minute timeseries: machine state + torque readings
+# ---------------------------------------------------------------------------
+
+def synth_inputs() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return two legacy DataFrames in the format ts-shape detectors expect."""
+    start = datetime(2026, 5, 7, 8, 0, 0)
+    rng = np.random.default_rng(42)
+
+    # Run/idle bool stream sampled every 30s, alternating in 5-minute blocks.
+    state_ts = pd.date_range(start, periods=60, freq="30s", tz="UTC")
+    state_vals = ([True] * 10 + [False] * 5) * 4  # 5min run / 2.5min idle
+    state_df = pd.DataFrame({
+        "systime": state_ts,
+        "value_bool": state_vals,
+        "uuid": ["asset-A"] * 60,
+        "is_delta": [(i == 0 or state_vals[i] != state_vals[i - 1])
+                     for i in range(60)],
+    })
+
+    # Torque readings every 1 minute with two injected outliers.
+    torque_ts = pd.date_range(start, periods=30, freq="1min", tz="UTC")
+    torque = rng.normal(loc=42.0, scale=0.8, size=30)
+    torque[12] = 80.0   # spike up
+    torque[24] = 5.0    # spike down
+    torque_df = pd.DataFrame({
+        "systime": torque_ts,
+        "value_double": torque,
+        "uuid": ["torque_sensor"] * 30,
+        "is_delta": [False] * 30,
+        "source_uuid": ["asset-A"] * 30,
+        "batch_id": ["B-2026-117"] * 15 + ["B-2026-118"] * 15,
+    })
+    return state_df, torque_df
+
+
+# ---------------------------------------------------------------------------
+# 2. Run detectors and normalize their output
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    state_df, torque_df = synth_inputs()
+
+    # --- machine state: interval events ------------------------------------
+    state_legacy = MachineStateEvents(
+        state_df, run_state_uuid="asset-A"
+    ).detect_run_idle()
+    # The legacy DataFrame already carries ``source_uuid``; the adapter
+    # auto-binds it to the OCEL ``asset`` object type.
+    state_log = to_event_log(
+        state_legacy,
+        detector="MachineStateEvents.detect_run_idle",
+    )
+
+    # --- outlier: point events with severity -------------------------------
+    outlier_legacy = OutlierDetectionEvents(
+        torque_df, value_column="value_double"
+    ).detect_outliers_zscore()
+    # Bind the ``batch_id`` column to the ``batch`` object type as well, so
+    # we can later flatten the log per-asset OR per-batch.
+    outlier_log = to_event_log(
+        outlier_legacy,
+        detector="OutlierDetectionEvents.detect_outliers_zscore",
+        objects={"batch": "batch_id"},
+        qualifiers={"asset": "produced_on", "batch": "during_batch"},
+    )
+
+    # --- concat into a single log ------------------------------------------
+    log = concat(state_log, outlier_log)
+
+    print("=" * 70)
+    print("EventLog summary")
+    print("=" * 70)
+    print(log)
+    print()
+
+    cols = [
+        "ocel:eid", "ocel:activity", "ocel:timestamp",
+        "ts_shape:start_timestamp", "ts_shape:duration_s",
+        "ts_shape:severity", "ts_shape:value",
+    ]
+    print("--- events (head) ---")
+    print(log.events[cols].to_string(index=False))
+    print()
+    print("--- objects ---")
+    print(log.objects.to_string(index=False))
+    print()
+    print("--- relations (head) ---")
+    print(log.relations.head(10).to_string(index=False))
+    print()
+
+    # ---------------------------------------------------------------------
+    # 3. Flat XES-style export
+    # ---------------------------------------------------------------------
+
+    print("=" * 70)
+    print("Flat XES export — case = asset")
+    print("=" * 70)
+    xes_asset = to_flat_df(log, case_object_type="asset", lifecycle="single")
+    print(xes_asset[
+        ["case:concept:name", "concept:name", "time:timestamp",
+         "lifecycle:transition"]
+    ].to_string(index=False))
+    print()
+
+    print("=" * 70)
+    print("Flat XES export — case = batch (only outlier events have batches)")
+    print("=" * 70)
+    xes_batch = to_flat_df(log, case_object_type="batch")
+    print(xes_batch[
+        ["case:concept:name", "concept:name", "time:timestamp"]
+    ].to_string(index=False))
+    print()
+
+    # ---------------------------------------------------------------------
+    # 4. OCEL 2.0 export (column names match the spec verbatim)
+    # ---------------------------------------------------------------------
+
+    events_df, objects_df, relations_df = to_ocel_tables(log)
+    print("=" * 70)
+    print("OCEL 2.0 tables")
+    print("=" * 70)
+    print(f"events:    {events_df.shape}")
+    print(f"objects:   {objects_df.shape}")
+    print(f"relations: {relations_df.shape}")
+    print()
+    print("These three frames can be passed directly to e.g.:")
+    print("  pm4py.write_ocel2_json(...)")
+    print("  pm4py.format_dataframe(xes_asset, ...)")
+    print("ts-shape itself imports neither — column names match the specs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Product Traceability: guides/traceability.md
   - Process Engineering: guides/engineering.md
   - Shift Reports & KPIs: guides/reporting.md
+  - Event Log (XES & OCEL): guides/eventlog.md
 - Pipelines:
   - Overview: pipelines/index.md
   - OEE Dashboard: pipelines/oee-dashboard.md
@@ -131,6 +132,7 @@ nav:
   - Cycle Extractor: examples/cycle-extractor.md
   - Context Enricher: examples/context-enricher.md
   - Statistics (Basic): examples/statistics-basic.md
+  - Event Log (XES & OCEL): examples/eventlog.md
 - API Reference: reference/
 - Development:
   - Contributing: contributing.md

--- a/src/ts_shape/eventlog/__init__.py
+++ b/src/ts_shape/eventlog/__init__.py
@@ -1,0 +1,83 @@
+"""ts-shape canonical event-log package.
+
+A lightweight, pm4py-compatible (XES + OCEL 2.0) representation of detector
+output. ts-shape itself adds no process-mining dependencies — the columns
+match the specs verbatim so users can hand the resulting DataFrames to
+pm4py / Disco / Celonis / OCEL viewers directly.
+
+Typical use::
+
+    from ts_shape.eventlog import to_event_log, concat, to_flat_df, to_ocel_tables
+    from ts_shape.events.production.machine_state import MachineStateEvents
+    from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+
+    state_log = to_event_log(
+        MachineStateEvents(df, run_state_uuid="m").detect_run_idle(),
+        detector="MachineStateEvents.detect_run_idle",
+    )
+    outlier_log = to_event_log(
+        OutlierDetectionEvents(df, value_column="value_double").detect_outliers_zscore(),
+        detector="OutlierDetectionEvents.detect_outliers_zscore",
+    )
+    log = concat(state_log, outlier_log)
+    xes_df = to_flat_df(log, case_object_type="asset")
+    events_df, objects_df, relations_df = to_ocel_tables(log)
+"""
+from .adapters import register_adapter
+from .concat import concat
+from .flat import to_flat_df
+from .model import EventLog
+from .normalizer import to_event_log
+from .ocel import to_ocel_tables
+from .schema import (
+    OCEL_ACTIVITY,
+    OCEL_EID,
+    OCEL_OID,
+    OCEL_QUALIFIER,
+    OCEL_TIMESTAMP,
+    OCEL_TYPE,
+    TS_DETECTOR,
+    TS_DURATION_S,
+    TS_PACK,
+    TS_SEVERITY,
+    TS_START_TIMESTAMP,
+    TS_VALUE,
+    XES_ACTIVITY,
+    XES_CASE,
+    XES_LIFECYCLE,
+    XES_RESOURCE,
+    XES_TIMESTAMP,
+    register_object_type,
+    validate,
+)
+from .taxonomy import REGISTRY, LabelRule
+
+__all__ = [
+    "EventLog",
+    "LabelRule",
+    "REGISTRY",
+    "concat",
+    "register_adapter",
+    "register_object_type",
+    "to_event_log",
+    "to_flat_df",
+    "to_ocel_tables",
+    "validate",
+    "OCEL_ACTIVITY",
+    "OCEL_EID",
+    "OCEL_OID",
+    "OCEL_QUALIFIER",
+    "OCEL_TIMESTAMP",
+    "OCEL_TYPE",
+    "TS_DETECTOR",
+    "TS_DURATION_S",
+    "TS_PACK",
+    "TS_SEVERITY",
+    "TS_START_TIMESTAMP",
+    "TS_VALUE",
+    "XES_ACTIVITY",
+    "XES_CASE",
+    "XES_LIFECYCLE",
+    "XES_RESOURCE",
+    "XES_TIMESTAMP",
+]

--- a/src/ts_shape/eventlog/adapters.py
+++ b/src/ts_shape/eventlog/adapters.py
@@ -1,0 +1,332 @@
+"""Shape-driven adapters that convert legacy detector DataFrames into the
+canonical :class:`~ts_shape.eventlog.model.EventLog`.
+
+There is one adapter implementation per *shape* (point, interval, summary,
+static). The per-method specifics live in
+:mod:`ts_shape.eventlog.taxonomy` (the ``REGISTRY``). A custom adapter for
+a specific ``(class, method)`` pair can be registered with
+``@register_adapter(...)`` to override the shape-driven default — useful
+for the few detectors whose legacy schema does not fit any standard shape.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Callable, Mapping, Sequence
+
+import pandas as pd
+
+from . import schema
+from .model import EventLog
+from .taxonomy import LabelRule, render_activity
+
+
+# ----------------------------------------------------------------------------
+# Registry of optional per-method overrides
+# ----------------------------------------------------------------------------
+
+AdapterFn = Callable[..., EventLog]
+_OVERRIDES: dict[tuple[str, str], AdapterFn] = {}
+
+
+def register_adapter(class_name: str, method_name: str) -> Callable[[AdapterFn], AdapterFn]:
+    """Register a custom adapter for a specific ``(class, method)``.
+
+    The function will be called with ``(legacy_df, *, rule, detector,
+    objects, qualifiers)``.
+    """
+    def deco(fn: AdapterFn) -> AdapterFn:
+        _OVERRIDES[(class_name, method_name)] = fn
+        return fn
+    return deco
+
+
+def get_override(class_name: str, method_name: str) -> AdapterFn | None:
+    return _OVERRIDES.get((class_name, method_name))
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+_NAMESPACE = _uuid.UUID("8a4d3f1c-9b2e-4d3a-8f1e-c0ffee123456")
+
+
+def _eid(detector: str, ts: pd.Timestamp, key: str) -> str:
+    return "e-" + str(_uuid.uuid5(_NAMESPACE, f"{detector}|{ts.isoformat()}|{key}"))
+
+
+def _to_utc_ts(value: object) -> pd.Timestamp | pd._libs.tslibs.nattype.NaTType:
+    if value is None:
+        return pd.NaT
+    ts = pd.Timestamp(value)
+    if ts is pd.NaT:
+        return pd.NaT
+    if ts.tz is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def _pick_time_col(df: pd.DataFrame, candidates: Sequence[str]) -> str | None:
+    for c in candidates:
+        if c in df.columns:
+            return c
+    # Fall back to first datetime-like column.
+    for c in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[c]):
+            return c
+    return None
+
+
+_POINT_CANDIDATES = (
+    "systime", "timestamp", "time", "event_time", "ts", "datetime",
+    "window_start", "window_end", "period_start", "period_end", "date",
+)
+
+
+def _classify_severity(value: object) -> str | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if v >= 4.5:
+        return "critical"
+    if v >= 3.0:
+        return "warn"
+    return "info"
+
+
+def _build_attrs_columns(
+    legacy: pd.DataFrame,
+    *,
+    pack: str,
+    drop: set[str],
+) -> dict[str, pd.Series]:
+    """Return a dict of ``"<pack>:<col>" -> Series`` for non-canonical columns."""
+    out: dict[str, pd.Series] = {}
+    for col in legacy.columns:
+        if col in drop:
+            continue
+        out[f"{pack}:{col}"] = legacy[col].reset_index(drop=True)
+    return out
+
+
+def _resolve_objects(
+    legacy: pd.DataFrame,
+    rule: LabelRule,
+    user_objects: Mapping[str, object] | None,
+) -> dict[str, pd.Series]:
+    """Produce ``object_type -> Series-of-oids`` aligned with legacy rows.
+
+    Only object types declared in ``rule.produces_objects`` are honored.
+    A user-provided binding overrides defaults for a given type.
+    """
+    declared = set(rule.produces_objects)
+    if not declared:
+        if user_objects:
+            raise ValueError(
+                f"adapter for {rule.template!r} declares no objects "
+                f"but caller supplied bindings: {list(user_objects)!r}"
+            )
+        return {}
+
+    bindings: dict[str, pd.Series] = {}
+
+    def _bind(otype: str, value: object) -> None:
+        if otype not in declared:
+            raise ValueError(
+                f"object type {otype!r} not declared by adapter "
+                f"(declared: {sorted(declared)})"
+            )
+        if isinstance(value, str):
+            if value not in legacy.columns:
+                return  # silently skip; column not present
+            bindings[otype] = legacy[value].reset_index(drop=True).astype("string")
+        elif callable(value):
+            bindings[otype] = pd.Series(
+                [value(r) for r in legacy.to_dict("records")], dtype="string"
+            )
+        elif isinstance(value, pd.Series):
+            bindings[otype] = value.reset_index(drop=True).astype("string")
+        else:
+            # Scalar broadcast.
+            bindings[otype] = pd.Series([str(value)] * len(legacy), dtype="string")
+
+    if user_objects:
+        for otype, val in user_objects.items():
+            _bind(otype, val)
+
+    # Defaults: asset = source_uuid if column exists.
+    if "asset" in declared and "asset" not in bindings:
+        if "source_uuid" in legacy.columns:
+            bindings["asset"] = legacy["source_uuid"].reset_index(drop=True).astype("string")
+
+    # Drop empty / all-NaN bindings.
+    return {k: v for k, v in bindings.items() if not v.isna().all()}
+
+
+def _to_relations(
+    eids: pd.Series,
+    object_bindings: Mapping[str, pd.Series],
+    qualifiers: Mapping[str, str] | None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if not object_bindings:
+        return schema.empty_objects(), schema.empty_relations()
+
+    qualifiers = qualifiers or {}
+    rel_frames: list[pd.DataFrame] = []
+    obj_pairs: list[tuple[str, str]] = []
+    for otype, oids in object_bindings.items():
+        oids = oids.reset_index(drop=True)
+        mask = oids.notna() & (oids.astype(str) != "") & (oids.astype(str) != "<NA>")
+        if not mask.any():
+            continue
+        rel_frames.append(pd.DataFrame({
+            schema.OCEL_EID: eids[mask].reset_index(drop=True).astype("string"),
+            schema.OCEL_OID: oids[mask].astype("string").reset_index(drop=True),
+            schema.OCEL_TYPE: pd.Series([otype] * int(mask.sum()), dtype="string"),
+            schema.OCEL_QUALIFIER: pd.Series(
+                [qualifiers.get(otype)] * int(mask.sum()), dtype="string"
+            ),
+        }))
+        for o in oids[mask].astype(str).unique():
+            obj_pairs.append((o, otype))
+
+    relations = (pd.concat(rel_frames, ignore_index=True)
+                 if rel_frames else schema.empty_relations())
+    if obj_pairs:
+        obj_df = pd.DataFrame(obj_pairs, columns=[schema.OCEL_OID, schema.OCEL_TYPE])
+        obj_df = obj_df.drop_duplicates().reset_index(drop=True)
+        obj_df[schema.OCEL_OID] = obj_df[schema.OCEL_OID].astype("string")
+        obj_df[schema.OCEL_TYPE] = obj_df[schema.OCEL_TYPE].astype("string")
+    else:
+        obj_df = schema.empty_objects()
+    return obj_df, relations
+
+
+_RESERVED = {"start", "end", "systime", "uuid", "source_uuid"}
+
+
+def _value_series(legacy: pd.DataFrame, rule: LabelRule) -> pd.Series:
+    if rule.value_field and rule.value_field in legacy.columns:
+        return pd.to_numeric(legacy[rule.value_field], errors="coerce")
+    for c in ("value", "value_double", "value_integer", "ts_shape:value"):
+        if c in legacy.columns:
+            return pd.to_numeric(legacy[c], errors="coerce")
+    return pd.Series([float("nan")] * len(legacy), dtype="float64")
+
+
+def _severity_series(legacy: pd.DataFrame, rule: LabelRule) -> pd.Series:
+    if rule.severity_field and rule.severity_field in legacy.columns:
+        col = legacy[rule.severity_field]
+        return col.map(_classify_severity).astype("string")
+    if "severity" in legacy.columns:
+        return legacy["severity"].astype("string")
+    return pd.Series([pd.NA] * len(legacy), dtype="string")
+
+
+# ----------------------------------------------------------------------------
+# The shape-driven adapter
+# ----------------------------------------------------------------------------
+
+def adapt(
+    legacy: pd.DataFrame,
+    *,
+    rule: LabelRule,
+    detector: str,
+    objects: Mapping[str, object] | None = None,
+    qualifiers: Mapping[str, str] | None = None,
+) -> EventLog:
+    """Convert one detector's output into a canonical :class:`EventLog`."""
+    if legacy is None or len(legacy) == 0:
+        return EventLog()
+
+    legacy = legacy.reset_index(drop=True)
+    n = len(legacy)
+
+    # Resolve timestamps based on shape.
+    if rule.shape == "interval":
+        start_col = _pick_time_col(legacy, ("start", "window_start", "period_start"))
+        end_col = _pick_time_col(legacy, ("end", "window_end", "period_end"))
+        if start_col is None or end_col is None:
+            # Fall back to point shape if data lacks interval columns.
+            return adapt(legacy, rule=LabelRule(
+                template=rule.template, pack=rule.pack, shape="point",
+                produces_objects=rule.produces_objects,
+                severity_field=rule.severity_field, value_field=rule.value_field,
+                drop_fields=rule.drop_fields,
+            ), detector=detector, objects=objects, qualifiers=qualifiers)
+        ts_end = legacy[end_col].apply(_to_utc_ts)
+        ts_start = legacy[start_col].apply(_to_utc_ts)
+        duration = (ts_end - ts_start).dt.total_seconds() if len(legacy) else pd.Series(dtype="float64")
+        time_cols_used = {start_col, end_col}
+    elif rule.shape in {"point", "summary"}:
+        time_col = _pick_time_col(legacy, _POINT_CANDIDATES)
+        if time_col is None:
+            ts_end = pd.Series([pd.Timestamp.utcnow()] * n)
+            time_cols_used = set()
+        else:
+            ts_end = legacy[time_col].apply(_to_utc_ts)
+            time_cols_used = {time_col}
+        # Summary may have a window_start / period_start counterpart.
+        start_col = _pick_time_col(legacy, ("window_start", "period_start", "start"))
+        if rule.shape == "summary" and start_col is not None and start_col != time_col:
+            ts_start = legacy[start_col].apply(_to_utc_ts)
+            time_cols_used.add(start_col)
+            duration = (ts_end - ts_start).dt.total_seconds()
+        else:
+            ts_start = pd.Series([pd.NaT] * n, dtype="datetime64[ns, UTC]")
+            duration = pd.Series([float("nan")] * n, dtype="float64")
+    elif rule.shape == "static":
+        # No natural time. Use a single fixed reference (now-UTC) for all rows.
+        now = pd.Timestamp.utcnow().tz_convert("UTC") if pd.Timestamp.utcnow().tz else pd.Timestamp.utcnow().tz_localize("UTC")
+        ts_end = pd.Series([now] * n)
+        ts_start = pd.Series([pd.NaT] * n, dtype="datetime64[ns, UTC]")
+        duration = pd.Series([float("nan")] * n, dtype="float64")
+        time_cols_used = set()
+    else:
+        raise ValueError(f"unknown shape {rule.shape!r}")
+
+    # Render activity name (template substitution per row).
+    activities = legacy.apply(lambda r: render_activity(rule, r), axis=1).astype("string")
+
+    # Build canonical event ids.
+    eids = pd.Series(
+        [_eid(detector, ts_end.iloc[i], f"{i}|{activities.iloc[i]}") for i in range(n)],
+        dtype="string",
+    )
+
+    severity = _severity_series(legacy, rule)
+    value = _value_series(legacy, rule)
+
+    # Drop time columns + columns redundantly captured elsewhere from attrs.
+    drop = set(time_cols_used) | set(rule.drop_fields)
+    if rule.severity_field:
+        drop.add(rule.severity_field)
+    if rule.value_field:
+        drop.add(rule.value_field)
+    # Don't dump huge object columns (`is_delta` etc are kept as attrs).
+    attrs = _build_attrs_columns(legacy, pack=rule.pack, drop=drop)
+
+    events = pd.DataFrame({
+        schema.OCEL_EID: eids,
+        schema.OCEL_ACTIVITY: activities,
+        schema.OCEL_TIMESTAMP: ts_end.astype("datetime64[ns, UTC]"),
+        schema.TS_START_TIMESTAMP: ts_start.astype("datetime64[ns, UTC]"),
+        schema.TS_DURATION_S: duration.astype("float64"),
+        schema.TS_DETECTOR: pd.Series([detector] * n, dtype="string"),
+        schema.TS_PACK: pd.Series([rule.pack] * n, dtype="string"),
+        schema.TS_SEVERITY: severity.astype("string"),
+        schema.TS_VALUE: value.astype("float64"),
+        **attrs,
+    })
+
+    object_bindings = _resolve_objects(legacy, rule, objects)
+    objects_df, relations_df = _to_relations(eids, object_bindings, qualifiers)
+
+    return EventLog(events=events, objects=objects_df, relations=relations_df)

--- a/src/ts_shape/eventlog/adapters.py
+++ b/src/ts_shape/eventlog/adapters.py
@@ -123,26 +123,17 @@ def _resolve_objects(
 ) -> dict[str, pd.Series]:
     """Produce ``object_type -> Series-of-oids`` aligned with legacy rows.
 
-    Only object types declared in ``rule.produces_objects`` are honored.
-    A user-provided binding overrides defaults for a given type.
+    Auto-extracts types declared in ``rule.produces_objects`` from the
+    legacy DataFrame's standard columns (e.g. ``source_uuid -> asset``).
+    Caller-supplied bindings via ``user_objects`` are always honored —
+    object types not declared by the adapter are treated as contextual
+    annotations the caller knows about (e.g. "this outlier happened
+    during batch B-2026-117").
     """
     declared = set(rule.produces_objects)
-    if not declared:
-        if user_objects:
-            raise ValueError(
-                f"adapter for {rule.template!r} declares no objects "
-                f"but caller supplied bindings: {list(user_objects)!r}"
-            )
-        return {}
-
     bindings: dict[str, pd.Series] = {}
 
     def _bind(otype: str, value: object) -> None:
-        if otype not in declared:
-            raise ValueError(
-                f"object type {otype!r} not declared by adapter "
-                f"(declared: {sorted(declared)})"
-            )
         if isinstance(value, str):
             if value not in legacy.columns:
                 return  # silently skip; column not present

--- a/src/ts_shape/eventlog/concat.py
+++ b/src/ts_shape/eventlog/concat.py
@@ -1,0 +1,32 @@
+"""Concatenate multiple :class:`EventLog` instances into one."""
+from __future__ import annotations
+
+import pandas as pd
+
+from . import schema
+from .model import EventLog
+
+
+def concat(*logs: EventLog) -> EventLog:
+    if not logs:
+        return EventLog()
+    events = pd.concat([l.events for l in logs], ignore_index=True)
+    objects = pd.concat([l.objects for l in logs], ignore_index=True)
+    relations = pd.concat([l.relations for l in logs], ignore_index=True)
+
+    if not objects.empty:
+        objects = objects.drop_duplicates(
+            subset=[schema.OCEL_OID, schema.OCEL_TYPE]
+        ).reset_index(drop=True)
+
+    if not events.empty:
+        events = events.sort_values(schema.OCEL_TIMESTAMP).reset_index(drop=True)
+        # Deduplicate identical event ids (e.g. same input passed twice).
+        events = events.drop_duplicates(subset=[schema.OCEL_EID]).reset_index(drop=True)
+
+    if not relations.empty:
+        relations = relations.drop_duplicates(
+            subset=[schema.OCEL_EID, schema.OCEL_OID, schema.OCEL_TYPE]
+        ).reset_index(drop=True)
+
+    return EventLog(events=events, objects=objects, relations=relations)

--- a/src/ts_shape/eventlog/flat.py
+++ b/src/ts_shape/eventlog/flat.py
@@ -1,0 +1,85 @@
+"""XES-flat exporter — produces a pandas DataFrame with ``case:concept:name``,
+``concept:name``, ``time:timestamp``, ``lifecycle:transition``,
+``org:resource`` columns. ts-shape itself does **not** import pm4py; users
+pass this DataFrame to ``pm4py.format_dataframe`` themselves.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from . import schema
+from .model import EventLog
+
+
+def to_flat_df(
+    eventlog: EventLog,
+    *,
+    case_object_type: str = "asset",
+    lifecycle: str = "single",
+) -> pd.DataFrame:
+    """Flatten the event log into an XES-style DataFrame.
+
+    A trace is built per object of ``case_object_type`` — each event linked
+    to that object becomes one (or two) rows in the trace.
+
+    ``lifecycle="single"`` — interval events become one row with
+    ``lifecycle:transition="complete"``. ``time:timestamp`` is the
+    interval-end; ``start_timestamp`` is exposed verbatim.
+
+    ``lifecycle="two_row"`` — interval events expand into a ``start`` row
+    (using ``ts_shape:start_timestamp``) and a ``complete`` row, paired by
+    ``concept:instance``.
+    """
+    if not eventlog.has_objects:
+        raise ValueError(
+            "to_flat_df requires objects: this event log was produced by a "
+            "detector with no object association. Use to_ocel_tables() or "
+            "supply objects to the adapter."
+        )
+    if lifecycle not in ("single", "two_row"):
+        raise ValueError(f"invalid lifecycle {lifecycle!r}")
+
+    rels = eventlog.relations
+    rels = rels[rels[schema.OCEL_TYPE] == case_object_type]
+    if rels.empty:
+        raise ValueError(
+            f"no objects of type {case_object_type!r} in event log; "
+            f"available types: {eventlog.relations[schema.OCEL_TYPE].unique().tolist()}"
+        )
+
+    joined = rels.merge(eventlog.events, on=schema.OCEL_EID, how="inner")
+
+    rename = {
+        schema.OCEL_OID: schema.XES_CASE,
+        schema.OCEL_ACTIVITY: schema.XES_ACTIVITY,
+        schema.OCEL_TIMESTAMP: schema.XES_TIMESTAMP,
+    }
+    base = joined.rename(columns=rename)
+    base[schema.XES_RESOURCE] = base.get(schema.XES_CASE)
+    base["start_timestamp"] = base[schema.TS_START_TIMESTAMP]
+
+    if lifecycle == "single":
+        base[schema.XES_LIFECYCLE] = "complete"
+        return _arrange_columns(base)
+
+    # Two-row expansion.
+    has_start = base[schema.TS_START_TIMESTAMP].notna()
+    starts = base[has_start].copy()
+    starts[schema.XES_TIMESTAMP] = starts[schema.TS_START_TIMESTAMP]
+    starts[schema.XES_LIFECYCLE] = "start"
+    completes = base.copy()
+    completes[schema.XES_LIFECYCLE] = "complete"
+    expanded = pd.concat([starts, completes], ignore_index=True)
+    expanded[schema.XES_INSTANCE] = expanded[schema.OCEL_EID]
+    expanded = expanded.sort_values(
+        [schema.XES_CASE, schema.XES_TIMESTAMP, schema.XES_LIFECYCLE]
+    ).reset_index(drop=True)
+    return _arrange_columns(expanded)
+
+
+def _arrange_columns(df: pd.DataFrame) -> pd.DataFrame:
+    head = [schema.XES_CASE, schema.XES_ACTIVITY, schema.XES_TIMESTAMP,
+            schema.XES_LIFECYCLE, schema.XES_RESOURCE, "start_timestamp"]
+    head = [c for c in head if c in df.columns]
+    rest = [c for c in df.columns if c not in head]
+    return df[head + rest]

--- a/src/ts_shape/eventlog/model.py
+++ b/src/ts_shape/eventlog/model.py
@@ -1,0 +1,67 @@
+"""The :class:`EventLog` dataclass — three DataFrames in OCEL 2.0 shape."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from . import schema
+
+
+@dataclass
+class EventLog:
+    """Canonical ts-shape event log: events + (optional) objects + relations.
+
+    Objects/relations are empty when the source detector has no natural object
+    association (e.g. a global cross-signal correlation statistic). Use
+    :attr:`has_objects` to check before calling :meth:`to_flat_df`.
+    """
+
+    events: pd.DataFrame = field(default_factory=schema.empty_events)
+    objects: pd.DataFrame = field(default_factory=schema.empty_objects)
+    relations: pd.DataFrame = field(default_factory=schema.empty_relations)
+
+    @property
+    def has_objects(self) -> bool:
+        return not self.objects.empty
+
+    def __len__(self) -> int:
+        return len(self.events)
+
+    def __repr__(self) -> str:
+        return (
+            f"EventLog(events={len(self.events)}, "
+            f"objects={len(self.objects)}, relations={len(self.relations)})"
+        )
+
+    def filter_by_pack(self, pack: str) -> "EventLog":
+        events = self.events[self.events[schema.TS_PACK] == pack]
+        eids = set(events[schema.OCEL_EID])
+        relations = self.relations[self.relations[schema.OCEL_EID].isin(eids)]
+        used = set(zip(relations[schema.OCEL_OID], relations[schema.OCEL_TYPE]))
+        objects = self.objects[
+            self.objects.apply(
+                lambda r: (r[schema.OCEL_OID], r[schema.OCEL_TYPE]) in used, axis=1
+            )
+        ] if used else schema.empty_objects()
+        return EventLog(events.reset_index(drop=True),
+                        objects.reset_index(drop=True),
+                        relations.reset_index(drop=True))
+
+    def filter_by_object(self, oid: str, type_: str | None = None) -> "EventLog":
+        rel = self.relations
+        mask = rel[schema.OCEL_OID] == oid
+        if type_ is not None:
+            mask &= rel[schema.OCEL_TYPE] == type_
+        eids = set(rel[mask][schema.OCEL_EID])
+        events = self.events[self.events[schema.OCEL_EID].isin(eids)]
+        relations = self.relations[self.relations[schema.OCEL_EID].isin(eids)]
+        used = set(zip(relations[schema.OCEL_OID], relations[schema.OCEL_TYPE]))
+        objects = self.objects[
+            self.objects.apply(
+                lambda r: (r[schema.OCEL_OID], r[schema.OCEL_TYPE]) in used, axis=1
+            )
+        ] if used else schema.empty_objects()
+        return EventLog(events.reset_index(drop=True),
+                        objects.reset_index(drop=True),
+                        relations.reset_index(drop=True))

--- a/src/ts_shape/eventlog/normalizer.py
+++ b/src/ts_shape/eventlog/normalizer.py
@@ -1,0 +1,58 @@
+"""Public ``to_event_log`` entry point — looks up the adapter and runs it."""
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+
+from . import adapters, schema, taxonomy
+from .model import EventLog
+
+
+def to_event_log(
+    df: pd.DataFrame,
+    *,
+    detector: str,
+    objects: Mapping[str, object] | None = None,
+    qualifiers: Mapping[str, str] | None = None,
+    validate: bool = True,
+) -> EventLog:
+    """Normalize a legacy detector DataFrame into the canonical event log.
+
+    ``detector`` is ``"ClassName.method_name"`` — the same key used in the
+    taxonomy registry and the value written to ``ts_shape:detector``.
+
+    ``objects`` binds OCEL object types to either:
+
+    * a string column name in ``df`` (e.g. ``{"asset": "source_uuid"}``),
+    * a callable taking a row dict and returning an oid,
+    * a ``pd.Series`` aligned with ``df`` rows,
+    * a scalar broadcast to every row.
+
+    Only object types declared by the adapter (``LabelRule.produces_objects``)
+    are honored; binding an undeclared type raises ``ValueError``.
+    """
+    if "." not in detector:
+        raise ValueError(
+            f"detector must be 'ClassName.method_name', got {detector!r}"
+        )
+    class_name, method_name = detector.split(".", 1)
+
+    rule = taxonomy.get(class_name, method_name)
+    if rule is None:
+        raise KeyError(
+            f"no taxonomy entry for {detector!r}. "
+            "Add a LabelRule to ts_shape.eventlog.taxonomy.REGISTRY."
+        )
+
+    override = adapters.get_override(class_name, method_name)
+    if override is not None:
+        log = override(df, rule=rule, detector=detector,
+                       objects=objects, qualifiers=qualifiers)
+    else:
+        log = adapters.adapt(df, rule=rule, detector=detector,
+                             objects=objects, qualifiers=qualifiers)
+
+    if validate:
+        schema.validate(log)
+    return log

--- a/src/ts_shape/eventlog/normalizer.py
+++ b/src/ts_shape/eventlog/normalizer.py
@@ -29,8 +29,10 @@ def to_event_log(
     * a ``pd.Series`` aligned with ``df`` rows,
     * a scalar broadcast to every row.
 
-    Only object types declared by the adapter (``LabelRule.produces_objects``)
-    are honored; binding an undeclared type raises ``ValueError``.
+    Caller-supplied bindings are always honored. Types listed in the
+    adapter's ``LabelRule.produces_objects`` are *also* auto-extracted from
+    standard legacy columns (e.g. ``source_uuid -> asset``) when no explicit
+    binding is given.
     """
     if "." not in detector:
         raise ValueError(

--- a/src/ts_shape/eventlog/ocel.py
+++ b/src/ts_shape/eventlog/ocel.py
@@ -1,0 +1,24 @@
+"""OCEL 2.0–shaped exporter — returns the three relational tables.
+
+ts-shape does not write OCEL JSON or SQLite itself; users feed these
+DataFrames to ``pm4py.write_ocel2_json`` (or any other OCEL tool) directly.
+The column names match the OCEL 2.0 spec verbatim.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from .model import EventLog
+
+
+def to_ocel_tables(eventlog: EventLog) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Return ``(events, objects, relations)`` DataFrames as-is.
+
+    The canonical schema already uses OCEL 2.0 column names, so this is a
+    pass-through with a defensive ``copy()`` to prevent caller mutation.
+    """
+    return (
+        eventlog.events.copy(),
+        eventlog.objects.copy(),
+        eventlog.relations.copy(),
+    )

--- a/src/ts_shape/eventlog/schema.py
+++ b/src/ts_shape/eventlog/schema.py
@@ -1,0 +1,182 @@
+"""Column-name constants and schema definitions for the ts-shape event log.
+
+The canonical event-log uses OCEL 2.0 column names (`ocel:*`) with a few
+ts-shape-prefixed columns for fields that have no OCEL counterpart but are
+useful for downstream consumers (interval starts, durations, severity, etc.).
+XES column names (`concept:name`, `time:timestamp`, `case:concept:name`,
+`lifecycle:transition`, `org:resource`) are produced only by the flat
+exporter; they do not appear in the canonical schema.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from .model import EventLog
+
+
+# ---- Events table -----------------------------------------------------------
+
+OCEL_EID = "ocel:eid"
+OCEL_ACTIVITY = "ocel:activity"
+OCEL_TIMESTAMP = "ocel:timestamp"
+
+TS_START_TIMESTAMP = "ts_shape:start_timestamp"
+TS_DURATION_S = "ts_shape:duration_s"
+TS_DETECTOR = "ts_shape:detector"
+TS_PACK = "ts_shape:pack"
+TS_SEVERITY = "ts_shape:severity"
+TS_VALUE = "ts_shape:value"
+
+EVENT_REQUIRED_COLUMNS: tuple[str, ...] = (
+    OCEL_EID,
+    OCEL_ACTIVITY,
+    OCEL_TIMESTAMP,
+    TS_DETECTOR,
+    TS_PACK,
+)
+
+EVENT_OPTIONAL_COLUMNS: tuple[str, ...] = (
+    TS_START_TIMESTAMP,
+    TS_DURATION_S,
+    TS_SEVERITY,
+    TS_VALUE,
+)
+
+
+# ---- Objects table ----------------------------------------------------------
+
+OCEL_OID = "ocel:oid"
+OCEL_TYPE = "ocel:type"
+
+OBJECT_REQUIRED_COLUMNS: tuple[str, ...] = (OCEL_OID, OCEL_TYPE)
+
+
+# ---- Event-to-object relations table ---------------------------------------
+
+OCEL_QUALIFIER = "ocel:qualifier"
+
+RELATION_REQUIRED_COLUMNS: tuple[str, ...] = (OCEL_EID, OCEL_OID, OCEL_TYPE)
+
+
+# ---- XES export columns -----------------------------------------------------
+
+XES_CASE = "case:concept:name"
+XES_ACTIVITY = "concept:name"
+XES_TIMESTAMP = "time:timestamp"
+XES_LIFECYCLE = "lifecycle:transition"
+XES_RESOURCE = "org:resource"
+XES_INSTANCE = "concept:instance"
+
+
+# ---- Object-type registry ---------------------------------------------------
+
+STANDARD_OBJECT_TYPES: tuple[str, ...] = (
+    "asset",
+    "cycle",
+    "batch",
+    "lot",
+    "material",
+    "serial",
+    "article",
+    "part",
+    "work_order",
+    "shift",
+    "operator",
+    "tool",
+    "recipe",
+    "station",
+    "signal",
+    "sensor",
+)
+_OBJECT_TYPES: set[str] = set(STANDARD_OBJECT_TYPES)
+
+
+def register_object_type(name: str) -> None:
+    """Register a custom OCEL object type so adapters can emit it."""
+    if not name or ":" in name:
+        raise ValueError(f"invalid object type {name!r}")
+    _OBJECT_TYPES.add(name)
+
+
+def is_known_object_type(name: str) -> bool:
+    return name in _OBJECT_TYPES
+
+
+# ---- Empty frames -----------------------------------------------------------
+
+def empty_events() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            OCEL_EID: pd.Series(dtype="string"),
+            OCEL_ACTIVITY: pd.Series(dtype="string"),
+            OCEL_TIMESTAMP: pd.Series(dtype="datetime64[ns, UTC]"),
+            TS_START_TIMESTAMP: pd.Series(dtype="datetime64[ns, UTC]"),
+            TS_DURATION_S: pd.Series(dtype="float64"),
+            TS_DETECTOR: pd.Series(dtype="string"),
+            TS_PACK: pd.Series(dtype="string"),
+            TS_SEVERITY: pd.Series(dtype="string"),
+            TS_VALUE: pd.Series(dtype="float64"),
+        }
+    )
+
+
+def empty_objects() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            OCEL_OID: pd.Series(dtype="string"),
+            OCEL_TYPE: pd.Series(dtype="string"),
+        }
+    )
+
+
+def empty_relations() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            OCEL_EID: pd.Series(dtype="string"),
+            OCEL_OID: pd.Series(dtype="string"),
+            OCEL_TYPE: pd.Series(dtype="string"),
+            OCEL_QUALIFIER: pd.Series(dtype="string"),
+        }
+    )
+
+
+# ---- Validation -------------------------------------------------------------
+
+def validate(eventlog: "EventLog") -> None:
+    """Raise ``ValueError`` if the event log violates the canonical schema."""
+    events, objects, relations = eventlog.events, eventlog.objects, eventlog.relations
+
+    missing = [c for c in EVENT_REQUIRED_COLUMNS if c not in events.columns]
+    if missing:
+        raise ValueError(f"events table missing required columns: {missing}")
+
+    if not events.empty and events[OCEL_EID].is_unique is False:
+        dup = events[OCEL_EID][events[OCEL_EID].duplicated()].iloc[0]
+        raise ValueError(f"duplicate {OCEL_EID}: {dup!r}")
+
+    missing = [c for c in OBJECT_REQUIRED_COLUMNS if c not in objects.columns]
+    if missing:
+        raise ValueError(f"objects table missing required columns: {missing}")
+
+    missing = [c for c in RELATION_REQUIRED_COLUMNS if c not in relations.columns]
+    if missing:
+        raise ValueError(f"relations table missing required columns: {missing}")
+
+    if not relations.empty:
+        eids = set(events[OCEL_EID])
+        bad = relations[OCEL_EID][~relations[OCEL_EID].isin(eids)]
+        if not bad.empty:
+            raise ValueError(
+                f"relations reference unknown {OCEL_EID}: {bad.iloc[0]!r}"
+            )
+        oids = set(zip(objects[OCEL_OID], objects[OCEL_TYPE]))
+        rel_pairs = list(zip(relations[OCEL_OID], relations[OCEL_TYPE]))
+        for pair in rel_pairs:
+            if pair not in oids:
+                raise ValueError(
+                    f"relation references unknown object {pair!r}; "
+                    "every (oid, type) in relations must appear in objects"
+                )

--- a/src/ts_shape/eventlog/taxonomy.py
+++ b/src/ts_shape/eventlog/taxonomy.py
@@ -15,10 +15,12 @@ A :class:`LabelRule` describes:
   ``"interval"``   → has ``start``/``end`` columns,
   ``"summary"``    → a windowed/aggregate row (uses end column or any datetime),
   ``"static"``     → no time semantics; uses ``ts_shape:fallback_now``.
-* ``produces_objects`` — declared object types this method can emit. Empty
-  tuple means "events only, no objects". The default is ``("asset",)`` if
-  the legacy DataFrame carries a ``source_uuid`` (or equivalent) column,
-  else ``()``.
+* ``produces_objects`` — object types the adapter *auto-extracts* from
+  the legacy DataFrame's standard columns (e.g. ``source_uuid -> asset``).
+  Callers can always attach additional contextual object types (batch,
+  shift, operator, ...) via the ``objects=`` argument to
+  :func:`~ts_shape.eventlog.to_event_log`. Empty tuple means "no
+  auto-extraction; objects only appear if the caller binds them".
 """
 from __future__ import annotations
 

--- a/src/ts_shape/eventlog/taxonomy.py
+++ b/src/ts_shape/eventlog/taxonomy.py
@@ -1,0 +1,654 @@
+"""Per-method label rules — the source of truth for ``ocel:activity`` names.
+
+Every public DataFrame-returning method on every detector class under
+``ts_shape.events.*`` must have an entry here. The coverage test
+``tests/eventlog/test_adapter_coverage.py`` enforces this.
+
+A :class:`LabelRule` describes:
+
+* ``template`` — the ``ocel:activity`` value. May contain ``{field}``
+  placeholders that get substituted from legacy DataFrame columns.
+* ``pack`` — one of ``quality``, ``production``, ``engineering``,
+  ``maintenance``, ``supplychain``, ``energy``, ``correlation``.
+* ``shape`` — how to interpret each legacy row:
+  ``"point"``      → single-timestamp event (`systime` or first datetime),
+  ``"interval"``   → has ``start``/``end`` columns,
+  ``"summary"``    → a windowed/aggregate row (uses end column or any datetime),
+  ``"static"``     → no time semantics; uses ``ts_shape:fallback_now``.
+* ``produces_objects`` — declared object types this method can emit. Empty
+  tuple means "events only, no objects". The default is ``("asset",)`` if
+  the legacy DataFrame carries a ``source_uuid`` (or equivalent) column,
+  else ``()``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class LabelRule:
+    template: str
+    pack: str
+    shape: str = "point"
+    produces_objects: tuple[str, ...] = ("asset",)
+    severity_field: str | None = None
+    value_field: str | None = None
+    drop_fields: tuple[str, ...] = ()
+
+
+# Aliases used while building the registry below to keep entries terse.
+_Q = "quality"
+_PR = "production"
+_E = "engineering"
+_M = "maintenance"
+_SC = "supplychain"
+_EN = "energy"
+_CO = "correlation"
+
+P = "point"
+I = "interval"
+S = "summary"
+ST = "static"
+
+ASSET = ("asset",)
+NONE: tuple[str, ...] = ()
+
+
+def _r(template: str, pack: str, shape: str = P,
+       objs: tuple[str, ...] = ASSET, **kw) -> LabelRule:
+    return LabelRule(template=template, pack=pack, shape=shape,
+                     produces_objects=objs, **kw)
+
+
+# ----------------------------------------------------------------------------
+# REGISTRY: (ClassName, method_name) -> LabelRule
+# ----------------------------------------------------------------------------
+
+REGISTRY: dict[tuple[str, str], LabelRule] = {
+
+    # ---- correlation -------------------------------------------------------
+    ("AnomalyCorrelationEvents", "cascade_detection"):
+        _r("correlation.anomaly.cascade", _CO, P, objs=("signal",)),
+    ("AnomalyCorrelationEvents", "coincident_anomalies"):
+        _r("correlation.anomaly.coincident", _CO, P, objs=("signal",)),
+    ("AnomalyCorrelationEvents", "root_cause_ranking"):
+        _r("correlation.anomaly.root_cause_rank", _CO, ST, objs=("signal",)),
+    ("SignalCorrelationEvents", "correlation_breakdown"):
+        _r("correlation.signal.breakdown", _CO, ST, objs=("signal",)),
+    ("SignalCorrelationEvents", "lag_correlation"):
+        _r("correlation.signal.lag", _CO, ST, objs=("signal",)),
+    ("SignalCorrelationEvents", "rolling_correlation"):
+        _r("correlation.signal.rolling", _CO, S, objs=("signal",)),
+
+    # ---- energy ------------------------------------------------------------
+    ("CarbonIntensityEvents", "carbon_intensity_per_unit"):
+        _r("energy.carbon.intensity_per_unit", _EN, S),
+    ("CarbonIntensityEvents", "emission_factor_audit"):
+        _r("energy.carbon.factor_audit", _EN, S),
+    ("CarbonIntensityEvents", "emissions_by_window"):
+        _r("energy.carbon.emissions_by_window", _EN, S),
+    ("CarbonIntensityEvents", "total_emissions_by_window"):
+        _r("energy.carbon.total_emissions_by_window", _EN, S),
+    ("EnergyConsumptionEvents", "consumption_baseline_deviation"):
+        _r("energy.consumption.baseline_deviation", _EN, S),
+    ("EnergyConsumptionEvents", "consumption_by_window"):
+        _r("energy.consumption.by_window", _EN, S),
+    ("EnergyConsumptionEvents", "energy_per_unit"):
+        _r("energy.consumption.per_unit", _EN, S),
+    ("EnergyConsumptionEvents", "normalize"):
+        _r("energy.consumption.normalize", _EN, S),
+    ("EnergyConsumptionEvents", "peak_demand_detection"):
+        _r("energy.consumption.peak_demand", _EN, P),
+    ("EnergyEfficiencyEvents", "efficiency_comparison"):
+        _r("energy.efficiency.comparison", _EN, S),
+    ("EnergyEfficiencyEvents", "efficiency_trend"):
+        _r("energy.efficiency.trend", _EN, S),
+    ("EnergyEfficiencyEvents", "idle_energy_waste"):
+        _r("energy.efficiency.idle_waste", _EN, S),
+    ("EnergyEfficiencyEvents", "normalize"):
+        _r("energy.efficiency.normalize", _EN, S),
+    ("EnergyEfficiencyEvents", "specific_energy_consumption"):
+        _r("energy.efficiency.specific_consumption", _EN, S),
+    ("EnergyPerformanceIndicatorEvents", "enpi_by_hierarchy"):
+        _r("energy.enpi.by_hierarchy", _EN, S),
+    ("EnergyPerformanceIndicatorEvents", "enpi_by_window"):
+        _r("energy.enpi.by_window", _EN, S),
+    ("EnergyPerformanceIndicatorEvents", "enpi_vs_baseline"):
+        _r("energy.enpi.vs_baseline", _EN, S),
+    ("IdleEnergyDetectionEvents", "idle_energy_by_shift"):
+        _r("energy.idle.by_shift", _EN, S, objs=("asset", "shift")),
+    ("IdleEnergyDetectionEvents", "idle_energy_by_window"):
+        _r("energy.idle.by_window", _EN, S),
+    ("IdleEnergyDetectionEvents", "idle_energy_trend"):
+        _r("energy.idle.trend", _EN, S),
+
+    # ---- engineering -------------------------------------------------------
+    ("ControlLoopHealthEvents", "detect_oscillation"):
+        _r("engineering.control_loop.oscillation", _E, I),
+    ("ControlLoopHealthEvents", "error_integrals"):
+        _r("engineering.control_loop.error_integrals", _E, S),
+    ("ControlLoopHealthEvents", "loop_health_summary"):
+        _r("engineering.control_loop.health_summary", _E, S),
+    ("ControlLoopHealthEvents", "output_saturation"):
+        _r("engineering.control_loop.output_saturation", _E, I),
+    ("DisturbanceRecoveryEvents", "before_after_comparison"):
+        _r("engineering.disturbance.before_after", _E, S),
+    ("DisturbanceRecoveryEvents", "detect_disturbances"):
+        _r("engineering.disturbance.detected", _E, P),
+    ("DisturbanceRecoveryEvents", "disturbance_frequency"):
+        _r("engineering.disturbance.frequency", _E, S),
+    ("DisturbanceRecoveryEvents", "recovery_time"):
+        _r("engineering.disturbance.recovery_time", _E, I),
+    ("MaterialBalanceEvents", "balance_check"):
+        _r("engineering.material_balance.check", _E, S),
+    ("MaterialBalanceEvents", "contribution_breakdown"):
+        _r("engineering.material_balance.contribution", _E, S),
+    ("MaterialBalanceEvents", "detect_balance_exceedance"):
+        _r("engineering.material_balance.exceedance", _E, P),
+    ("MaterialBalanceEvents", "imbalance_trend"):
+        _r("engineering.material_balance.trend", _E, S),
+    ("OperatingRangeEvents", "detect_regime_change"):
+        _r("engineering.operating_range.regime_change", _E, P),
+    ("OperatingRangeEvents", "operating_envelope"):
+        _r("engineering.operating_range.envelope", _E, S),
+    ("OperatingRangeEvents", "time_in_range"):
+        _r("engineering.operating_range.time_in_range", _E, S),
+    ("OperatingRangeEvents", "value_distribution"):
+        _r("engineering.operating_range.distribution", _E, S),
+    ("ProcessStabilityIndex", "score_trend"):
+        _r("engineering.stability.score_trend", _E, S),
+    ("ProcessStabilityIndex", "stability_comparison"):
+        _r("engineering.stability.comparison", _E, S),
+    ("ProcessStabilityIndex", "stability_score"):
+        _r("engineering.stability.score", _E, S),
+    ("ProcessStabilityIndex", "worst_periods"):
+        _r("engineering.stability.worst_periods", _E, S),
+    ("ProcessWindowEvents", "detect_mean_shift"):
+        _r("engineering.process_window.mean_shift", _E, P),
+    ("ProcessWindowEvents", "detect_variance_change"):
+        _r("engineering.process_window.variance_change", _E, P),
+    ("ProcessWindowEvents", "window_comparison"):
+        _r("engineering.process_window.comparison", _E, S),
+    ("ProcessWindowEvents", "windowed_statistics"):
+        _r("engineering.process_window.statistics", _E, S),
+    ("RateOfChangeEvents", "detect_rapid_change"):
+        _r("engineering.rate_of_change.rapid", _E, P),
+    ("RateOfChangeEvents", "detect_step_changes"):
+        _r("engineering.rate_of_change.step", _E, P),
+    ("RateOfChangeEvents", "rate_statistics"):
+        _r("engineering.rate_of_change.statistics", _E, S),
+    ("SetpointChangeEvents", "control_quality_metrics"):
+        _r("engineering.setpoint.control_quality", _E, S),
+    ("SetpointChangeEvents", "decay_rate"):
+        _r("engineering.setpoint.decay_rate", _E, S),
+    ("SetpointChangeEvents", "detect_setpoint_changes"):
+        _r("engineering.setpoint.change", _E, P),
+    ("SetpointChangeEvents", "detect_setpoint_ramps"):
+        _r("engineering.setpoint.ramp", _E, I),
+    ("SetpointChangeEvents", "detect_setpoint_steps"):
+        _r("engineering.setpoint.step_{change_type}", _E, I),
+    ("SetpointChangeEvents", "oscillation_frequency"):
+        _r("engineering.setpoint.oscillation_frequency", _E, S),
+    ("SetpointChangeEvents", "overshoot_metrics"):
+        _r("engineering.setpoint.overshoot_metrics", _E, S),
+    ("SetpointChangeEvents", "rise_time"):
+        _r("engineering.setpoint.rise_time", _E, S),
+    ("SetpointChangeEvents", "time_to_settle"):
+        _r("engineering.setpoint.time_to_settle", _E, S),
+    ("SetpointChangeEvents", "time_to_settle_derivative"):
+        _r("engineering.setpoint.time_to_settle_derivative", _E, S),
+    ("SignalComparisonEvents", "correlation_windows"):
+        _r("engineering.signal_comparison.correlation_windows", _E, S, objs=("signal",)),
+    ("SignalComparisonEvents", "detect_divergence"):
+        _r("engineering.signal_comparison.divergence", _E, P, objs=("signal",)),
+    ("SignalComparisonEvents", "deviation_statistics"):
+        _r("engineering.signal_comparison.deviation_statistics", _E, S, objs=("signal",)),
+    ("SignalComparisonEvents", "tracking_error_trend"):
+        _r("engineering.signal_comparison.tracking_error_trend", _E, S, objs=("signal",)),
+    ("StartupDetectionEvents", "assess_startup_quality"):
+        _r("engineering.startup.quality_assessment", _E, S),
+    ("StartupDetectionEvents", "detect_failed_startups"):
+        _r("engineering.startup.failed", _E, P),
+    ("StartupDetectionEvents", "detect_startup_adaptive"):
+        _r("engineering.startup.adaptive", _E, I),
+    ("StartupDetectionEvents", "detect_startup_by_slope"):
+        _r("engineering.startup.by_slope", _E, I),
+    ("StartupDetectionEvents", "detect_startup_by_threshold"):
+        _r("engineering.startup.by_threshold", _E, I),
+    ("StartupDetectionEvents", "detect_startup_multi_signal"):
+        _r("engineering.startup.multi_signal", _E, I),
+    ("StartupDetectionEvents", "track_startup_phases"):
+        _r("engineering.startup.phase_{phase}", _E, I),
+    ("SteadyStateDetectionEvents", "detect_steady_state"):
+        _r("engineering.steady_state.detected", _E, I),
+    ("SteadyStateDetectionEvents", "detect_transient_periods"):
+        _r("engineering.steady_state.transient", _E, I),
+    ("SteadyStateDetectionEvents", "steady_state_value_bands"):
+        _r("engineering.steady_state.value_bands", _E, S),
+    ("ThresholdMonitoringEvents", "multi_level_threshold"):
+        _r("engineering.threshold.multi_level", _E, P),
+    ("ThresholdMonitoringEvents", "threshold_exceedance_trend"):
+        _r("engineering.threshold.exceedance_trend", _E, S),
+    ("ThresholdMonitoringEvents", "threshold_with_hysteresis"):
+        _r("engineering.threshold.hysteresis", _E, P),
+    ("ThresholdMonitoringEvents", "time_above_threshold"):
+        _r("engineering.threshold.time_above", _E, S),
+    ("WarmUpCoolDownEvents", "detect_cooldown"):
+        _r("engineering.thermal.cooldown", _E, I),
+    ("WarmUpCoolDownEvents", "detect_warmup"):
+        _r("engineering.thermal.warmup", _E, I),
+    ("WarmUpCoolDownEvents", "time_to_target"):
+        _r("engineering.thermal.time_to_target", _E, S),
+    ("WarmUpCoolDownEvents", "warmup_consistency"):
+        _r("engineering.thermal.warmup_consistency", _E, S),
+
+    # ---- maintenance -------------------------------------------------------
+    ("DegradationDetectionEvents", "detect_level_shift"):
+        _r("maintenance.degradation.level_shift", _M, P),
+    ("DegradationDetectionEvents", "detect_trend_degradation"):
+        _r("maintenance.degradation.trend", _M, I),
+    ("DegradationDetectionEvents", "detect_variance_increase"):
+        _r("maintenance.degradation.variance_increase", _M, I),
+    ("DegradationDetectionEvents", "health_score"):
+        _r("maintenance.health.score_window", _M, S),
+    ("FailurePredictionEvents", "detect_exceedance_pattern"):
+        _r("maintenance.failure.exceedance_pattern", _M, P),
+    ("FailurePredictionEvents", "remaining_useful_life"):
+        _r("maintenance.failure.remaining_useful_life", _M, S),
+    ("FailurePredictionEvents", "time_to_threshold"):
+        _r("maintenance.failure.time_to_threshold", _M, S),
+    ("VibrationAnalysisEvents", "bearing_health_indicators"):
+        _r("maintenance.vibration.bearing_health", _M, S),
+    ("VibrationAnalysisEvents", "detect_amplitude_growth"):
+        _r("maintenance.vibration.amplitude_growth", _M, P),
+    ("VibrationAnalysisEvents", "detect_rms_exceedance"):
+        _r("maintenance.vibration.rms_exceedance", _M, P),
+
+    # ---- production --------------------------------------------------------
+    ("AlarmManagementEvents", "alarm_duration_stats"):
+        _r("production.alarm.duration_stats", _PR, S),
+    ("AlarmManagementEvents", "alarm_frequency"):
+        _r("production.alarm.frequency", _PR, S),
+    ("AlarmManagementEvents", "chattering_detection"):
+        _r("production.alarm.chattering", _PR, I),
+    ("AlarmManagementEvents", "standing_alarms"):
+        _r("production.alarm.standing", _PR, I),
+    ("BatchTrackingEvents", "batch_duration_stats"):
+        _r("production.batch.duration_stats", _PR, S, objs=("asset", "batch")),
+    ("BatchTrackingEvents", "batch_transition_matrix"):
+        _r("production.batch.transition_matrix", _PR, ST, objs=("asset", "batch")),
+    ("BatchTrackingEvents", "batch_yield"):
+        _r("production.batch.yield", _PR, S, objs=("asset", "batch")),
+    ("BatchTrackingEvents", "detect_batches"):
+        _r("production.batch.detected", _PR, I, objs=("asset", "batch")),
+    ("BottleneckDetectionEvents", "detect_bottleneck"):
+        _r("production.bottleneck.detected", _PR, P, objs=("asset", "station")),
+    ("BottleneckDetectionEvents", "shifting_bottleneck"):
+        _r("production.bottleneck.shifting", _PR, S, objs=("asset", "station")),
+    ("BottleneckDetectionEvents", "station_utilization"):
+        _r("production.bottleneck.station_utilization", _PR, S, objs=("asset", "station")),
+    ("ChangeoverEvents", "changeover_quality_metrics"):
+        _r("production.changeover.quality_metrics", _PR, S),
+    ("ChangeoverEvents", "changeover_window"):
+        _r("production.changeover.window", _PR, I),
+    ("ChangeoverEvents", "detect_changeover"):
+        _r("production.changeover.detected", _PR, I),
+    ("ContinuousProcessAlignmentEvents", "align_to_reference"):
+        _r("production.alignment.to_reference", _PR, S, objs=("asset", "station")),
+    ("ContinuousProcessAlignmentEvents", "alignment_quality"):
+        _r("production.alignment.quality", _PR, S, objs=("asset", "station")),
+    ("ContinuousProcessAlignmentEvents", "lag_profile"):
+        _r("production.alignment.lag_profile", _PR, S, objs=("asset", "station")),
+    ("ContinuousProcessAlignmentEvents", "segment_by_cut"):
+        _r("production.alignment.segment_by_cut", _PR, I, objs=("asset", "station")),
+    ("CycleTimeTracking", "cycle_time_by_part"):
+        _r("production.cycle_time.by_part", _PR, S, objs=("asset", "part")),
+    ("CycleTimeTracking", "cycle_time_statistics"):
+        _r("production.cycle_time.statistics", _PR, S),
+    ("CycleTimeTracking", "cycle_time_trend"):
+        _r("production.cycle_time.trend", _PR, S),
+    ("CycleTimeTracking", "detect_slow_cycles"):
+        _r("production.cycle_time.slow", _PR, P, objs=("asset", "cycle")),
+    ("CycleTimeTracking", "hourly_cycle_time_summary"):
+        _r("production.cycle_time.hourly_summary", _PR, S),
+    ("DowntimeTracking", "availability_trend"):
+        _r("production.downtime.availability_trend", _PR, S),
+    ("DowntimeTracking", "downtime_by_reason"):
+        _r("production.downtime.by_reason", _PR, S),
+    ("DowntimeTracking", "downtime_by_shift"):
+        _r("production.downtime.by_shift", _PR, S, objs=("asset", "shift")),
+    ("DowntimeTracking", "top_downtime_reasons"):
+        _r("production.downtime.top_reasons", _PR, ST),
+    ("DutyCycleEvents", "cycle_count"):
+        _r("production.duty_cycle.count", _PR, S),
+    ("DutyCycleEvents", "duty_cycle_per_window"):
+        _r("production.duty_cycle.per_window", _PR, S),
+    ("DutyCycleEvents", "excessive_cycling"):
+        _r("production.duty_cycle.excessive", _PR, P),
+    ("DutyCycleEvents", "on_off_intervals"):
+        _r("production.duty_cycle.on_off", _PR, I),
+    ("FlowConstraintEvents", "blocked_events"):
+        _r("production.flow.blocked", _PR, I, objs=("asset", "station")),
+    ("FlowConstraintEvents", "starved_events"):
+        _r("production.flow.starved", _PR, I, objs=("asset", "station")),
+    ("LineThroughputEvents", "count_parts"):
+        _r("production.throughput.count_parts", _PR, S),
+    ("LineThroughputEvents", "cycle_quality_check"):
+        _r("production.throughput.cycle_quality_check", _PR, P, objs=("asset", "cycle")),
+    ("LineThroughputEvents", "takt_adherence"):
+        _r("production.throughput.takt_adherence", _PR, S),
+    ("LineThroughputEvents", "throughput_oee"):
+        _r("production.throughput.oee", _PR, S),
+    ("LineThroughputEvents", "throughput_trends"):
+        _r("production.throughput.trends", _PR, S),
+    ("LongDowntimeEvents", "count_events_between_gaps"):
+        _r("production.long_downtime.events_between_gaps", _PR, S),
+    ("LongDowntimeEvents", "detect_long_downtime"):
+        _r("production.long_downtime.detected", _PR, I),
+    ("MachineStateEvents", "detect_rapid_transitions"):
+        _r("production.machine_state.rapid_transitions", _PR, P),
+    ("MachineStateEvents", "detect_run_idle"):
+        _r("production.machine_state.{state}", _PR, I),
+    ("MachineStateEvents", "transition_events"):
+        _r("production.machine_state.transition_{transition}", _PR, P),
+    ("MicroStopEvents", "detect_micro_stops"):
+        _r("production.micro_stop.detected", _PR, I),
+    ("MicroStopEvents", "micro_stop_frequency"):
+        _r("production.micro_stop.frequency", _PR, S),
+    ("MicroStopEvents", "micro_stop_impact"):
+        _r("production.micro_stop.impact", _PR, S),
+    ("MicroStopEvents", "micro_stop_patterns"):
+        _r("production.micro_stop.patterns", _PR, S),
+    ("MultiProcessTraceabilityEvents", "build_timeline"):
+        _r("production.traceability.timeline", _PR, P, objs=("asset", "serial", "station")),
+    ("MultiProcessTraceabilityEvents", "handover_log"):
+        _r("production.traceability.handover", _PR, P, objs=("asset", "serial", "station")),
+    ("MultiProcessTraceabilityEvents", "lead_time"):
+        _r("production.traceability.lead_time", _PR, S, objs=("serial",)),
+    ("MultiProcessTraceabilityEvents", "parallel_activity"):
+        _r("production.traceability.parallel_activity", _PR, I, objs=("serial", "station")),
+    ("MultiProcessTraceabilityEvents", "routing_paths"):
+        _r("production.traceability.routing_paths", _PR, ST, objs=("serial",)),
+    ("MultiProcessTraceabilityEvents", "station_statistics"):
+        _r("production.traceability.station_statistics", _PR, S, objs=("station",)),
+    ("OEECalculator", "calculate_availability"):
+        _r("production.oee.availability", _PR, S),
+    ("OEECalculator", "calculate_oee"):
+        _r("production.oee.total", _PR, S),
+    ("OEECalculator", "calculate_performance"):
+        _r("production.oee.performance", _PR, S),
+    ("OEECalculator", "calculate_quality"):
+        _r("production.oee.quality", _PR, S),
+    ("OperatorPerformanceTracking", "operator_comparison"):
+        _r("production.operator.comparison", _PR, S, objs=("operator",)),
+    ("OperatorPerformanceTracking", "operator_efficiency"):
+        _r("production.operator.efficiency", _PR, S, objs=("operator",)),
+    ("OperatorPerformanceTracking", "production_by_operator"):
+        _r("production.operator.production", _PR, S, objs=("operator",)),
+    ("OperatorPerformanceTracking", "quality_by_operator"):
+        _r("production.operator.quality", _PR, S, objs=("operator",)),
+    ("OrderTraceabilityEvents", "build_timeline"):
+        _r("production.order.timeline", _PR, P, objs=("asset", "work_order", "station")),
+    ("OrderTraceabilityEvents", "current_status"):
+        _r("production.order.current_status", _PR, ST, objs=("work_order",)),
+    ("OrderTraceabilityEvents", "lead_time"):
+        _r("production.order.lead_time", _PR, S, objs=("work_order",)),
+    ("OrderTraceabilityEvents", "station_dwell_statistics"):
+        _r("production.order.station_dwell_statistics", _PR, S, objs=("station",)),
+    ("ValueTraceabilityEvents", "build_timeline"):
+        _r("production.value_trace.timeline", _PR, P, objs=("asset", "serial", "station")),
+    ("ValueTraceabilityEvents", "current_status"):
+        _r("production.value_trace.current_status", _PR, ST, objs=("serial",)),
+    ("ValueTraceabilityEvents", "lead_time"):
+        _r("production.value_trace.lead_time", _PR, S, objs=("serial",)),
+    ("ValueTraceabilityEvents", "station_dwell_statistics"):
+        _r("production.value_trace.station_dwell_statistics", _PR, S, objs=("station",)),
+    ("PartProductionTracking", "daily_production_summary"):
+        _r("production.part.daily_summary", _PR, S, objs=("asset", "part")),
+    ("PartProductionTracking", "production_by_part"):
+        _r("production.part.production", _PR, S, objs=("asset", "part")),
+    ("PartProductionTracking", "production_totals"):
+        _r("production.part.totals", _PR, S, objs=("asset", "part")),
+    ("PerformanceLossTracking", "performance_by_shift"):
+        _r("production.performance.by_shift", _PR, S, objs=("asset", "shift")),
+    ("PerformanceLossTracking", "performance_trend"):
+        _r("production.performance.trend", _PR, S),
+    ("PerformanceLossTracking", "slow_periods"):
+        _r("production.performance.slow_period", _PR, I),
+    ("PeriodSummary", "compare_periods"):
+        _r("production.period.compare", _PR, S),
+    ("PeriodSummary", "from_daily_data"):
+        _r("production.period.from_daily", _PR, S),
+    ("PeriodSummary", "monthly_summary"):
+        _r("production.period.monthly_summary", _PR, S),
+    ("PeriodSummary", "weekly_summary"):
+        _r("production.period.weekly_summary", _PR, S),
+    ("QualityTracking", "daily_quality_summary"):
+        _r("production.quality.daily_summary", _PR, S),
+    ("QualityTracking", "nok_by_reason"):
+        _r("production.quality.nok_by_reason", _PR, S),
+    ("QualityTracking", "nok_by_shift"):
+        _r("production.quality.nok_by_shift", _PR, S, objs=("asset", "shift")),
+    ("QualityTracking", "quality_by_part"):
+        _r("production.quality.by_part", _PR, S, objs=("asset", "part")),
+    ("ReworkTracking", "rework_by_reason"):
+        _r("production.rework.by_reason", _PR, S),
+    ("ReworkTracking", "rework_by_shift"):
+        _r("production.rework.by_shift", _PR, S, objs=("asset", "shift")),
+    ("ReworkTracking", "rework_cost"):
+        _r("production.rework.cost", _PR, S),
+    ("ReworkTracking", "rework_rate"):
+        _r("production.rework.rate", _PR, S),
+    ("ReworkTracking", "rework_trend"):
+        _r("production.rework.trend", _PR, S),
+    ("RoutingTraceabilityEvents", "build_routing_timeline"):
+        _r("production.routing.timeline", _PR, P, objs=("asset", "serial", "station")),
+    ("RoutingTraceabilityEvents", "lead_time"):
+        _r("production.routing.lead_time", _PR, S, objs=("serial",)),
+    ("RoutingTraceabilityEvents", "routing_paths"):
+        _r("production.routing.paths", _PR, ST, objs=("serial",)),
+    ("RoutingTraceabilityEvents", "station_statistics"):
+        _r("production.routing.station_statistics", _PR, S, objs=("station",)),
+    ("ScrapTracking", "scrap_by_reason"):
+        _r("production.scrap.by_reason", _PR, S),
+    ("ScrapTracking", "scrap_by_shift"):
+        _r("production.scrap.by_shift", _PR, S, objs=("asset", "shift")),
+    ("ScrapTracking", "scrap_cost"):
+        _r("production.scrap.cost", _PR, S),
+    ("ScrapTracking", "scrap_trend"):
+        _r("production.scrap.trend", _PR, S),
+    ("SetupTimeTracking", "setup_by_product"):
+        _r("production.setup.by_product", _PR, S, objs=("asset", "part")),
+    ("SetupTimeTracking", "setup_durations"):
+        _r("production.setup.durations", _PR, I),
+    ("SetupTimeTracking", "setup_statistics"):
+        _r("production.setup.statistics", _PR, S),
+    ("SetupTimeTracking", "setup_trend"):
+        _r("production.setup.trend", _PR, S),
+    ("ShiftHandoverReport", "from_shift_data"):
+        _r("production.shift.handover_from_data", _PR, S, objs=("asset", "shift")),
+    ("ShiftHandoverReport", "generate_report"):
+        _r("production.shift.handover_report", _PR, S, objs=("asset", "shift")),
+    ("ShiftReporting", "best_and_worst_shifts"):
+        _r("production.shift.best_and_worst", _PR, S, objs=("asset", "shift")),
+    ("ShiftReporting", "shift_comparison"):
+        _r("production.shift.comparison", _PR, S, objs=("asset", "shift")),
+    ("ShiftReporting", "shift_production"):
+        _r("production.shift.production", _PR, S, objs=("asset", "shift")),
+    ("ShiftReporting", "shift_targets"):
+        _r("production.shift.targets", _PR, S, objs=("asset", "shift")),
+    ("TargetTracking", "compare_to_target"):
+        _r("production.target.compare", _PR, S),
+    ("TargetTracking", "target_achievement_summary"):
+        _r("production.target.achievement_summary", _PR, S),
+
+    # ---- quality -----------------------------------------------------------
+    ("AnomalyClassificationEvents", "classify_anomalies"):
+        _r("quality.anomaly.classified_{anomaly_class}", _Q, P),
+    ("AnomalyClassificationEvents", "detect_drift"):
+        _r("quality.anomaly.drift", _Q, P),
+    ("AnomalyClassificationEvents", "detect_flatline"):
+        _r("quality.anomaly.flatline", _Q, I),
+    ("AnomalyClassificationEvents", "detect_oscillation"):
+        _r("quality.anomaly.oscillation", _Q, I),
+    ("CapabilityTrendingEvents", "capability_forecast"):
+        _r("quality.capability.forecast", _Q, S),
+    ("CapabilityTrendingEvents", "capability_over_time"):
+        _r("quality.capability.over_time", _Q, S),
+    ("CapabilityTrendingEvents", "detect_capability_drop"):
+        _r("quality.capability.drop", _Q, P),
+    ("CapabilityTrendingEvents", "yield_estimate"):
+        _r("quality.capability.yield_estimate", _Q, S),
+    ("DataGapAnalysisEvents", "coverage_by_period"):
+        _r("quality.data_gap.coverage_by_period", _Q, S, objs=("signal",)),
+    ("DataGapAnalysisEvents", "find_gaps"):
+        _r("quality.data_gap.gap", _Q, I, objs=("signal",)),
+    ("DataGapAnalysisEvents", "gap_summary"):
+        _r("quality.data_gap.summary", _Q, S, objs=("signal",)),
+    ("DataGapAnalysisEvents", "interpolation_candidates"):
+        _r("quality.data_gap.interpolation_candidate", _Q, P, objs=("signal",)),
+    ("GaugeRepeatabilityEvents", "gauge_rr_summary"):
+        _r("quality.gauge_rr.summary", _Q, ST, objs=("tool",)),
+    ("GaugeRepeatabilityEvents", "measurement_bias"):
+        _r("quality.gauge_rr.bias", _Q, ST, objs=("tool",)),
+    ("GaugeRepeatabilityEvents", "repeatability"):
+        _r("quality.gauge_rr.repeatability", _Q, ST, objs=("tool",)),
+    ("GaugeRepeatabilityEvents", "reproducibility"):
+        _r("quality.gauge_rr.reproducibility", _Q, ST, objs=("tool",)),
+    ("MultiSensorValidationEvents", "consensus_score"):
+        _r("quality.multi_sensor.consensus_score", _Q, S, objs=("sensor",)),
+    ("MultiSensorValidationEvents", "detect_disagreement"):
+        _r("quality.multi_sensor.disagreement", _Q, P, objs=("sensor",)),
+    ("MultiSensorValidationEvents", "identify_outlier_sensor"):
+        _r("quality.multi_sensor.outlier_sensor", _Q, ST, objs=("sensor",)),
+    ("MultiSensorValidationEvents", "pairwise_bias"):
+        _r("quality.multi_sensor.pairwise_bias", _Q, ST, objs=("sensor",)),
+    ("OutlierDetectionEvents", "detect_outliers_iqr"):
+        _r("quality.outlier.iqr", _Q, P, severity_field="severity_score"),
+    ("OutlierDetectionEvents", "detect_outliers_isolation_forest"):
+        _r("quality.outlier.isolation_forest", _Q, P, severity_field="severity_score"),
+    ("OutlierDetectionEvents", "detect_outliers_mad"):
+        _r("quality.outlier.mad", _Q, P, severity_field="severity_score"),
+    ("OutlierDetectionEvents", "detect_outliers_zscore"):
+        _r("quality.outlier.zscore", _Q, P, severity_field="severity_score"),
+    ("SensorDriftEvents", "calibration_health"):
+        _r("quality.sensor_drift.calibration_health", _Q, S, objs=("sensor",)),
+    ("SensorDriftEvents", "detect_span_drift"):
+        _r("quality.sensor_drift.span_drift", _Q, P, objs=("sensor",)),
+    ("SensorDriftEvents", "detect_zero_drift"):
+        _r("quality.sensor_drift.zero_drift", _Q, P, objs=("sensor",)),
+    ("SensorDriftEvents", "drift_trend"):
+        _r("quality.sensor_drift.trend", _Q, S, objs=("sensor",)),
+    ("SignalQualityEvents", "data_completeness"):
+        _r("quality.signal.completeness", _Q, S, objs=("signal",)),
+    ("SignalQualityEvents", "detect_missing_data"):
+        _r("quality.signal.missing", _Q, I, objs=("signal",)),
+    ("SignalQualityEvents", "detect_out_of_range"):
+        _r("quality.signal.out_of_range", _Q, P, objs=("signal",)),
+    ("SignalQualityEvents", "sampling_regularity"):
+        _r("quality.signal.sampling_regularity", _Q, S, objs=("signal",)),
+    ("StatisticalProcessControlRuleBased", "apply_rules_vectorized"):
+        _r("quality.spc.rule_violation", _Q, P),
+    ("StatisticalProcessControlRuleBased", "calculate_control_limits"):
+        _r("quality.spc.control_limits", _Q, ST),
+    ("StatisticalProcessControlRuleBased", "calculate_dynamic_control_limits"):
+        _r("quality.spc.control_limits_dynamic", _Q, S),
+    ("StatisticalProcessControlRuleBased", "detect_cusum_shifts"):
+        _r("quality.spc.cusum_shift", _Q, P),
+    ("StatisticalProcessControlRuleBased", "interpret_violations"):
+        _r("quality.spc.violation_interpretation", _Q, P),
+    ("StatisticalProcessControlRuleBased", "process"):
+        _r("quality.spc.rule_violation", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_1"):
+        _r("quality.spc.rule_1", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_2"):
+        _r("quality.spc.rule_2", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_3"):
+        _r("quality.spc.rule_3", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_4"):
+        _r("quality.spc.rule_4", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_5"):
+        _r("quality.spc.rule_5", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_6"):
+        _r("quality.spc.rule_6", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_7"):
+        _r("quality.spc.rule_7", _Q, P),
+    ("StatisticalProcessControlRuleBased", "rule_8"):
+        _r("quality.spc.rule_8", _Q, P),
+    ("ToleranceDeviationEvents", "process_and_group_data_with_events"):
+        _r("quality.tolerance.deviation", _Q, P, severity_field="severity"),
+    ("ValueDistributionEvents", "detect_bimodal"):
+        _r("quality.distribution.bimodal", _Q, S),
+    ("ValueDistributionEvents", "detect_mode_changes"):
+        _r("quality.distribution.mode_change", _Q, P),
+    ("ValueDistributionEvents", "normality_windows"):
+        _r("quality.distribution.normality", _Q, S),
+    ("ValueDistributionEvents", "percentile_tracking"):
+        _r("quality.distribution.percentile", _Q, S),
+
+    # ---- supplychain -------------------------------------------------------
+    ("DemandPatternEvents", "demand_by_period"):
+        _r("supplychain.demand.by_period", _SC, S, objs=("material",)),
+    ("DemandPatternEvents", "detect_demand_spikes"):
+        _r("supplychain.demand.spike", _SC, P, objs=("material",)),
+    ("DemandPatternEvents", "seasonality_summary"):
+        _r("supplychain.demand.seasonality", _SC, ST, objs=("material",)),
+    ("InventoryMonitoringEvents", "consumption_rate"):
+        _r("supplychain.inventory.consumption_rate", _SC, S, objs=("material",)),
+    ("InventoryMonitoringEvents", "detect_low_stock"):
+        _r("supplychain.inventory.low_stock", _SC, P, objs=("material",)),
+    ("InventoryMonitoringEvents", "reorder_point_breach"):
+        _r("supplychain.inventory.reorder_point_breach", _SC, P, objs=("material",)),
+    ("InventoryMonitoringEvents", "stockout_prediction"):
+        _r("supplychain.inventory.stockout_prediction", _SC, S, objs=("material",)),
+    ("LeadTimeAnalysisEvents", "calculate_lead_times"):
+        _r("supplychain.lead_time.calculated", _SC, I, objs=("work_order",)),
+    ("LeadTimeAnalysisEvents", "detect_lead_time_anomalies"):
+        _r("supplychain.lead_time.anomaly", _SC, P, objs=("work_order",)),
+    ("LeadTimeAnalysisEvents", "lead_time_statistics"):
+        _r("supplychain.lead_time.statistics", _SC, S, objs=("work_order",)),
+}
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+def get(class_name: str, method_name: str) -> LabelRule | None:
+    return REGISTRY.get((class_name, method_name))
+
+
+def render_activity(rule: LabelRule, row: Mapping[str, object]) -> str:
+    """Substitute ``{field}`` placeholders in ``rule.template`` from ``row``.
+
+    Missing fields render as ``unknown`` rather than raising — adapters
+    should not crash on partial input data.
+    """
+    template = rule.template
+    if "{" not in template:
+        return template
+    out = template
+    # Minimal templating: scan for {name} occurrences.
+    i = 0
+    parts: list[str] = []
+    while i < len(template):
+        j = template.find("{", i)
+        if j == -1:
+            parts.append(template[i:])
+            break
+        parts.append(template[i:j])
+        k = template.find("}", j + 1)
+        if k == -1:
+            parts.append(template[j:])
+            break
+        field_name = template[j + 1:k]
+        val = row.get(field_name) if hasattr(row, "get") else None  # type: ignore[arg-type]
+        if val is None:
+            try:
+                val = row[field_name]  # type: ignore[index]
+            except (KeyError, TypeError):
+                val = "unknown"
+        parts.append(str(val))
+        i = k + 1
+    return "".join(parts)

--- a/tests/eventlog/test_adapter_coverage.py
+++ b/tests/eventlog/test_adapter_coverage.py
@@ -1,0 +1,76 @@
+"""Coverage test: every public DataFrame-returning method on every detector
+class under ``ts_shape.events.*`` must have a taxonomy entry. CI fails if a
+new detector method ships without a registered LabelRule.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Iterator
+
+import pandas as pd
+import pytest
+
+import ts_shape.events as events_pkg
+from ts_shape.eventlog.taxonomy import REGISTRY
+
+
+# Methods inherited from utils.base.Base that are not detector outputs.
+_BASE_METHODS = {"get_dataframe"}
+
+
+def _walk_detector_methods() -> Iterator[tuple[str, str]]:
+    for m in pkgutil.walk_packages(events_pkg.__path__, prefix="ts_shape.events."):
+        if m.ispkg:
+            continue
+        try:
+            mod = importlib.import_module(m.name)
+        except Exception:
+            continue
+        for cname, cls in inspect.getmembers(mod, inspect.isclass):
+            if cls.__module__ != m.name:
+                continue
+            for mname, fn in inspect.getmembers(cls, predicate=inspect.isfunction):
+                if mname.startswith("_") or mname in _BASE_METHODS:
+                    continue
+                try:
+                    sig = inspect.signature(fn)
+                except (TypeError, ValueError):
+                    continue
+                ann = sig.return_annotation
+                if ann is pd.DataFrame or "DataFrame" in str(ann):
+                    yield (cname, mname)
+
+
+def test_every_detector_method_has_label_rule():
+    discovered = set(_walk_detector_methods())
+    missing = sorted(discovered - set(REGISTRY))
+    assert not missing, (
+        f"{len(missing)} detector method(s) lack a taxonomy entry — "
+        f"add a LabelRule for each in ts_shape.eventlog.taxonomy.REGISTRY:\n  "
+        + "\n  ".join(f"{c}.{m}" for c, m in missing[:30])
+    )
+
+
+def test_no_orphan_registry_entries():
+    """Every registry entry should match a real detector method."""
+    discovered = set(_walk_detector_methods())
+    orphans = sorted(set(REGISTRY) - discovered)
+    assert not orphans, (
+        "Registry entries with no corresponding detector method:\n  "
+        + "\n  ".join(f"{c}.{m}" for c, m in orphans[:30])
+    )
+
+
+def test_every_label_rule_has_valid_pack():
+    valid = {"quality", "production", "engineering",
+             "maintenance", "supplychain", "energy", "correlation"}
+    bad = [(k, r.pack) for k, r in REGISTRY.items() if r.pack not in valid]
+    assert not bad, f"invalid pack on entries: {bad[:10]}"
+
+
+def test_every_label_rule_has_valid_shape():
+    valid = {"point", "interval", "summary", "static"}
+    bad = [(k, r.shape) for k, r in REGISTRY.items() if r.shape not in valid]
+    assert not bad, f"invalid shape on entries: {bad[:10]}"

--- a/tests/eventlog/test_adapters.py
+++ b/tests/eventlog/test_adapters.py
@@ -117,19 +117,25 @@ def test_bad_detector_spec_raises():
         to_event_log(pd.DataFrame(), detector="missing_dot")
 
 
-# ---------- objects= rejects undeclared types -------------------------------
+# ---------- caller-supplied objects= ----------------------------------------
 
-def test_objects_undeclared_type_raises(outlier_df):
+def test_caller_can_supply_contextual_object_types(outlier_df):
+    """The adapter only auto-extracts ``asset`` from ``source_uuid``, but a
+    caller can attach contextual types like ``batch`` via ``objects=``."""
     legacy = OutlierDetectionEvents(
         outlier_df, value_column="value_double"
     ).detect_outliers_zscore()
-    # OutlierDetectionEvents.detect_outliers_zscore declares ("asset",)
-    with pytest.raises(ValueError, match="not declared"):
-        to_event_log(
-            legacy,
-            detector="OutlierDetectionEvents.detect_outliers_zscore",
-            objects={"batch": "uuid"},
-        )
+    legacy = legacy.assign(batch_id="B-2026-117")
+    log = to_event_log(
+        legacy,
+        detector="OutlierDetectionEvents.detect_outliers_zscore",
+        objects={"batch": "batch_id"},
+        qualifiers={"asset": "produced_on", "batch": "during_batch"},
+    )
+    types = set(log.objects[OCEL_TYPE])
+    assert {"asset", "batch"} <= types
+    # qualifier propagated to relations.
+    assert "during_batch" in set(log.relations["ocel:qualifier"].dropna())
 
 
 # ---------- severity bucket mapping -----------------------------------------

--- a/tests/eventlog/test_adapters.py
+++ b/tests/eventlog/test_adapters.py
@@ -1,0 +1,148 @@
+"""Per-shape adapter tests using representative real detectors."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ts_shape.eventlog import (
+    OCEL_ACTIVITY,
+    OCEL_EID,
+    OCEL_OID,
+    OCEL_TIMESTAMP,
+    OCEL_TYPE,
+    TS_DETECTOR,
+    TS_DURATION_S,
+    TS_PACK,
+    TS_SEVERITY,
+    TS_START_TIMESTAMP,
+    TS_VALUE,
+    to_event_log,
+)
+from ts_shape.events.production.machine_state import MachineStateEvents
+from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+
+
+# ---------- fixtures --------------------------------------------------------
+
+@pytest.fixture()
+def run_idle_df() -> pd.DataFrame:
+    ts = pd.date_range("2026-05-07", periods=20, freq="30s", tz="UTC")
+    return pd.DataFrame({
+        "systime": ts,
+        "value_bool": [True]*5 + [False]*5 + [True]*5 + [False]*5,
+        "uuid": ["m"]*20,
+        "is_delta": [True]+[False]*4 + [True]+[False]*4
+                  + [True]+[False]*4 + [True]+[False]*4,
+    })
+
+
+@pytest.fixture()
+def outlier_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=20, freq="1min", tz="UTC"),
+        "value_double": [1.0]*8 + [50.0] + [1.0]*5 + [-30.0] + [1.0]*5,
+        "uuid": ["m"]*20,
+        "is_delta": [False]*20,
+        "source_uuid": ["asset-A"]*20,
+    })
+
+
+# ---------- interval shape (machine_state.detect_run_idle) ------------------
+
+def test_interval_adapter_basic_shape(run_idle_df):
+    legacy = MachineStateEvents(run_idle_df, run_state_uuid="m").detect_run_idle()
+    log = to_event_log(legacy, detector="MachineStateEvents.detect_run_idle")
+
+    assert len(log.events) == len(legacy)
+    # Activity templated on the `state` field.
+    activities = set(log.events[OCEL_ACTIVITY])
+    assert {"production.machine_state.run", "production.machine_state.idle"} <= activities
+
+    # Interval columns populated.
+    assert log.events[TS_START_TIMESTAMP].notna().all()
+    assert (log.events[TS_DURATION_S] > 0).all()
+
+    # Pack/detector tags.
+    assert (log.events[TS_PACK] == "production").all()
+    assert (log.events[TS_DETECTOR] == "MachineStateEvents.detect_run_idle").all()
+
+    # Object: source_uuid → asset binding.
+    assert log.has_objects
+    assert (log.objects[OCEL_TYPE] == "asset").all()
+
+
+def test_interval_adapter_eids_unique(run_idle_df):
+    legacy = MachineStateEvents(run_idle_df, run_state_uuid="m").detect_run_idle()
+    log = to_event_log(legacy, detector="MachineStateEvents.detect_run_idle")
+    assert log.events[OCEL_EID].is_unique
+
+
+# ---------- point shape (outlier_zscore) ------------------------------------
+
+def test_point_adapter_basic_shape(outlier_df):
+    legacy = OutlierDetectionEvents(
+        outlier_df, value_column="value_double"
+    ).detect_outliers_zscore()
+    log = to_event_log(legacy, detector="OutlierDetectionEvents.detect_outliers_zscore")
+
+    assert len(log.events) == len(legacy)
+    assert (log.events[OCEL_ACTIVITY] == "quality.outlier.zscore").all()
+    assert log.events[TS_START_TIMESTAMP].isna().all()
+    # severity_score got mapped to severity bucket (warn/critical).
+    assert log.events[TS_SEVERITY].notna().all()
+    # value got pulled from value_double automatically.
+    assert log.events[TS_VALUE].notna().all()
+
+
+# ---------- empty-input handling --------------------------------------------
+
+def test_empty_input_returns_empty_log():
+    empty = pd.DataFrame()
+    log = to_event_log(empty, detector="MachineStateEvents.detect_run_idle")
+    assert len(log) == 0
+    assert not log.has_objects
+
+
+# ---------- unknown detector ------------------------------------------------
+
+def test_unknown_detector_raises():
+    with pytest.raises(KeyError, match="no taxonomy entry"):
+        to_event_log(pd.DataFrame(), detector="DoesNotExist.do_thing")
+
+
+# ---------- bad detector spec ----------------------------------------------
+
+def test_bad_detector_spec_raises():
+    with pytest.raises(ValueError, match="ClassName.method_name"):
+        to_event_log(pd.DataFrame(), detector="missing_dot")
+
+
+# ---------- objects= rejects undeclared types -------------------------------
+
+def test_objects_undeclared_type_raises(outlier_df):
+    legacy = OutlierDetectionEvents(
+        outlier_df, value_column="value_double"
+    ).detect_outliers_zscore()
+    # OutlierDetectionEvents.detect_outliers_zscore declares ("asset",)
+    with pytest.raises(ValueError, match="not declared"):
+        to_event_log(
+            legacy,
+            detector="OutlierDetectionEvents.detect_outliers_zscore",
+            objects={"batch": "uuid"},
+        )
+
+
+# ---------- severity bucket mapping -----------------------------------------
+
+def test_severity_bucket_thresholds():
+    df = pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=3, freq="1min", tz="UTC"),
+        "value_double": [1.0, 1.0, 1.0],
+        "uuid": ["m", "m", "m"],
+        "is_delta": [False, False, False],
+        "source_uuid": ["asset-A"]*3,
+        "severity_score": [1.0, 3.5, 5.0],
+    })
+    log = to_event_log(df, detector="OutlierDetectionEvents.detect_outliers_zscore")
+    sev = log.events[TS_SEVERITY].tolist()
+    assert sev == ["info", "warn", "critical"]

--- a/tests/eventlog/test_flat_and_ocel.py
+++ b/tests/eventlog/test_flat_and_ocel.py
@@ -1,0 +1,88 @@
+"""Tests for to_flat_df (XES-style) and to_ocel_tables exporters."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ts_shape.eventlog import (
+    EventLog,
+    XES_ACTIVITY,
+    XES_CASE,
+    XES_LIFECYCLE,
+    XES_TIMESTAMP,
+    concat,
+    to_event_log,
+    to_flat_df,
+    to_ocel_tables,
+)
+from ts_shape.events.production.machine_state import MachineStateEvents
+from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+
+
+@pytest.fixture()
+def small_log():
+    state_df = pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=20, freq="30s", tz="UTC"),
+        "value_bool": [True]*5 + [False]*5 + [True]*5 + [False]*5,
+        "uuid": ["asset-A"]*20,
+        "is_delta": [True]+[False]*4 + [True]+[False]*4
+                  + [True]+[False]*4 + [True]+[False]*4,
+    })
+    legacy_state = MachineStateEvents(state_df, run_state_uuid="asset-A").detect_run_idle()
+    legacy_state["source_uuid"] = "asset-A"
+    state_log = to_event_log(legacy_state, detector="MachineStateEvents.detect_run_idle")
+
+    out_df = pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=20, freq="1min", tz="UTC"),
+        "value_double": [1.0]*8 + [50.0] + [1.0]*5 + [-30.0] + [1.0]*5,
+        "uuid": ["asset-A"]*20,
+        "is_delta": [False]*20,
+        "source_uuid": ["asset-A"]*20,
+    })
+    legacy_out = OutlierDetectionEvents(out_df, value_column="value_double").detect_outliers_zscore()
+    out_log = to_event_log(legacy_out, detector="OutlierDetectionEvents.detect_outliers_zscore")
+    return concat(state_log, out_log)
+
+
+def test_to_flat_df_single_lifecycle(small_log):
+    flat = to_flat_df(small_log, case_object_type="asset", lifecycle="single")
+    assert {XES_CASE, XES_ACTIVITY, XES_TIMESTAMP, XES_LIFECYCLE}.issubset(flat.columns)
+    assert (flat[XES_CASE] == "asset-A").all()
+    assert (flat[XES_LIFECYCLE] == "complete").all()
+    activities = set(flat[XES_ACTIVITY])
+    assert "production.machine_state.run" in activities
+    assert "quality.outlier.zscore" in activities
+
+
+def test_to_flat_df_two_row_lifecycle(small_log):
+    flat = to_flat_df(small_log, case_object_type="asset", lifecycle="two_row")
+    # Interval rows expand to start+complete; point rows stay as one row.
+    assert (flat[XES_LIFECYCLE].isin(["start", "complete"])).all()
+    # At least one start row exists (for the run/idle intervals).
+    assert (flat[XES_LIFECYCLE] == "start").sum() > 0
+
+
+def test_to_flat_df_unknown_object_type_raises(small_log):
+    with pytest.raises(ValueError, match="no objects of type"):
+        to_flat_df(small_log, case_object_type="batch")
+
+
+def test_to_flat_df_no_objects_raises():
+    log = EventLog()  # empty, no objects
+    with pytest.raises(ValueError, match="requires objects"):
+        to_flat_df(log)
+
+
+def test_to_flat_df_invalid_lifecycle(small_log):
+    with pytest.raises(ValueError, match="invalid lifecycle"):
+        to_flat_df(small_log, lifecycle="weird")
+
+
+def test_to_ocel_tables_returns_three_frames(small_log):
+    events, objects, relations = to_ocel_tables(small_log)
+    assert isinstance(events, pd.DataFrame)
+    assert isinstance(objects, pd.DataFrame)
+    assert isinstance(relations, pd.DataFrame)
+    assert len(events) == len(small_log.events)
+    assert len(objects) == len(small_log.objects)
+    assert len(relations) == len(small_log.relations)

--- a/tests/eventlog/test_schema.py
+++ b/tests/eventlog/test_schema.py
@@ -1,0 +1,72 @@
+"""Schema-level tests: required columns, validation, empty frames."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ts_shape.eventlog import (
+    EventLog,
+    OCEL_ACTIVITY,
+    OCEL_EID,
+    OCEL_OID,
+    OCEL_TIMESTAMP,
+    OCEL_TYPE,
+    TS_DETECTOR,
+    TS_PACK,
+    validate,
+)
+from ts_shape.eventlog import schema as S
+
+
+def test_empty_eventlog_validates():
+    log = EventLog()
+    validate(log)
+    assert len(log) == 0
+    assert not log.has_objects
+
+
+def test_missing_required_column_raises():
+    log = EventLog(events=pd.DataFrame({OCEL_EID: ["e-1"]}))
+    with pytest.raises(ValueError, match="missing required columns"):
+        validate(log)
+
+
+def test_duplicate_eid_raises():
+    events = S.empty_events()
+    events = pd.concat([
+        events,
+        pd.DataFrame({
+            OCEL_EID: ["e-1", "e-1"],
+            OCEL_ACTIVITY: ["a", "a"],
+            OCEL_TIMESTAMP: pd.to_datetime(["2026-01-01", "2026-01-02"], utc=True),
+            TS_DETECTOR: ["x", "x"],
+            TS_PACK: ["quality", "quality"],
+        }),
+    ], ignore_index=True)
+    log = EventLog(events=events)
+    with pytest.raises(ValueError, match="duplicate"):
+        validate(log)
+
+
+def test_relation_to_unknown_event_raises():
+    relations = pd.DataFrame({
+        OCEL_EID: ["e-missing"],
+        OCEL_OID: ["o-1"],
+        OCEL_TYPE: ["asset"],
+        S.OCEL_QUALIFIER: [pd.NA],
+    })
+    log = EventLog(relations=relations)
+    with pytest.raises(ValueError, match="unknown"):
+        validate(log)
+
+
+def test_register_object_type_rejects_invalid():
+    with pytest.raises(ValueError):
+        S.register_object_type("")
+    with pytest.raises(ValueError):
+        S.register_object_type("bad:name")
+
+
+def test_register_object_type_adds_known():
+    S.register_object_type("custom_type_xyz")
+    assert S.is_known_object_type("custom_type_xyz")


### PR DESCRIPTION
Standardize ts-shape detector outputs behind a shape-driven adapter layer
that emits a canonical EventLog (events + objects + relations) using OCEL
2.0 and XES column names verbatim. ts-shape itself adds no process-mining
dependencies; users can hand the resulting DataFrames to pm4py / OCEL
viewers directly.

The taxonomy registry covers all 264 public DataFrame-returning methods
across the seven event packs, with a CI coverage test that fails if a new
detector method ships without a registered LabelRule. Object/relation
tables are only populated when the source detector has a natural object
association (declared via `produces_objects`).

https://claude.ai/code/session_01E8y5483TJYyg8F92UkX7ZA