### PR TITLE
Add lambda-rule subsystem for declarative, user-authored event detectors

### DIFF
--- a/docs/concept.md
+++ b/docs/concept.md
@@ -41,6 +41,108 @@ flowchart TB
     style D3 stroke-dasharray: 4 3
 ```
 
+## Full library architecture
+
+A more detailed map showing every top-level package, the key classes inside each, and how they hand data to one another. The five top rows mirror the abstract pipeline above; the bottom row is the canonical event log + exporters that every detector funnels into. For how a single detection actually flows through these layers, see [Event Handling — Visual Overview](guides/event-handling-flow.md).
+
+```mermaid
+flowchart TB
+    subgraph LOADER["ts_shape.loader — data acquisition"]
+        direction LR
+        L_TS["<b>timeseries/</b><br/>ParquetLoader · S3Loader<br/>AzureBlobLoader · TimescaleLoader"]
+        L_MD["<b>metadata/</b><br/>MetadataJsonLoader<br/>MetadataCsvLoader"]
+        L_CX["<b>context/</b><br/>ContextLoader · BatchContextLoader"]
+        L_CM["<b>combine/</b><br/>JoinLoaders · MergeOnTime"]
+    end
+
+    subgraph TRANSFORM["ts_shape.transform — signal conditioning"]
+        direction LR
+        T_FN["<b>functions/</b><br/>resample · interpolate · clip"]
+        T_FT["<b>filter/</b><br/>RangeFilter · DeltaFilter<br/>NullFilter · UuidFilter"]
+        T_CA["<b>calculator/</b><br/>UnitConvert · Derivatives<br/>SignalArithmetic"]
+        T_TM["<b>time_functions/</b><br/>shift · align · gap_fill"]
+        T_HM["harmonization.py"]
+    end
+
+    subgraph FEATURE["ts_shape.features — analytics"]
+        direction LR
+        F_ST["<b>stats/</b><br/>WindowedStats · RollingAgg"]
+        F_TS["<b>time_stats/</b><br/>seasonal · trend · changepoint"]
+        F_CY["<b>cycles/</b><br/>CycleExtractor · CycleStats"]
+        F_SE["<b>segment_analysis/</b><br/>regime detection"]
+        F_CR["<b>cross_signal.py</b> · <b>pattern_recognition.py</b>"]
+    end
+
+    subgraph CONTEXT["ts_shape.context"]
+        CX["value_mapping.py — categorical lookups, code → label"]
+    end
+
+    subgraph EVENTS["ts_shape.events — detector library (290 methods, 68 classes)"]
+        direction LR
+        EV_Q["<b>quality/</b> · 11 classes<br/>OutlierDetection · SPC · ToleranceDeviation<br/>SensorDrift · GaugeRepeatability · ValueDistribution<br/>AnomalyClassification · CapabilityTrending<br/>DataGapAnalysis · MultiSensorValidation · SignalQuality"]
+        EV_P["<b>production/</b> · 30 classes<br/>MachineState · OEECalculator · DowntimeTracking<br/>CycleTime · ChangeoverEvents · BatchTracking<br/>QualityTracking · ScrapTracking · ShiftReporting<br/>OrderTraceability · …"]
+        EV_E["<b>engineering/</b> · 12 classes<br/>ControlLoopHealth · ProcessStability<br/>SetpointChange · StartupDetection · SteadyState<br/>ThresholdMonitoring · WarmUpCoolDown · …"]
+        EV_M["<b>maintenance/</b> · 3 classes<br/>DegradationDetection<br/>FailurePrediction · VibrationAnalysis"]
+        EV_EN["<b>energy/</b> · 5 classes<br/>EnergyConsumption · EnergyEfficiency<br/>CarbonIntensity · IdleEnergyDetection<br/>EnergyPerformanceIndicator"]
+        EV_CO["<b>correlation/</b> · 2 classes<br/>SignalCorrelation · AnomalyCorrelation"]
+        EV_SC["<b>supplychain/</b> · 3 classes<br/>DemandPattern · InventoryMonitoring<br/>LeadTimeAnalysis"]
+    end
+
+    subgraph EVENTLOG["ts_shape.eventlog — canonical OCEL 2.0 layer"]
+        direction LR
+        EL_M["<b>model.py</b><br/>EventLog (events · objects · relations)"]
+        EL_S["<b>schema.py</b><br/>OCEL columns · STANDARD_ATTR_KEYS<br/>register_object_type · validate"]
+        EL_T["<b>taxonomy.py</b><br/>LabelRule · REGISTRY (290+ entries)"]
+        EL_A["<b>adapters.py</b> · <b>archetypes.py</b><br/>shape-driven adapter · ARCHETYPE_BY_METHOD"]
+        EL_N["<b>normalizer.py</b><br/>to_event_log(df, detector=…)"]
+        EL_FO["<b>flat.py · ocel.py · concat.py</b><br/>to_flat_df (XES) · to_ocel_tables · concat"]
+        EL_LR["<b>lambda_rules/</b><br/>RuleSpec · TriggerSpec · LambdaDetector<br/>compile_expression (AST-restricted)<br/>register_lambda_rule · load_yaml<br/>run_backtest"]
+    end
+
+    subgraph UTILS["ts_shape.utils"]
+        U["base.py — Base class (get_dataframe, common ctor)"]
+    end
+
+    subgraph CONSUMERS["Consumers"]
+        direction LR
+        C_XES["pm4py / Disco / Celonis<br/>(XES)"]
+        C_OCEL["OCEL 2.0 viewers"]
+        C_KPI["BI · dashboards · reports"]
+    end
+
+    LOADER --> TRANSFORM --> FEATURE
+    FEATURE --> EVENTS
+    CONTEXT -.enriches.-> EVENTS
+    U -.base class.-> EVENTS
+    EVENTS -.legacy DataFrames.-> EL_N
+    EL_T --> EL_N
+    EL_A --> EL_N
+    EL_S --> EL_N
+    EL_N --> EL_M
+    EL_LR -.registers in.-> EL_T
+    EL_LR -.runs through.-> EL_N
+    EL_M --> EL_FO
+    EL_FO --> CONSUMERS
+
+    style LOADER fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style TRANSFORM fill:#1a3a4a,stroke:#2dd4bf,color:#ccfbf1
+    style FEATURE fill:#1a3a4a,stroke:#2dd4bf,color:#ccfbf1
+    style CONTEXT fill:#1a3a4a,stroke:#2dd4bf,color:#ccfbf1
+    style EVENTS fill:#3d2a0f,stroke:#f59e0b,color:#fef3c7
+    style EVENTLOG fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style UTILS fill:#27272a,stroke:#a1a1aa,color:#e4e4e7
+    style CONSUMERS fill:#14532d,stroke:#22c55e,color:#dcfce7
+    style EL_LR stroke:#a78bfa,stroke-width:2px
+```
+
+**How to read it.**
+
+- **Top to bottom** = data direction. A pipeline reads `loader → transform → feature → events → eventlog`.
+- **`utils.base.Base`** is the lone shared parent for nearly every detector class (provides `__init__(dataframe, column_names, ...)` and `get_dataframe()`). Dashed arrow.
+- **`eventlog/`** is the convergence point — every detector method maps to a `LabelRule` in `REGISTRY` and is normalized by the shape-driven adapter into the same `EventLog` schema.
+- **`lambda_rules/`** (purple-bordered) coexists with the 290 built-in detectors. It registers dynamically in `REGISTRY`, then runs through `normalizer.to_event_log` exactly like a hand-coded class.
+- **No detector class imports another detector class.** All cross-detector composition happens at the `EventLog` level via `concat()`.
+
 ## Core Principles
 
 | Principle | Description |

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -4,53 +4,41 @@ ts-shape is a lightweight toolkit for shaping timeseries data into analysis-read
 
 ## Architecture
 
+A layered, abstract view of the pipeline. The detection layer is intentionally pluggable — see [Lambda Rules](guides/lambda-rules.md) for the user-authored path.
+
 ```mermaid
-flowchart LR
-    subgraph ACQ["<b>Data Acquisition</b><br/><i>8 loaders</i>"]
-        L1["Parquet"]
-        L2["S3 / Azure"]
-        L3["TimescaleDB"]
-        L4["Metadata"]
+flowchart TB
+    subgraph IN["Sources"]
+        S1[Time-series stores<br/><i>Parquet · S3/Azure · TimescaleDB</i>]
+        S2[Object &amp; context<br/><i>batches · shifts · assets</i>]
     end
-
-    subgraph COND["<b>Signal Conditioning</b><br/><i>9 classes</i>"]
-        T["Filters &<br/>Calculations"]
+    subgraph LOAD["Load &amp; Enrich"]
+        L1[Loaders]
+        L2[Transforms · Features · Statistics]
     end
-
-    subgraph ANA["<b>Signal Analytics</b><br/><i>5 classes</i>"]
-        F["Statistics &<br/>Cycles"]
+    subgraph DETECT["Detection Layer"]
+        D1["Built-in detectors<br/>(290 methods, 68 classes)"]
+        D2["Lambda rules<br/>(YAML / DSL)"]
+        D3["Gen-AI authoring<br/><i>roadmap</i>"]
     end
-
-    subgraph EVT["<b>Event Detection</b>"]
-        E1["Quality & SPC<br/><i>9 classes</i>"]
-        E2["Production<br/><i>26 classes</i>"]
-        E3["Engineering<br/><i>13 classes</i>"]
-        E4["Maintenance /<br/>Energy / Supply<br/><i>10 classes</i>"]
+    subgraph EVENTLOG["Canonical EventLog (OCEL 2.0)"]
+        E1[Events]
+        E2[Objects]
+        E3[Relations]
     end
-
-    subgraph RPT["<b>Reports</b>"]
-        R1["Shift Handover"]
-        R2["Period Summary"]
+    subgraph OUT["Consumers"]
+        O1[XES / pm4py]
+        O2[OCEL viewers]
+        O3[KPIs &amp; reports]
     end
-
-    L1 --> T
-    L2 --> T
-    L3 --> T
-    L4 --> T
-
-    T --> F --> E1
-    F --> E2
-    F --> E3
-    F --> E4
-
-    E2 --> R1
-    E2 --> R2
-
-    style ACQ fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
-    style COND fill:#1a3a4a,stroke:#2dd4bf,color:#e0f2fe
-    style ANA fill:#1a3a4a,stroke:#2dd4bf,color:#e0f2fe
-    style EVT fill:#1a3a4a,stroke:#f59e0b,color:#fef3c7
-    style RPT fill:#14532d,stroke:#22c55e,color:#dcfce7
+    IN --> LOAD --> DETECT
+    D1 --> EVENTLOG
+    D2 --> EVENTLOG
+    D3 -.-> D2
+    EVENTLOG --> OUT
+    style DETECT fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style EVENTLOG fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style D3 stroke-dasharray: 4 3
 ```
 
 ## Core Principles

--- a/docs/guides/event-handling-flow.md
+++ b/docs/guides/event-handling-flow.md
@@ -1,0 +1,211 @@
+# Event Handling — Visual Overview
+
+How ts-shape turns raw signals into events. Three layers, four archetypes, one canonical event log.
+
+Every detection in ts-shape — whether it comes from one of the 290 built-in detector methods or a [user-authored lambda rule](lambda-rules.md) — passes through the same three-layer flow:
+
+1. **Signals** — raw timeseries DataFrame columns (booleans, floats, categoricals).
+2. **Events** — rows in the canonical `EventLog` produced by a detector method.
+3. **Rule** — the code or YAML that defines *when* signals trigger an event, classified into one of four **archetypes**: `threshold`, `interval`, `aggregate`, `static`.
+
+The archetype determines the event's *shape* (point / interval / summary / static), which standard attributes the rule must populate (e.g. `ts_shape:method`, `ts_shape:lifecycle_state`), and which OCEL object types are auto-extracted.
+
+The four diagrams below show one representative scenario per archetype. Read each as a stack: raw signals on top, derived events in the middle, rule definition on the bottom. Dashed links read **rule → signal it watches**; solid links read **rule → event it produces**.
+
+---
+
+## Archetype 1 — `threshold` (point shape)
+
+Per-row check: a single sample compared against a reference. Outliers, SPC violations, tolerance deviations, exceedances. One True row → one point event.
+
+**Representative scenario.** Tool wear: emit one event per torque sample that exceeds 75 Nm while the tool is running.
+
+```mermaid
+flowchart TB
+    subgraph SIG["① Signals — raw DataFrame columns"]
+        direction LR
+        S1["<b>torque</b><br/>72 · 74 · <b>79.5</b> · <b>86</b> · 73 · <b>95</b> · 68"]
+        S2["<b>state</b><br/>run · run · run · run · run · run · idle"]
+        S3["<b>source_uuid</b><br/>asset-A everywhere"]
+    end
+    subgraph EVT["② Events — canonical EventLog rows"]
+        direction LR
+        E1["⚠ high_torque @ t₃<br/>severity=warn · value=79.5"]
+        E2["🛑 high_torque @ t₄<br/>severity=critical · value=86"]
+        E3["🛑 high_torque @ t₆<br/>severity=critical · value=95"]
+    end
+    subgraph RULE["③ Rule — threshold archetype"]
+        R["<b>OutlierDetectionEvents.detect_outliers_iqr</b><br/>(built-in)<br/>— or —<br/><b>LambdaToolWear.high_torque</b><br/>(YAML rule)<br/><br/>expression: torque &gt; 75 &amp; state == 'run'<br/>activity template: maintenance.tool.high_torque<br/>required standard_attrs: ts_shape:method, ts_shape:direction"]
+    end
+    R -.watches.-> S1
+    R -.watches.-> S2
+    R ==>|emits| E1
+    R ==>|emits| E2
+    R ==>|emits| E3
+    S3 -.auto-extract→ asset object.-> E1
+    style SIG fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style EVT fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style RULE fill:#1a3a2e,stroke:#34d399,color:#d1fae5
+    style E1 fill:#78350f,color:#fef3c7
+    style E2 fill:#7f1d1d,color:#fee2e2
+    style E3 fill:#7f1d1d,color:#fee2e2
+```
+
+**Required `standard_attrs` for `threshold`:** `ts_shape:method`, `ts_shape:direction`.
+
+---
+
+## Archetype 2 — `interval` (interval shape)
+
+Contiguous runs of True samples are coalesced (per group) into one event with `start`, `end`, duration. Optional `min_duration_s` filter rejects short blips (hysteresis).
+
+**Representative scenario.** Sustained hot-bearing windows per machine: ignore single-sample spikes, flag any window of ≥ 30 s where `bearing_temp_c > 85`.
+
+```mermaid
+flowchart TB
+    subgraph SIG["① Signals — multi-asset stream"]
+        direction LR
+        SA["<b>bearing_temp_c</b> @ asset-A<br/>82 · 86 · 88 · 87 · 84 · 83 · 90 · 82"]
+        SB["<b>bearing_temp_c</b> @ asset-B<br/>80 · 81 · 82 · 80 · 89 · 90 · 91 · 92"]
+        SU["<b>source_uuid</b><br/>used as group_by key"]
+    end
+    subgraph MASK["② Mask + coalesce per group"]
+        direction LR
+        MA["asset-A run 1: 3 samples · 45 s ✓"]
+        MA2["asset-A run 2: 1 sample · 0 s ✗ drop"]
+        MB["asset-B run: 4 samples · 45 s ✓"]
+    end
+    subgraph EVT["③ Events — interval rows"]
+        direction LR
+        EA["🟥 hot_window @ asset-A<br/>start=t₁ · end=t₃ · 45 s · mean=87"]
+        EB["🟥 hot_window @ asset-B<br/>start=t₄ · end=t₆ · 45 s · mean=90"]
+    end
+    subgraph RULE["④ Rule — interval archetype"]
+        R["<b>MachineStateEvents.detect_run_idle</b> (built-in)<br/>— or —<br/><b>LambdaBearing.hot_window</b> (YAML rule)<br/><br/>expression: bearing_temp_c &gt; 85<br/>min_duration_s: 30 · group_by: [source_uuid]<br/>activity template: maintenance.bearing.hot<br/>required standard_attrs: ts_shape:lifecycle_state"]
+    end
+    R -.watches.-> SA
+    R -.watches.-> SB
+    R -.group by.-> SU
+    SA --> MA
+    SA --> MA2
+    SB --> MB
+    MA ==> EA
+    MB ==> EB
+    MA2 -. dropped .-x EA
+    R --> MA
+    style SIG fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style MASK fill:#2a1a3d,stroke:#a78bfa,color:#ede9fe
+    style EVT fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style RULE fill:#1a3a2e,stroke:#34d399,color:#d1fae5
+    style EA fill:#7f1d1d,color:#fee2e2
+    style EB fill:#7f1d1d,color:#fee2e2
+    style MA2 fill:#3f3f46,color:#a1a1aa,stroke-dasharray: 4 3
+```
+
+**Required `standard_attrs` for `interval`:** `ts_shape:lifecycle_state`.
+
+---
+
+## Archetype 3 — `aggregate` (summary shape)
+
+Window-based statistics. One row per period × group: per-shift OEE, per-day production, hourly cycle-time stats. The event timestamp marks the period end; `ts_shape:start_timestamp` marks the period start.
+
+**Representative scenario.** OEE by shift: roll cycle counts, downtime, and reject counts into one summary row per (shift × asset).
+
+```mermaid
+flowchart TB
+    subgraph SIG["① Signals — multi-source"]
+        direction LR
+        SC["<b>cycle_count</b><br/>1 · 1 · 1 · 0 · 1 · 1 · …"]
+        SR["<b>reject_count</b><br/>0 · 0 · 1 · 0 · 0 · 0 · …"]
+        SS["<b>state</b> (run/idle/down)"]
+        SP["<b>part_id, shift_id</b><br/>(context columns)"]
+    end
+    subgraph AGG["② Aggregation window"]
+        direction LR
+        W1["shift_id = A · 08:00–16:00<br/>parts=412 · rejects=7 · downtime=18min"]
+        W2["shift_id = B · 16:00–00:00<br/>parts=389 · rejects=4 · downtime=22min"]
+    end
+    subgraph EVT["③ Events — summary rows"]
+        direction LR
+        EW1["📊 oee_shift @ shift-A<br/>availability=0.95 · performance=0.91 · quality=0.98<br/>OEE=0.85 · sample_count=412"]
+        EW2["📊 oee_shift @ shift-B<br/>availability=0.93 · performance=0.89 · quality=0.99<br/>OEE=0.82 · sample_count=389"]
+    end
+    subgraph RULE["④ Rule — aggregate archetype"]
+        R["<b>OEECalculator.calculate_oee</b> (built-in)<br/>— or —<br/><b>PartProductionTracking.daily_production_summary</b><br/><br/>group_by: [shift_id, asset]<br/>window: per shift<br/>activity template: production.oee.shift_summary<br/>required standard_attrs: ts_shape:sample_count"]
+    end
+    R -.watches.-> SC
+    R -.watches.-> SR
+    R -.watches.-> SS
+    R -.group by.-> SP
+    SC --> W1
+    SR --> W1
+    SS --> W1
+    SC --> W2
+    W1 ==> EW1
+    W2 ==> EW2
+    style SIG fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style AGG fill:#2a1a3d,stroke:#a78bfa,color:#ede9fe
+    style EVT fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style RULE fill:#1a3a2e,stroke:#34d399,color:#d1fae5
+    style EW1 fill:#064e3b,color:#d1fae5
+    style EW2 fill:#064e3b,color:#d1fae5
+```
+
+**Required `standard_attrs` for `aggregate`:** `ts_shape:sample_count`.
+
+---
+
+## Archetype 4 — `static` (static shape)
+
+No natural time axis. Reference data, snapshots, top-N tables, gauge R&R results. One event per row, timestamped at the export moment so it still fits the canonical schema.
+
+**Representative scenario.** SPC control-limit calculation: produce a single snapshot per signal capturing UCL/LCL/centre line for downstream rule evaluation.
+
+```mermaid
+flowchart TB
+    subgraph SIG["① Signals — historical baseline window"]
+        direction LR
+        SH["<b>value_double</b><br/>(100 historical samples for asset-A · torque)"]
+    end
+    subgraph CALC["② Control-limit calculation"]
+        C["mean = 42.1<br/>std = 1.4<br/>UCL = mean + 3σ = 46.3<br/>LCL = mean − 3σ = 37.9"]
+    end
+    subgraph EVT["③ Events — static rows"]
+        direction LR
+        ES["📐 spc_limits @ asset-A · torque<br/>method=xbar_r · UCL=46.3 · LCL=37.9 · mean=42.1<br/>sample_count=100"]
+    end
+    subgraph RULE["④ Rule — static archetype"]
+        R["<b>StatisticalProcessControlRuleBased.calculate_control_limits</b><br/>— or —<br/><b>GaugeRepeatabilityEvents.repeatability</b><br/><br/>method: xbar_r / nelson / westgard<br/>activity template: quality.spc.control_limits<br/>required standard_attrs: ts_shape:method"]
+    end
+    R -.watches.-> SH
+    SH --> C
+    C ==> ES
+    style SIG fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style CALC fill:#2a1a3d,stroke:#a78bfa,color:#ede9fe
+    style EVT fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style RULE fill:#1a3a2e,stroke:#34d399,color:#d1fae5
+    style ES fill:#1e3a8a,color:#dbeafe
+```
+
+**Required `standard_attrs` for `static`:** `ts_shape:method`.
+
+---
+
+## Reading the diagrams
+
+| Visual cue | Meaning |
+|---|---|
+| **Blue subgraph** | Raw signals — DataFrame columns the detector reads. |
+| **Purple subgraph** | Intermediate computation (mask, coalescing, aggregation window). Not always present. |
+| **Amber subgraph** | Events — rows in the canonical `EventLog`. Color of an event node hints at severity. |
+| **Green subgraph** | The rule itself — code (built-in detector class.method) or YAML (lambda rule). |
+| **Dashed arrow** | Rule *watches* this signal — it appears as a column reference in the trigger or as a parameter to the detector constructor. |
+| **Solid bold arrow** | Rule *emits* this event row. |
+| **Dotted X arrow** | Filtered out (e.g., interval shorter than `min_duration_s`). |
+
+---
+
+## Where this fits in the rest of the library
+
+For the full module map — including loaders, transforms, features, and how the event layer plugs into them — see the architecture chart in [Concept](../concept.md#full-library-architecture). For the canonical event-log schema events ultimately land in, see [Event Log (XES & OCEL)](eventlog.md). For the user-authored path that emits straight into this same flow, see [Lambda Rules](lambda-rules.md).

--- a/docs/guides/eventlog.md
+++ b/docs/guides/eventlog.md
@@ -33,6 +33,9 @@ flowchart LR
 !!! tip "Need a rule without writing a Python class?"
     The [Lambda Rules guide](lambda-rules.md) walks through declaring detectors in YAML. They register dynamically with the same taxonomy and flow through the same adapter described below.
 
+!!! info "Want to see the three-layer flow?"
+    [Event Handling — Visual Overview](event-handling-flow.md) has one infographic per archetype (threshold / interval / aggregate / static) showing raw signals → events → rule definition stacked together.
+
 ---
 
 ## The canonical schema

--- a/docs/guides/eventlog.md
+++ b/docs/guides/eventlog.md
@@ -26,9 +26,12 @@ flowchart LR
     style NORM fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
 ```
 
-- One adapter layer normalizes **all 264** public DataFrame-returning detector methods into the same schema.
+- One adapter layer normalizes **all 290+** public DataFrame-returning detector methods into the same schema. User-authored detectors via the [Lambda Rules](lambda-rules.md) subsystem flow through the same adapter without any extra plumbing.
 - The event log keeps OCEL's separation of **events**, **objects**, and **event-to-object relations** — no single "case" is forced.
 - `to_flat_df(case_object_type=...)` defers the case-id question to export time: flatten the same log per asset, per batch, per cycle, etc.
+
+!!! tip "Need a rule without writing a Python class?"
+    The [Lambda Rules guide](lambda-rules.md) walks through declaring detectors in YAML. They register dynamically with the same taxonomy and flow through the same adapter described below.
 
 ---
 

--- a/docs/guides/lambda-rules.md
+++ b/docs/guides/lambda-rules.md
@@ -297,4 +297,4 @@ Both rely on (a) the canonical-event-log plumbing already in place, (b) the lamb
 
 Other roadmap items: rule packs (versioned YAML bundles per industry), streaming evaluation over chunked DataFrames, polars backend, and labelled backtest scoring (precision/recall).
 
-For an end-to-end runnable example see [`examples/lambda_rules_demo.py`](https://github.com/jakobgabriel/ts-shape/blob/main/examples/lambda_rules_demo.py). For the canonical schema the rules ultimately emit into, see the [Event Log guide](eventlog.md).
+For an end-to-end runnable example see [`examples/lambda_rules_demo.py`](https://github.com/jakobgabriel/ts-shape/blob/main/examples/lambda_rules_demo.py). For the canonical schema the rules ultimately emit into, see the [Event Log guide](eventlog.md). For a side-by-side view of how every detection archetype flows from raw signals through events to rule definitions, see [Event Handling — Visual Overview](event-handling-flow.md).

--- a/docs/guides/lambda-rules.md
+++ b/docs/guides/lambda-rules.md
@@ -1,0 +1,300 @@
+# Lambda Rules: declarative, user-authored detectors
+
+ts-shape ships ~290 hand-written detector methods across 68 classes — a curated industry library covering machine state, OEE, SPC, drift, vibration, energy, supply chain, and more. They are precise, opinionated, and parametric. They are also code: every new detection idea requires a new Python class, a new taxonomy entry, a new archetype, a new test.
+
+The **lambda-rule** subsystem coexists with that library. You declare a rule in YAML (or a dict), the loader compiles it into a `LambdaDetector`, and it joins the same `REGISTRY` the built-ins live in. From that point on the canonical-event-log pipeline does not care which kind of detector emitted the row — the rule's output flows through the same shape-driven adapter, severity bucketing, object auto-extraction, OCEL / XES export, `concat`, and schema validation.
+
+No new pipeline. No refactor of existing detectors. The same `EventLog`.
+
+---
+
+## At a glance
+
+```mermaid
+flowchart TB
+    subgraph IN["Sources"]
+        S1[Time-series stores]
+        S2[Object &amp; context]
+    end
+    subgraph LOAD["Load &amp; Enrich"]
+        L1[Loaders]
+        L2[Transforms / Features]
+    end
+    subgraph DETECT["Detection Layer"]
+        D1["Built-in detectors<br/>(290 methods, 68 classes)"]
+        D2["Lambda rules<br/>(YAML / DSL)"]
+        D3["Gen-AI authoring<br/><i>roadmap</i>"]
+    end
+    subgraph EVENTLOG["Canonical EventLog (OCEL 2.0)"]
+        E1[Events]
+        E2[Objects]
+        E3[Relations]
+    end
+    subgraph OUT["Consumers"]
+        O1[XES / pm4py]
+        O2[OCEL viewers]
+        O3[KPIs &amp; reports]
+    end
+    IN --> LOAD --> DETECT
+    D1 --> EVENTLOG
+    D2 --> EVENTLOG
+    D3 -.-> D2
+    EVENTLOG --> OUT
+    style DETECT fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style EVENTLOG fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style D3 stroke-dasharray: 4 3
+```
+
+The lambda subsystem occupies the middle column alongside the built-ins. A future gen-AI authoring layer (roadmap, dashed) will emit lambda rules — not new Python code — so it shares the safety net of the AST-restricted expression compiler.
+
+---
+
+## How a lambda rule flows through the system
+
+```mermaid
+flowchart LR
+    Y["YAML rule"] --> SP["RuleSpec"]
+    SP --> COMP["compile_expression<br/>(AST whitelist)"]
+    COMP --> LD["LambdaDetector"]
+    SP --> REG["register_lambda_rule<br/>(writes REGISTRY)"]
+    DF[("DataFrame")] --> LD
+    LD --> LG["legacy DataFrame"]
+    LG --> NORM["to_event_log"]
+    REG -.-> NORM
+    NORM --> EL["EventLog"]
+```
+
+The trigger expression is compiled once, the spec is written into `REGISTRY` once, and from then on the detector behaves identically to a built-in: the same `to_event_log(df, detector="...")` entry point dispatches on the detector name, finds the same `LabelRule`, and runs the same shape-driven adapter.
+
+---
+
+## Case 1 — point/threshold: "high torque on a running tool"
+
+**Plant context.** A CNC tool experiences occasional torque spikes when machining harder material or when wear is progressing. We want a point event every time torque exceeds 75 Nm *while the machine is running* (not during retracts or setups), with severity derived from a precomputed `severity_score` column. Downstream, these events feed an OEE dashboard's "tool stress" panel and a maintenance scheduler.
+
+**Signals required.** `torque` (float), `state` (`"run"` / `"idle"`), `severity_score` (float; 4.5 → critical, 3.0 → warn, else info), `source_uuid` (string; auto-extracts to `asset`).
+
+**Rule.**
+
+```yaml
+- id: high_torque
+  class_name: LambdaToolWear
+  method_name: high_torque
+  pack: maintenance
+  shape: point
+  archetype: threshold
+  template: "maintenance.tool.high_torque"
+  produces_objects: [asset]
+  severity_field: severity_score
+  value_field: torque
+  trigger:
+    expression: "(torque > 75) & (state == 'run')"
+  standard_attrs:
+    ts_shape:method: lambda_threshold
+    ts_shape:direction: above
+    ts_shape:threshold_high: 75.0
+```
+
+**What happens.**
+
+```mermaid
+flowchart LR
+    subgraph T["torque on asset-A, state == 'run'"]
+        t1["72"] --> t2["74"] --> t3["79.5<br/>HIT"] --> t4["86<br/>HIT"] --> t5["73"] --> t6["95<br/>HIT"]
+    end
+    t3 --> EV1["event: maintenance.tool.high_torque<br/>severity = warn"]
+    t4 --> EV2["event: maintenance.tool.high_torque<br/>severity = critical"]
+    t6 --> EV3["event: maintenance.tool.high_torque<br/>severity = critical"]
+    style t3 fill:#7f1d1d,color:#fee2e2
+    style t4 fill:#7f1d1d,color:#fee2e2
+    style t6 fill:#7f1d1d,color:#fee2e2
+```
+
+**Resulting EventLog row (one of three).**
+
+| Column | Value |
+|---|---|
+| `ocel:eid` | `e-f0aab89f-345c-…` |
+| `ocel:activity` | `maintenance.tool.high_torque` |
+| `ocel:timestamp` | `2026-05-07 08:05:00+00:00` |
+| `ts_shape:detector` | `LambdaToolWear.high_torque` |
+| `ts_shape:pack` | `maintenance` |
+| `ts_shape:severity` | `warn` |
+| `ts_shape:value` | `79.5` |
+| `ts_shape:method` | `lambda_threshold` |
+| `ts_shape:direction` | `above` |
+| `ts_shape:threshold_high` | `75.0` |
+| `maintenance:source_uuid` | `asset-A` |
+
+The relations table receives a row tying this event to `(asset, asset-A)` — auto-extracted from `source_uuid` because the rule declared `produces_objects: [asset]`.
+
+---
+
+## Case 2 — interval / hysteresis / group-by: "bearing hot window per asset"
+
+**Plant context.** A line of identical pumps occasionally runs hot. Short single-sample spikes are sensor noise; we only care about *sustained* windows of ≥ 30 seconds, and we want one event per machine — not a global one. Downstream, these intervals feed a predictive-maintenance model that buckets time-above-threshold per asset.
+
+**Signals required.** `bearing_temp_c` (float), `source_uuid` (string), a datetime column (`systime`).
+
+**Rule.**
+
+```yaml
+- id: bearing_hot
+  class_name: LambdaBearing
+  method_name: hot_window
+  pack: maintenance
+  shape: interval
+  archetype: interval
+  template: "maintenance.bearing.hot"
+  produces_objects: [asset]
+  value_field: bearing_temp_c
+  trigger:
+    expression: "bearing_temp_c > 85"
+    min_duration_s: 30
+    group_by: [source_uuid]
+  standard_attrs:
+    ts_shape:lifecycle_state: hot
+```
+
+**What happens.**
+
+```mermaid
+flowchart TB
+    subgraph A["asset-A bearing_temp_c"]
+        A1["82"] --> A2["86 ✓"] --> A3["88 ✓"] --> A4["87 ✓"] --> A5["84"]
+    end
+    subgraph B["asset-B bearing_temp_c"]
+        B1["89 ✓"] --> B2["83"] --> B3["90 ✓"] --> B4["91 ✓"] --> B5["92 ✓"]
+    end
+    A2 --> IA["interval A: 3 samples, 45s ✓ keep"]
+    B1 --> IB1["interval B: 1 sample, 0s ✗ drop (min_duration_s=30)"]
+    B3 --> IB2["interval B: 3 samples, 45s ✓ keep"]
+    IA --> EVI["events emitted: 2"]
+    IB2 --> EVI
+```
+
+The evaluator groups by `source_uuid`, finds contiguous True runs *per group*, and drops anything shorter than `min_duration_s`. Each surviving run becomes one row with `start`, `end`, the mean of `value_field` over the run, and the group key.
+
+**Resulting EventLog row (one of two).**
+
+| Column | Value |
+|---|---|
+| `ocel:activity` | `maintenance.bearing.hot` |
+| `ocel:timestamp` | `2026-05-07 08:14:30+00:00` (interval end) |
+| `ts_shape:start_timestamp` | `2026-05-07 08:10:00+00:00` |
+| `ts_shape:duration_s` | `270.0` |
+| `ts_shape:value` | `87.4` (mean over the window) |
+| `ts_shape:lifecycle_state` | `hot` |
+| `maintenance:source_uuid` | `asset-A` |
+
+Relations again carry the `(asset, asset-A)` binding — auto-extracted because the rule declared `produces_objects: [asset]` and the input frame had a `source_uuid` column.
+
+---
+
+## Expression language
+
+Trigger expressions are written in **a tiny subset of Python**. The compiler parses with `ast.parse(mode="eval")` and walks the tree, rejecting any node not on a small allowlist.
+
+```mermaid
+flowchart TB
+    EX["expression string"] --> P["ast.parse(mode='eval')"]
+    P --> W{"node in whitelist?"}
+    W -- "yes (Compare, BoolOp, BinOp, abs/min/max)" --> OK["compile -> Callable[df, Series]"]
+    W -- "no (Import, Attribute, Call, ...)" --> REJ["raise UnsafeExpression"]
+    style OK fill:#064e3b,stroke:#34d399,color:#d1fae5
+    style REJ fill:#7f1d1d,stroke:#fca5a5,color:#fee2e2
+```
+
+**Allowed.**
+
+- Comparisons: `<`, `<=`, `>`, `>=`, `==`, `!=`, `in`, `not in`
+- Vectorized boolean ops: `&` (and), `|` (or), `~` (not)
+- Arithmetic: `+`, `-`, `*`, `/`, `%`, unary `-`/`+`
+- Constants and column-name references (any column in the input DataFrame)
+- Function calls: only `abs`, `min`, `max`
+
+**Rejected (raises `UnsafeExpression`).** Imports, attribute access, indexing, comprehensions, lambdas, any function call that isn't on the allowlist, dunder access, statements, assignments.
+
+**Operator-precedence gotcha.** Python's bitwise `&` and `|` (the vectorized ones pandas understands) bind *tighter* than comparison operators, so wrap each comparison in parens:
+
+```python
+"(torque > 75) & (state == 'run')"   # correct
+"torque > 75 & state == 'run'"        # wrong — parses as torque > (75 & state) == 'run'
+```
+
+Same convention as `pandas.eval` and `DataFrame.query`.
+
+---
+
+## Registration and lifecycle
+
+Two ways in:
+
+```python
+from ts_shape.eventlog import load_yaml, register_lambda_rule, RuleSpec, TriggerSpec
+
+# 1. From a YAML file.
+detectors = load_yaml("rules.yaml")
+
+# 2. From a hand-built spec.
+det = register_lambda_rule(RuleSpec(
+    id="high_torque",
+    class_name="LambdaToolWear",
+    method_name="high_torque",
+    pack="maintenance",
+    shape="point",
+    archetype="threshold",
+    template="maintenance.tool.high_torque",
+    trigger=TriggerSpec(expression="(torque > 75) & (state == 'run')"),
+    severity_field="severity_score",
+    value_field="torque",
+    standard_attrs={
+        "ts_shape:method": "lambda_threshold",
+        "ts_shape:direction": "above",
+        "ts_shape:threshold_high": 75.0,
+    },
+))
+```
+
+Both call paths end up in the same `REGISTRY` mutation. From there:
+
+```python
+log = det.to_event_log(df)                      # one rule
+log = concat(det_a.to_event_log(df),            # many rules
+             det_b.to_event_log(df))
+```
+
+`unregister_lambda_rule(class_name, method_name)` removes a rule cleanly — useful in tests, demos, and reloadable notebooks. Lambda rules live in-process only; persistence is a roadmap item.
+
+---
+
+## Backtest
+
+The MVP backtest is hit-counting + severity/asset histograms — the surface area required to validate that a rule does what you expect, before you ship it.
+
+```python
+from ts_shape.eventlog import run_backtest
+
+result = run_backtest(det, df)
+print(result.hit_count)        # 3
+print(result.by_severity)      # {'critical': 2, 'warn': 1}
+print(result.by_asset)         # {'asset-A': 3}
+result.event_log               # the full EventLog — slice it any way you want
+```
+
+Precision/recall against labelled historical events is a roadmap item (Phase 4 expanded), as is multi-rule diffing.
+
+---
+
+## What's next
+
+The lambda subsystem is the substrate for two AI-authoring features on the roadmap:
+
+- **Rule recommendation from data** — an LLM ingests dataset statistics (and optional labelled events) and proposes candidate lambda rules in this same DSL. The AST-restricted compiler is the safety net: anything the LLM emits that does not type-check, or that touches a disallowed AST node, is silently rejected. Surviving candidates are backtested.
+- **Detector recommender** — given a process description and a list of signals, an LLM picks from the 290 built-in detectors (and recommended parameters) — grounded in the same `LabelRule` taxonomy used here. The output is verified against `REGISTRY` keys before being returned to avoid hallucinated method names.
+
+Both rely on (a) the canonical-event-log plumbing already in place, (b) the lambda DSL described above, and (c) the AST whitelist as the safety boundary.
+
+Other roadmap items: rule packs (versioned YAML bundles per industry), streaming evaluation over chunked DataFrames, polars backend, and labelled backtest scoring (precision/recall).
+
+For an end-to-end runnable example see [`examples/lambda_rules_demo.py`](https://github.com/jakobgabriel/ts-shape/blob/main/examples/lambda_rules_demo.py). For the canonical schema the rules ultimately emit into, see the [Event Log guide](eventlog.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,22 +118,41 @@ Timeseries analytics for manufacturing — from raw signals to production KPIs.
 </div>
 
 ```mermaid
-flowchart LR
-    subgraph Input
-        A1[Parquet]
-        A2[S3 / Azure]
-        A3[TimescaleDB]
+flowchart TB
+    subgraph IN["Sources"]
+        S1[Time-series stores<br/><i>Parquet · S3/Azure · TimescaleDB</i>]
+        S2[Object &amp; context<br/><i>batches · shifts · assets</i>]
     end
-
-    A1 --> L[Load & Enrich]
-    A2 --> L
-    A3 --> L
-
-    L --> T[Transform & Filter]
-    T --> F[Features & Statistics]
-    F --> E[Event Detection]
-    E --> O[Production KPIs & Reports]
+    subgraph LOAD["Load &amp; Enrich"]
+        L1[Loaders]
+        L2[Transforms · Features · Statistics]
+    end
+    subgraph DETECT["Detection Layer"]
+        D1["Built-in detectors<br/>(290 methods, 68 classes)"]
+        D2["Lambda rules<br/>(YAML / DSL)"]
+        D3["Gen-AI authoring<br/><i>roadmap</i>"]
+    end
+    subgraph EVENTLOG["Canonical EventLog (OCEL 2.0)"]
+        E1[Events]
+        E2[Objects]
+        E3[Relations]
+    end
+    subgraph OUT["Consumers"]
+        O1[XES / pm4py]
+        O2[OCEL viewers]
+        O3[KPIs &amp; reports]
+    end
+    IN --> LOAD --> DETECT
+    D1 --> EVENTLOG
+    D2 --> EVENTLOG
+    D3 -.-> D2
+    EVENTLOG --> OUT
+    style DETECT fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style EVENTLOG fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+    style D3 stroke-dasharray: 4 3
 ```
+
+The detection layer is intentionally pluggable: hand-coded detector classes for the curated industry library, YAML-declared [lambda rules](guides/lambda-rules.md) for user-authored or per-site customizations, and (roadmap) gen-AI authoring that emits lambda rules — so it inherits the same AST-sandbox safety net. Whichever path a detection comes from, the output lands in the same canonical event log.
 
 ---
 

--- a/examples/lambda_rules_demo.py
+++ b/examples/lambda_rules_demo.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Lambda Rules Demo for ts-shape
+==============================
+
+Demonstrates user-authored detection rules — declared in YAML, no Python
+class on disk — that flow through the same canonical-event-log plumbing
+as the 290 built-in detector methods.
+
+This example covers both shapes that the MVP supports:
+
+1. **Case 1 — point/threshold:** "high torque on a running tool" — fires
+   per row that crosses a threshold. Severity is derived from a numeric
+   ``severity_score`` column the rule binds via ``severity_field``.
+2. **Case 2 — interval / hysteresis / group-by:** "sustained hot bearing
+   window per asset" — coalesces consecutive True rows per ``source_uuid``
+   into a single interval event, then drops anything shorter than
+   ``min_duration_s=30``.
+
+Run it:  ``python examples/lambda_rules_demo.py``
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from ts_shape.eventlog import (
+    concat,
+    load_yaml,
+    run_backtest,
+    to_flat_df,
+    to_ocel_tables,
+    unregister_lambda_rule,
+)
+
+
+def synth_inputs() -> pd.DataFrame:
+    """Synthesize one DataFrame that covers both demo rules.
+
+    Columns: systime, torque, state, severity_score, bearing_temp_c,
+             source_uuid. 30 minutes at 30-second resolution; 2 assets.
+    """
+    start = datetime(2026, 5, 7, 8, 0, 0)
+    ts = pd.date_range(start, periods=60, freq="30s", tz="UTC")
+    rng = np.random.default_rng(42)
+
+    asset_a = pd.DataFrame({
+        "systime": ts,
+        "source_uuid": ["asset-A"] * 60,
+        "state": ["run"] * 50 + ["idle"] * 10,
+        # Baseline torque ~ 42, three sustained spikes for the threshold rule.
+        "torque": rng.normal(loc=42.0, scale=1.5, size=60),
+        # Baseline bearing temp ~ 80, one long hot window (10 contiguous rows = 270s)
+        # at rows 20..29, plus one isolated spike at row 45.
+        "bearing_temp_c": rng.normal(loc=80.0, scale=0.7, size=60),
+    })
+    asset_a.loc[10, "torque"] = 79.5
+    asset_a.loc[15, "torque"] = 86.0
+    asset_a.loc[40, "torque"] = 95.0
+    asset_a.loc[10, "severity_score"] = 3.2
+    asset_a.loc[15, "severity_score"] = 4.6
+    asset_a.loc[40, "severity_score"] = 4.9
+    asset_a.loc[20:29, "bearing_temp_c"] = [86, 87, 88, 87, 89, 90, 88, 86, 87, 86]
+    asset_a.loc[45, "bearing_temp_c"] = 91  # isolated spike, < min_duration
+
+    asset_b = pd.DataFrame({
+        "systime": ts,
+        "source_uuid": ["asset-B"] * 60,
+        "state": ["run"] * 60,
+        "torque": rng.normal(loc=40.0, scale=1.2, size=60),
+        # asset-B has a 90s hot window at rows 5..8 (>= 30s threshold).
+        "bearing_temp_c": rng.normal(loc=78.0, scale=0.6, size=60),
+    })
+    asset_b.loc[5:8, "bearing_temp_c"] = [88, 89, 90, 86]
+
+    df = pd.concat([asset_a, asset_b], ignore_index=True)
+    df["severity_score"] = df["severity_score"].fillna(1.0)
+    return df
+
+
+def main() -> None:
+    df = synth_inputs()
+    yaml_path = Path(__file__).parent / "lambda_rules_demo.yaml"
+
+    # ---------------------------------------------------------------------
+    # 1. Load + register the two YAML rules.
+    # ---------------------------------------------------------------------
+    detectors = load_yaml(yaml_path)
+    try:
+        torque_det, bearing_det = detectors
+        print("=" * 70)
+        print("Registered lambda rules")
+        print("=" * 70)
+        for d in detectors:
+            print(f"  {d.detector_name:48s}  shape={d.spec.shape}")
+        print()
+
+        # -----------------------------------------------------------------
+        # 2. Run each detector → EventLog and inspect.
+        # -----------------------------------------------------------------
+        torque_log = torque_det.to_event_log(df)
+        bearing_log = bearing_det.to_event_log(df)
+        log = concat(torque_log, bearing_log)
+
+        print("=" * 70)
+        print("EventLog summary")
+        print("=" * 70)
+        print(log)
+        print()
+
+        cols = [
+            "ocel:eid", "ocel:activity", "ocel:timestamp",
+            "ts_shape:start_timestamp", "ts_shape:duration_s",
+            "ts_shape:severity", "ts_shape:value",
+        ]
+        print("--- events ---")
+        print(log.events[cols].to_string(index=False))
+        print()
+
+        # -----------------------------------------------------------------
+        # 3. XES and OCEL 2.0 round-trip.
+        # -----------------------------------------------------------------
+        xes = to_flat_df(log, case_object_type="asset")
+        print("=" * 70)
+        print("Flat XES export — case = asset (first 10 rows)")
+        print("=" * 70)
+        print(xes[
+            ["case:concept:name", "concept:name", "time:timestamp"]
+        ].head(10).to_string(index=False))
+        print()
+
+        events_df, objects_df, relations_df = to_ocel_tables(log)
+        print("=" * 70)
+        print("OCEL 2.0 tables")
+        print("=" * 70)
+        print(f"events:    {events_df.shape}")
+        print(f"objects:   {objects_df.shape}")
+        print(f"relations: {relations_df.shape}")
+        print()
+
+        # -----------------------------------------------------------------
+        # 4. Backtest the threshold rule.
+        # -----------------------------------------------------------------
+        print("=" * 70)
+        print("Backtest — torque threshold rule")
+        print("=" * 70)
+        result = run_backtest(torque_det, df)
+        print(result)
+        print()
+        print("  by_severity:", result.by_severity)
+        print("  by_asset:   ", result.by_asset)
+    finally:
+        # Keep the global REGISTRY clean so re-running the demo is idempotent
+        # and so coverage tests run after the demo still pass.
+        for d in detectors:
+            unregister_lambda_rule(d.spec.class_name, d.spec.method_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lambda_rules_demo.yaml
+++ b/examples/lambda_rules_demo.yaml
@@ -1,0 +1,36 @@
+dsl_version: "0.1.0"
+rules:
+  # Case 1 — simple point/threshold rule.
+  - id: high_torque
+    class_name: LambdaToolWearDemo
+    method_name: high_torque
+    pack: maintenance
+    shape: point
+    archetype: threshold
+    template: "maintenance.tool.high_torque"
+    produces_objects: [asset]
+    severity_field: severity_score
+    value_field: torque
+    trigger:
+      expression: "(torque > 75) & (state == 'run')"
+    standard_attrs:
+      ts_shape:method: lambda_threshold
+      ts_shape:direction: above
+      ts_shape:threshold_high: 75.0
+
+  # Case 2 — interval rule with hysteresis + group-by per asset.
+  - id: bearing_hot
+    class_name: LambdaBearingDemo
+    method_name: hot_window
+    pack: maintenance
+    shape: interval
+    archetype: interval
+    template: "maintenance.bearing.hot"
+    produces_objects: [asset]
+    value_field: bearing_temp_c
+    trigger:
+      expression: "bearing_temp_c > 85"
+      min_duration_s: 30
+      group_by: [source_uuid]
+    standard_attrs:
+      ts_shape:lifecycle_state: hot

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Process Engineering: guides/engineering.md
   - Shift Reports & KPIs: guides/reporting.md
   - Event Log (XES & OCEL): guides/eventlog.md
+  - Event Handling — Visual Overview: guides/event-handling-flow.md
   - Lambda Rules: guides/lambda-rules.md
 - Pipelines:
   - Overview: pipelines/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Process Engineering: guides/engineering.md
   - Shift Reports & KPIs: guides/reporting.md
   - Event Log (XES & OCEL): guides/eventlog.md
+  - Lambda Rules: guides/lambda-rules.md
 - Pipelines:
   - Overview: pipelines/index.md
   - OEE Dashboard: pipelines/oee-dashboard.md

--- a/src/ts_shape/eventlog/__init__.py
+++ b/src/ts_shape/eventlog/__init__.py
@@ -26,6 +26,19 @@ Typical use::
 from .adapters import register_adapter
 from .concat import concat
 from .flat import to_flat_df
+from .lambda_rules import (
+    BacktestResult,
+    LambdaDetector,
+    RuleSpec,
+    TriggerSpec,
+    UnsafeExpression,
+    compile_expression,
+    load_dicts,
+    load_yaml,
+    register_lambda_rule,
+    run_backtest,
+    unregister_lambda_rule,
+)
 from .model import EventLog
 from .normalizer import to_event_log
 from .ocel import to_ocel_tables
@@ -53,15 +66,26 @@ from .schema import (
 from .taxonomy import REGISTRY, LabelRule
 
 __all__ = [
+    "BacktestResult",
     "EventLog",
     "LabelRule",
+    "LambdaDetector",
     "REGISTRY",
+    "RuleSpec",
+    "TriggerSpec",
+    "UnsafeExpression",
+    "compile_expression",
     "concat",
+    "load_dicts",
+    "load_yaml",
     "register_adapter",
+    "register_lambda_rule",
     "register_object_type",
+    "run_backtest",
     "to_event_log",
     "to_flat_df",
     "to_ocel_tables",
+    "unregister_lambda_rule",
     "validate",
     "OCEL_ACTIVITY",
     "OCEL_EID",

--- a/src/ts_shape/eventlog/lambda_rules/__init__.py
+++ b/src/ts_shape/eventlog/lambda_rules/__init__.py
@@ -1,0 +1,47 @@
+"""Lambda-rule subsystem — declarative, YAML-driven detectors that share
+all canonical-event-log plumbing with the 290 built-in detector methods.
+
+Typical use::
+
+    from ts_shape.eventlog import register_lambda_rule, RuleSpec, TriggerSpec
+
+    spec = RuleSpec(
+        id="high_torque",
+        class_name="LambdaToolWear",
+        method_name="high_torque",
+        pack="maintenance",
+        shape="point",
+        archetype="threshold",
+        template="maintenance.tool.high_torque",
+        trigger=TriggerSpec(expression="torque > 75 & state == 'run'"),
+        standard_attrs={
+            "ts_shape:method": "lambda_threshold",
+            "ts_shape:direction": "above",
+            "ts_shape:threshold_high": 75.0,
+        },
+    )
+    detector = register_lambda_rule(spec)
+    log = detector.to_event_log(df)
+
+See :doc:`/guides/lambda-rules` for the full walkthrough including a
+threshold case and an interval-with-hysteresis case.
+"""
+from .backtest import BacktestResult, run_backtest
+from .detector import LambdaDetector
+from .expression import UnsafeExpression, compile_expression
+from .loader import load_dicts, load_yaml, register_lambda_rule, unregister_lambda_rule
+from .spec import RuleSpec, TriggerSpec
+
+__all__ = [
+    "BacktestResult",
+    "LambdaDetector",
+    "RuleSpec",
+    "TriggerSpec",
+    "UnsafeExpression",
+    "compile_expression",
+    "load_dicts",
+    "load_yaml",
+    "register_lambda_rule",
+    "run_backtest",
+    "unregister_lambda_rule",
+]

--- a/src/ts_shape/eventlog/lambda_rules/backtest.py
+++ b/src/ts_shape/eventlog/lambda_rules/backtest.py
@@ -1,0 +1,70 @@
+"""Minimal hit-count backtest for lambda rules.
+
+The first-slice MVP supports "run rule, count hits" only — no
+label-matching, no precision/recall. The returned
+:class:`BacktestResult` still carries the full :class:`EventLog` so the
+caller can inspect any individual hit and run their own downstream
+analysis (e.g. ``to_flat_df`` for pm4py, ``filter_by_pack`` for
+domain-specific drill-down).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import pandas as pd
+
+from ..model import EventLog
+from ..schema import OCEL_TYPE, OCEL_OID, TS_SEVERITY
+from .detector import LambdaDetector
+
+
+@dataclass
+class BacktestResult:
+    detector: str
+    hit_count: int
+    by_severity: dict[str, int]
+    by_asset: dict[str, int]
+    event_log: EventLog
+
+    def __repr__(self) -> str:
+        return (
+            f"BacktestResult(detector={self.detector!r}, "
+            f"hits={self.hit_count}, "
+            f"severity={self.by_severity}, "
+            f"assets={len(self.by_asset)})"
+        )
+
+
+def run_backtest(
+    detector: LambdaDetector,
+    df: pd.DataFrame,
+    *,
+    objects: Mapping[str, object] | None = None,
+    qualifiers: Mapping[str, str] | None = None,
+) -> BacktestResult:
+    """Run ``detector`` over ``df`` and summarize hit counts."""
+    log = detector.to_event_log(df, objects=objects, qualifiers=qualifiers)
+
+    by_severity: dict[str, int] = {}
+    if TS_SEVERITY in log.events.columns and not log.events.empty:
+        by_severity = {
+            (str(k) if pd.notna(k) else "unset"): int(v)
+            for k, v in log.events[TS_SEVERITY].value_counts(dropna=False).items()
+        }
+
+    by_asset: dict[str, int] = {}
+    if not log.relations.empty:
+        asset_rel = log.relations[log.relations[OCEL_TYPE] == "asset"]
+        by_asset = {
+            str(k): int(v)
+            for k, v in asset_rel[OCEL_OID].value_counts().items()
+        }
+
+    return BacktestResult(
+        detector=detector.detector_name,
+        hit_count=len(log.events),
+        by_severity=by_severity,
+        by_asset=by_asset,
+        event_log=log,
+    )

--- a/src/ts_shape/eventlog/lambda_rules/detector.py
+++ b/src/ts_shape/eventlog/lambda_rules/detector.py
@@ -1,0 +1,53 @@
+"""``LambdaDetector`` — the runtime object produced by ``register_lambda_rule``.
+
+A LambdaDetector is the lambda-rule counterpart of the 290 built-in
+detector classes under ``ts_shape.events.*``. It does not subclass any
+of them — instead it implements the same conceptual contract:
+
+1. ``evaluate(df)`` returns a legacy-shaped DataFrame.
+2. ``to_event_log(df, ...)`` runs the evaluator and hands the result to
+   the canonical :func:`~ts_shape.eventlog.to_event_log` dispatcher.
+
+Because the spec is registered in :data:`ts_shape.eventlog.taxonomy.REGISTRY`
+at registration time, ``to_event_log`` finds it without any new code path.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+
+from ..model import EventLog
+from ..normalizer import to_event_log
+from .evaluator import evaluate
+from .spec import RuleSpec
+
+
+class LambdaDetector:
+    """Runnable form of a :class:`RuleSpec`."""
+
+    def __init__(self, spec: RuleSpec) -> None:
+        self.spec = spec
+        self.detector_name = f"{spec.class_name}.{spec.method_name}"
+
+    def evaluate(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Apply the rule to ``df`` and return a legacy-shaped DataFrame."""
+        return evaluate(self.spec, df)
+
+    def to_event_log(
+        self,
+        df: pd.DataFrame,
+        *,
+        objects: Mapping[str, object] | None = None,
+        qualifiers: Mapping[str, str] | None = None,
+    ) -> EventLog:
+        legacy = self.evaluate(df)
+        return to_event_log(
+            legacy,
+            detector=self.detector_name,
+            objects=objects,
+            qualifiers=qualifiers,
+        )
+
+    def __repr__(self) -> str:
+        return f"LambdaDetector({self.detector_name!r}, shape={self.spec.shape!r})"

--- a/src/ts_shape/eventlog/lambda_rules/evaluator.py
+++ b/src/ts_shape/eventlog/lambda_rules/evaluator.py
@@ -1,0 +1,142 @@
+"""Shape-specific evaluators that turn a compiled trigger into a legacy
+DataFrame in the same format the shape-driven adapter already consumes.
+
+Point and summary rules pass matching rows through; interval rules
+coalesce contiguous True runs (per ``group_by``) into single rows with
+``start``/``end``/duration; static rules emit a single summary row.
+
+Whatever the shape, the returned frame is fed verbatim to
+:func:`~ts_shape.eventlog.to_event_log`, which then exercises the same
+adapter, EID generation, severity bucketing, object auto-extraction and
+schema validation as built-in detectors. No parallel pipeline.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from .expression import compile_expression
+from .spec import RuleSpec
+
+
+_POINT_TIME_CANDIDATES = (
+    "systime", "timestamp", "time", "event_time", "ts", "datetime",
+)
+
+
+def evaluate(spec: RuleSpec, df: pd.DataFrame) -> pd.DataFrame:
+    """Run ``spec`` against ``df`` and return a legacy-shaped DataFrame.
+
+    The output column conventions match what the shape adapter expects:
+
+    * ``shape="point" | "summary"``: original rows with a ``systime``-like
+      timestamp column preserved (no renaming).
+    * ``shape="interval"``: rows with ``start``, ``end``, ``source_uuid``
+      (if grouped), plus value/severity columns averaged over the run.
+    * ``shape="static"``: a single row carrying summary fields.
+    """
+    if df is None or len(df) == 0:
+        return df.iloc[0:0].copy() if df is not None else pd.DataFrame()
+
+    mask_fn = compile_expression(spec.trigger.expression)
+    mask = mask_fn(df)
+
+    if spec.shape == "point":
+        return _evaluate_point(df, mask)
+    if spec.shape == "interval":
+        return _evaluate_interval(df, mask, spec)
+    if spec.shape == "summary":
+        return _evaluate_summary(df, mask, spec)
+    if spec.shape == "static":
+        return _evaluate_static(df, mask, spec)
+    raise ValueError(f"unsupported shape {spec.shape!r}")  # pragma: no cover
+
+
+def _evaluate_point(df: pd.DataFrame, mask: pd.Series) -> pd.DataFrame:
+    return df.loc[mask].reset_index(drop=True).copy()
+
+
+def _pick_time_col(df: pd.DataFrame) -> str | None:
+    for c in _POINT_TIME_CANDIDATES:
+        if c in df.columns:
+            return c
+    for c in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[c]):
+            return c
+    return None
+
+
+def _evaluate_interval(
+    df: pd.DataFrame,
+    mask: pd.Series,
+    spec: RuleSpec,
+) -> pd.DataFrame:
+    time_col = _pick_time_col(df)
+    if time_col is None:
+        raise ValueError(
+            "interval lambda rule requires a datetime column in the input "
+            "(systime / timestamp / time / event_time / ts / datetime)"
+        )
+    work = df.copy()
+    work["_mask"] = mask.astype(bool).to_numpy()
+
+    rows: list[dict[str, object]] = []
+    group_by = list(spec.trigger.group_by)
+    if group_by:
+        grouped = work.groupby(group_by, sort=False, dropna=False)
+        iterator = ((tuple(k) if not isinstance(k, tuple) else k, g)
+                    for k, g in grouped)
+    else:
+        iterator = iter([((), work)])
+
+    for key, sub in iterator:
+        sub = sub.sort_values(time_col).reset_index(drop=True)
+        run_id = (sub["_mask"] != sub["_mask"].shift()).cumsum()
+        for _, run in sub.groupby(run_id, sort=False):
+            if not bool(run["_mask"].iloc[0]):
+                continue
+            start_ts = pd.Timestamp(run[time_col].iloc[0])
+            end_ts = pd.Timestamp(run[time_col].iloc[-1])
+            duration_s = (end_ts - start_ts).total_seconds()
+            if (spec.trigger.min_duration_s is not None
+                    and duration_s < spec.trigger.min_duration_s):
+                continue
+            row: dict[str, object] = {
+                "start": start_ts,
+                "end": end_ts,
+            }
+            for col_name, col_val in zip(group_by, key):
+                row[col_name] = col_val
+            # Carry the value column through as the mean of the run, if set.
+            if spec.value_field and spec.value_field in run.columns:
+                row[spec.value_field] = pd.to_numeric(
+                    run[spec.value_field], errors="coerce"
+                ).mean()
+            # Carry severity_score as max over the run.
+            if spec.severity_field and spec.severity_field in run.columns:
+                row[spec.severity_field] = pd.to_numeric(
+                    run[spec.severity_field], errors="coerce"
+                ).max()
+            # Pass through source_uuid (asset auto-extract) when grouped on it.
+            if "source_uuid" not in row and "source_uuid" in run.columns:
+                row["source_uuid"] = run["source_uuid"].iloc[0]
+            row["sample_count"] = int(len(run))
+            rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def _evaluate_summary(
+    df: pd.DataFrame,
+    mask: pd.Series,
+    spec: RuleSpec,  # noqa: ARG001 — kept for signature symmetry
+) -> pd.DataFrame:
+    return df.loc[mask].reset_index(drop=True).copy()
+
+
+def _evaluate_static(
+    df: pd.DataFrame,
+    mask: pd.Series,
+    spec: RuleSpec,  # noqa: ARG001
+) -> pd.DataFrame:
+    hits = int(mask.sum())
+    return pd.DataFrame([{"sample_count": hits}])

--- a/src/ts_shape/eventlog/lambda_rules/expression.py
+++ b/src/ts_shape/eventlog/lambda_rules/expression.py
@@ -1,0 +1,94 @@
+"""AST-restricted Python expression compiler.
+
+Lambda-rule triggers are written as short Python-syntax expressions
+(``"(torque > 75) & (state == 'run')"``). To run them safely we parse
+with :func:`ast.parse` in ``mode="eval"`` and walk the tree, rejecting
+any node that is not on a small allowlist.
+
+Operator gotcha: Python's bitwise ``&`` / ``|`` (the vectorized ones
+pandas understands) bind **tighter** than comparison operators, so you
+must wrap each comparison in parentheses:
+``"(x > 1) & (y < 0)"`` — not ``"x > 1 & y < 0"``. This matches the
+convention used by ``pandas.eval`` and ``DataFrame.query``.
+
+Why an AST whitelist over ``pandas.eval`` or ``polars.expr``?
+
+* Full control over error messages.
+* Reliable Int64 / nullable-bool handling.
+* Zero extra dependencies — stdlib :mod:`ast` only.
+* The whitelist refuses dunders, attribute access, imports, comprehensions,
+  and any function call outside of ``abs``, ``min``, ``max`` — so an
+  LLM-proposed expression cannot exfiltrate or mutate state.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Callable
+
+import pandas as pd
+
+
+class UnsafeExpression(ValueError):
+    """Raised when a trigger expression contains a disallowed AST node."""
+
+
+_ALLOWED_FUNCS: frozenset[str] = frozenset({"abs", "min", "max"})
+
+_ALLOWED_NODES: tuple[type, ...] = (
+    ast.Expression,
+    ast.BoolOp, ast.BinOp, ast.UnaryOp, ast.Compare,
+    ast.Name, ast.Constant, ast.Load,
+    ast.And, ast.Or, ast.Not,
+    ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod, ast.USub, ast.UAdd,
+    ast.BitAnd, ast.BitOr, ast.BitXor, ast.Invert,
+    ast.Call,
+    ast.Tuple, ast.List,
+    ast.In, ast.NotIn,
+)
+
+
+def _validate(tree: ast.AST) -> None:
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise UnsafeExpression(
+                f"expression contains disallowed syntax: "
+                f"{type(node).__name__} is not on the AST whitelist"
+            )
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name) or node.func.id not in _ALLOWED_FUNCS:
+                raise UnsafeExpression(
+                    "only abs / min / max calls are allowed in trigger expressions"
+                )
+
+
+def compile_expression(expression: str) -> Callable[[pd.DataFrame], pd.Series]:
+    """Compile a trigger expression to a vectorized boolean mask function.
+
+    The returned callable accepts a :class:`pandas.DataFrame` and returns
+    a :class:`pandas.Series` of booleans (NaN → False) aligned with the
+    frame's rows.
+    """
+    if not isinstance(expression, str) or not expression.strip():
+        raise UnsafeExpression("expression must be a non-empty string")
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise UnsafeExpression(f"could not parse expression: {exc}") from exc
+    _validate(tree)
+    code = compile(tree, filename="<lambda-rule>", mode="eval")
+
+    def _evaluate(df: pd.DataFrame) -> pd.Series:
+        # Build a name → Series mapping plus the three allow-listed builtins.
+        local_ns: dict[str, object] = {col: df[col] for col in df.columns}
+        global_ns: dict[str, object] = {
+            "__builtins__": {},
+            "abs": abs, "min": min, "max": max,
+        }
+        result = eval(code, global_ns, local_ns)  # noqa: S307 — sandboxed
+        if not isinstance(result, pd.Series):
+            # Constant expression: broadcast.
+            result = pd.Series([bool(result)] * len(df), index=df.index)
+        return result.fillna(False).astype(bool)
+
+    return _evaluate

--- a/src/ts_shape/eventlog/lambda_rules/loader.py
+++ b/src/ts_shape/eventlog/lambda_rules/loader.py
@@ -1,0 +1,152 @@
+"""Registration helpers + YAML/dict loaders for lambda rules.
+
+A lambda rule lives in two places once registered:
+
+* :data:`ts_shape.eventlog.taxonomy.REGISTRY` — the
+  :class:`~ts_shape.eventlog.taxonomy.LabelRule` mapping that
+  :func:`~ts_shape.eventlog.to_event_log` consults.
+* :data:`ts_shape.eventlog.archetypes.ARCHETYPE_BY_METHOD` — the
+  archetype classification that the coverage tests use to enforce
+  ``standard_attrs`` completeness.
+
+Both mutations happen through :func:`register_lambda_rule`. The
+coverage test ``test_no_orphan_registry_entries`` is configured to
+exempt entries whose class name starts with ``Lambda``, so registered
+lambda rules do not need a real Python class on disk.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from ..archetypes import ARCHETYPE_BY_METHOD
+from ..schema import STANDARD_ATTR_KEYS
+from ..taxonomy import REGISTRY, LabelRule
+from .detector import LambdaDetector
+from .spec import RuleSpec, TriggerSpec
+
+
+# Required ``standard_attrs`` keys per archetype, mirroring the contract
+# enforced by ``tests/eventlog/test_adapter_coverage.py``. Kept here so
+# registration fails fast with a clear message instead of waiting for the
+# coverage test to find the gap later.
+_REQUIRED_KEYS_BY_ARCHETYPE: dict[str, frozenset[str]] = {
+    "threshold": frozenset({"ts_shape:method", "ts_shape:direction"}),
+    "interval": frozenset({"ts_shape:lifecycle_state"}),
+    "aggregate": frozenset({"ts_shape:sample_count"}),
+    "outcome": frozenset({"ts_shape:outcome"}),
+    "static": frozenset({"ts_shape:method"}),
+    "trace": frozenset({"ts_shape:lifecycle_state", "ts_shape:direction"}),
+    "forecast": frozenset({"ts_shape:method", "ts_shape:confidence"}),
+    "correlation": frozenset({"ts_shape:method"}),
+}
+
+
+def _validate_standard_attrs(spec: RuleSpec) -> None:
+    allowed = set(STANDARD_ATTR_KEYS)
+    bad = [k for k in spec.standard_attrs if k not in allowed]
+    if bad:
+        raise ValueError(
+            f"lambda rule {spec.class_name}.{spec.method_name}: "
+            f"standard_attrs uses unknown keys {bad}; "
+            f"must be a subset of {sorted(allowed)}"
+        )
+    required = _REQUIRED_KEYS_BY_ARCHETYPE[spec.archetype]
+    missing = required - set(spec.standard_attrs)
+    if missing:
+        raise ValueError(
+            f"lambda rule {spec.class_name}.{spec.method_name} "
+            f"(archetype={spec.archetype!r}) is missing required "
+            f"standard_attrs keys: {sorted(missing)}"
+        )
+
+
+def register_lambda_rule(spec: RuleSpec) -> LambdaDetector:
+    """Register ``spec`` in REGISTRY + ARCHETYPE_BY_METHOD; return runnable detector.
+
+    Raises :class:`ValueError` if the spec is malformed, the
+    ``standard_attrs`` mapping uses unknown keys, the archetype's
+    required keys are missing, or a rule with the same
+    ``(class_name, method_name)`` is already registered.
+    """
+    _validate_standard_attrs(spec)
+    key = (spec.class_name, spec.method_name)
+    if key in REGISTRY:
+        raise ValueError(
+            f"a rule for {spec.class_name}.{spec.method_name} is already registered"
+        )
+
+    REGISTRY[key] = LabelRule(
+        template=spec.template,
+        pack=spec.pack,
+        shape=spec.shape,
+        produces_objects=spec.produces_objects,
+        severity_field=spec.severity_field,
+        value_field=spec.value_field,
+        standard_attrs=dict(spec.standard_attrs),
+    )
+    ARCHETYPE_BY_METHOD[key] = spec.archetype
+    return LambdaDetector(spec)
+
+
+def unregister_lambda_rule(class_name: str, method_name: str) -> None:
+    """Remove a rule previously installed by :func:`register_lambda_rule`.
+
+    Used by tests to keep the global REGISTRY clean between cases. No-op
+    if the rule was not registered.
+    """
+    key = (class_name, method_name)
+    REGISTRY.pop(key, None)
+    ARCHETYPE_BY_METHOD.pop(key, None)
+
+
+def _spec_from_dict(entry: Mapping[str, Any]) -> RuleSpec:
+    trigger_raw = dict(entry.get("trigger", {}))
+    trigger = TriggerSpec(
+        expression=str(trigger_raw["expression"]),
+        min_duration_s=(float(trigger_raw["min_duration_s"])
+                        if trigger_raw.get("min_duration_s") is not None
+                        else None),
+        group_by=tuple(trigger_raw.get("group_by", ())),
+    )
+    return RuleSpec(
+        id=str(entry["id"]),
+        class_name=str(entry["class_name"]),
+        method_name=str(entry["method_name"]),
+        pack=str(entry["pack"]),
+        shape=str(entry["shape"]),
+        archetype=str(entry["archetype"]),
+        template=str(entry["template"]),
+        trigger=trigger,
+        produces_objects=tuple(entry.get("produces_objects", ("asset",))),
+        severity_field=entry.get("severity_field"),
+        value_field=entry.get("value_field"),
+        standard_attrs=dict(entry.get("standard_attrs") or {}),
+    )
+
+
+def load_dicts(entries: Iterable[Mapping[str, Any]]) -> list[LambdaDetector]:
+    """Compile + register an iterable of dict rules."""
+    return [register_lambda_rule(_spec_from_dict(e)) for e in entries]
+
+
+def load_yaml(path: str | Path) -> list[LambdaDetector]:
+    """Load and register every rule under a YAML file's ``rules:`` key.
+
+    YAML is imported lazily so :mod:`ts_shape.eventlog` does not gain a
+    hard runtime dependency on PyYAML for users who only use built-in
+    detectors. Install ``pyyaml`` to enable this loader.
+    """
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:  # pragma: no cover - import error path
+        raise RuntimeError(
+            "load_yaml requires PyYAML. Install with `pip install pyyaml` "
+            "or use load_dicts(...) with a hand-built list."
+        ) from exc
+    raw = yaml.safe_load(Path(path).read_text())
+    if not isinstance(raw, Mapping) or "rules" not in raw:
+        raise ValueError(
+            f"YAML file {path!s} must define a top-level 'rules:' list"
+        )
+    return load_dicts(raw["rules"])

--- a/src/ts_shape/eventlog/lambda_rules/spec.py
+++ b/src/ts_shape/eventlog/lambda_rules/spec.py
@@ -1,0 +1,98 @@
+"""Declarative rule spec for the lambda-rule subsystem.
+
+A :class:`RuleSpec` is the user-facing description of one detection rule.
+It carries everything the loader needs to (a) compile the trigger
+expression, (b) build a :class:`~ts_shape.eventlog.taxonomy.LabelRule`,
+and (c) classify the rule into an archetype that
+``tests/eventlog/test_adapter_coverage.py`` already validates.
+
+The shape mirrors the built-in detector taxonomy: every lambda rule
+ultimately becomes a ``(class_name, method_name)`` REGISTRY entry that
+the canonical :func:`~ts_shape.eventlog.to_event_log` dispatcher
+understands without any special-case code.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+_VALID_SHAPES: frozenset[str] = frozenset({"point", "interval", "summary", "static"})
+_VALID_PACKS: frozenset[str] = frozenset({
+    "quality", "production", "engineering",
+    "maintenance", "supplychain", "energy", "correlation",
+})
+_VALID_ARCHETYPES: frozenset[str] = frozenset({
+    "threshold", "interval", "aggregate", "outcome",
+    "static", "trace", "forecast", "correlation",
+})
+
+
+@dataclass(frozen=True)
+class TriggerSpec:
+    """When does the rule fire?
+
+    ``expression`` is evaluated against the input DataFrame by the
+    AST-restricted compiler in :mod:`.expression`. It must produce a
+    boolean Series aligned with the input rows.
+
+    ``min_duration_s`` and ``group_by`` are only meaningful for
+    ``shape="interval"`` rules: consecutive True rows are coalesced
+    (per group) and the resulting interval is dropped if shorter than
+    ``min_duration_s`` seconds.
+    """
+
+    expression: str
+    min_duration_s: float | None = None
+    group_by: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RuleSpec:
+    """A complete lambda-rule definition.
+
+    Required fields mirror the built-in REGISTRY contract — ``class_name``
+    is synthesized (must start with ``Lambda``) so the rule slots into the
+    same ``(class, method) -> LabelRule`` table as the 290 built-ins.
+    """
+
+    id: str
+    class_name: str
+    method_name: str
+    pack: str
+    shape: str
+    archetype: str
+    template: str
+    trigger: TriggerSpec
+    produces_objects: tuple[str, ...] = ("asset",)
+    severity_field: str | None = None
+    value_field: str | None = None
+    standard_attrs: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.class_name.startswith("Lambda"):
+            raise ValueError(
+                f"class_name must start with 'Lambda', got {self.class_name!r}"
+            )
+        if self.shape not in _VALID_SHAPES:
+            raise ValueError(
+                f"shape must be one of {sorted(_VALID_SHAPES)}, got {self.shape!r}"
+            )
+        if self.pack not in _VALID_PACKS:
+            raise ValueError(
+                f"pack must be one of {sorted(_VALID_PACKS)}, got {self.pack!r}"
+            )
+        if self.archetype not in _VALID_ARCHETYPES:
+            raise ValueError(
+                f"archetype must be one of {sorted(_VALID_ARCHETYPES)}, "
+                f"got {self.archetype!r}"
+            )
+        if self.shape == "interval" and self.archetype != "interval":
+            raise ValueError(
+                "shape='interval' requires archetype='interval' "
+                f"(got archetype={self.archetype!r})"
+            )
+        if self.trigger.min_duration_s is not None and self.shape != "interval":
+            raise ValueError(
+                "trigger.min_duration_s is only valid for shape='interval'"
+            )

--- a/tests/eventlog/test_adapter_coverage.py
+++ b/tests/eventlog/test_adapter_coverage.py
@@ -74,9 +74,17 @@ def test_every_detector_method_has_label_rule():
 
 
 def test_no_orphan_registry_entries():
-    """Every registry entry should match a real detector method."""
+    """Every registry entry should match a real detector method.
+
+    Lambda-rule entries (class name starting with ``Lambda``) are exempt:
+    they are registered dynamically by
+    :func:`ts_shape.eventlog.register_lambda_rule` and intentionally have
+    no Python class on disk.
+    """
     discovered = set(_walk_detector_methods())
-    orphans = sorted(set(REGISTRY) - discovered)
+    orphans = sorted(
+        k for k in set(REGISTRY) - discovered if not k[0].startswith("Lambda")
+    )
     assert not orphans, (
         "Registry entries with no corresponding detector method:\n  "
         + "\n  ".join(f"{c}.{m}" for c, m in orphans[:30])

--- a/tests/eventlog/test_lambda_rules.py
+++ b/tests/eventlog/test_lambda_rules.py
@@ -1,0 +1,450 @@
+"""Tests for the lambda-rule subsystem.
+
+The lambda subsystem mutates the global REGISTRY / ARCHETYPE_BY_METHOD
+dicts at registration time. Every test that registers a rule uses a
+distinct ``(class_name, method_name)`` pair and explicitly cleans up
+via :func:`unregister_lambda_rule`, so the rest of the eventlog test
+suite (notably ``test_adapter_coverage.py``) sees a pristine REGISTRY.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ts_shape.eventlog import (
+    OCEL_ACTIVITY,
+    OCEL_OID,
+    OCEL_TYPE,
+    TS_DETECTOR,
+    TS_DURATION_S,
+    TS_PACK,
+    TS_SEVERITY,
+    LambdaDetector,
+    RuleSpec,
+    TriggerSpec,
+    UnsafeExpression,
+    compile_expression,
+    concat,
+    load_dicts,
+    register_lambda_rule,
+    run_backtest,
+    to_event_log,
+    to_flat_df,
+    to_ocel_tables,
+    unregister_lambda_rule,
+)
+from ts_shape.eventlog.archetypes import ARCHETYPE_BY_METHOD
+from ts_shape.eventlog.taxonomy import REGISTRY
+
+
+# ---------- fixtures -------------------------------------------------------
+
+@pytest.fixture()
+def torque_df() -> pd.DataFrame:
+    """A 10-row torque/state frame with 2 obvious overload events."""
+    return pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=10, freq="1min", tz="UTC"),
+        "torque": [60.0, 62.0, 70.0, 78.0, 80.0, 72.0, 50.0, 90.0, 65.0, 60.0],
+        "state": ["run"] * 8 + ["idle", "idle"],
+        "severity_score": [1.0, 1.0, 2.0, 3.5, 4.7, 2.0, 1.0, 4.9, 1.0, 1.0],
+        "source_uuid": ["asset-A"] * 10,
+    })
+
+
+@pytest.fixture()
+def bearing_df() -> pd.DataFrame:
+    """Two-asset bearing-temperature stream with one short and one long run."""
+    # asset-A: 4 contiguous >85 samples spaced 15s → 45s window (> min_duration_s=30) → kept
+    # asset-A: 1 isolated >85 sample later → dropped
+    # asset-B: 0 >85 samples → no events
+    ts = pd.date_range("2026-05-07", periods=24, freq="15s", tz="UTC")
+    df_a = pd.DataFrame({
+        "systime": ts,
+        "bearing_temp_c": [
+            82, 83, 86, 88, 87, 86, 80, 82,  # rows 0-7: long hot window rows 2-5
+            83, 84, 90, 83, 83, 82, 81, 80,  # rows 8-15: short hot at row 10
+            83, 84, 82, 81, 80, 82, 83, 81,
+        ],
+        "source_uuid": ["asset-A"] * 24,
+    })
+    df_b = pd.DataFrame({
+        "systime": ts,
+        "bearing_temp_c": [80] * 24,
+        "source_uuid": ["asset-B"] * 24,
+    })
+    return pd.concat([df_a, df_b], ignore_index=True)
+
+
+# ---------- expression compiler -------------------------------------------
+
+def test_compile_expression_rejects_unsafe():
+    for expr in [
+        "__import__('os').system('rm')",
+        "open('/etc/passwd').read()",
+        "x.__class__",
+        "[i for i in range(10)]",
+        "lambda x: x",
+    ]:
+        with pytest.raises(UnsafeExpression):
+            compile_expression(expr)
+
+
+def test_compile_expression_basic():
+    # Bitwise & has higher precedence than comparison in Python, so parens
+    # are required around each comparison — same convention as pandas.eval.
+    fn = compile_expression("(x > 1) & (y < 0)")
+    df = pd.DataFrame({"x": [0, 2, 3, 0], "y": [-1, -1, 1, -1]})
+    mask = fn(df)
+    assert list(mask) == [False, True, False, False]
+
+
+def test_compile_expression_only_allowed_calls():
+    fn = compile_expression("abs(x) > 2")
+    df = pd.DataFrame({"x": [-3, -1, 1, 3]})
+    assert list(fn(df)) == [True, False, False, True]
+    with pytest.raises(UnsafeExpression):
+        compile_expression("sum(x) > 2")
+
+
+def test_compile_expression_nan_treated_as_false():
+    fn = compile_expression("x > 1")
+    df = pd.DataFrame({"x": [2.0, float("nan"), 0.0]})
+    assert list(fn(df)) == [True, False, False]
+
+
+# ---------- spec validation ------------------------------------------------
+
+def test_rule_spec_requires_lambda_prefix():
+    with pytest.raises(ValueError, match="class_name must start with 'Lambda'"):
+        RuleSpec(
+            id="bad", class_name="MyDetector", method_name="foo",
+            pack="maintenance", shape="point", archetype="threshold",
+            template="x.y.z",
+            trigger=TriggerSpec(expression="x > 1"),
+        )
+
+
+def test_rule_spec_validates_pack_shape_archetype():
+    with pytest.raises(ValueError, match="pack must be one of"):
+        RuleSpec(
+            id="x", class_name="LambdaX", method_name="m",
+            pack="bogus", shape="point", archetype="threshold",
+            template="x.y.z", trigger=TriggerSpec(expression="x > 1"),
+        )
+
+
+def test_rule_spec_interval_requires_interval_archetype():
+    with pytest.raises(ValueError, match="archetype='interval'"):
+        RuleSpec(
+            id="x", class_name="LambdaX", method_name="m",
+            pack="maintenance", shape="interval", archetype="threshold",
+            template="x.y.z",
+            trigger=TriggerSpec(expression="x > 1", min_duration_s=10),
+        )
+
+
+# ---------- registration --------------------------------------------------
+
+def _spec_high_torque(class_name: str = "LambdaToolWear") -> RuleSpec:
+    return RuleSpec(
+        id="high_torque",
+        class_name=class_name,
+        method_name="high_torque",
+        pack="maintenance",
+        shape="point",
+        archetype="threshold",
+        template="maintenance.tool.high_torque",
+        trigger=TriggerSpec(expression="(torque > 75)"),
+        produces_objects=("asset",),
+        severity_field="severity_score",
+        value_field="torque",
+        standard_attrs={
+            "ts_shape:method": "lambda_threshold",
+            "ts_shape:direction": "above",
+            "ts_shape:threshold_high": 75.0,
+        },
+    )
+
+
+def _spec_bearing_hot(class_name: str = "LambdaBearing") -> RuleSpec:
+    return RuleSpec(
+        id="bearing_hot",
+        class_name=class_name,
+        method_name="hot_window",
+        pack="maintenance",
+        shape="interval",
+        archetype="interval",
+        template="maintenance.bearing.hot",
+        trigger=TriggerSpec(
+            expression="bearing_temp_c > 85",
+            min_duration_s=30,
+            group_by=("source_uuid",),
+        ),
+        produces_objects=("asset",),
+        value_field="bearing_temp_c",
+        standard_attrs={
+            "ts_shape:lifecycle_state": "hot",
+        },
+    )
+
+
+def test_register_lambda_rule_writes_registry():
+    spec = _spec_high_torque("LambdaReg1")
+    try:
+        det = register_lambda_rule(spec)
+        assert isinstance(det, LambdaDetector)
+        assert (spec.class_name, spec.method_name) in REGISTRY
+        assert ARCHETYPE_BY_METHOD[(spec.class_name, spec.method_name)] == "threshold"
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+    assert (spec.class_name, spec.method_name) not in REGISTRY
+
+
+def test_register_lambda_rule_validates_archetype_attrs():
+    bad = RuleSpec(
+        id="missing_attrs",
+        class_name="LambdaReg2",
+        method_name="missing_attrs",
+        pack="maintenance",
+        shape="point",
+        archetype="threshold",
+        template="maintenance.x.y",
+        trigger=TriggerSpec(expression="torque > 1"),
+        standard_attrs={"ts_shape:method": "lambda_threshold"},  # direction missing
+    )
+    with pytest.raises(ValueError, match="missing required standard_attrs keys"):
+        register_lambda_rule(bad)
+
+
+def test_register_lambda_rule_rejects_duplicate():
+    spec = _spec_high_torque("LambdaReg3")
+    try:
+        register_lambda_rule(spec)
+        with pytest.raises(ValueError, match="already registered"):
+            register_lambda_rule(spec)
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+def test_register_lambda_rule_rejects_unknown_standard_attrs():
+    bad = RuleSpec(
+        id="bad_attr",
+        class_name="LambdaReg4",
+        method_name="bad_attr",
+        pack="maintenance",
+        shape="point",
+        archetype="threshold",
+        template="maintenance.x.y",
+        trigger=TriggerSpec(expression="x > 1"),
+        standard_attrs={
+            "ts_shape:method": "x", "ts_shape:direction": "above",
+            "ts_shape:unknown_key": 1,
+        },
+    )
+    with pytest.raises(ValueError, match="unknown keys"):
+        register_lambda_rule(bad)
+
+
+# ---------- end-to-end: point ---------------------------------------------
+
+def test_point_rule_end_to_end(torque_df):
+    spec = _spec_high_torque("LambdaPoint1")
+    try:
+        det = register_lambda_rule(spec)
+        log = det.to_event_log(torque_df)
+
+        # Three torque > 75 rows: indices 3 (78), 4 (80), 7 (90).
+        assert len(log.events) == 3
+        assert set(log.events[OCEL_ACTIVITY]) == {"maintenance.tool.high_torque"}
+        assert set(log.events[TS_DETECTOR]) == {"LambdaPoint1.high_torque"}
+        assert set(log.events[TS_PACK]) == {"maintenance"}
+        # severity_score 3.5/4.7/4.9 → warn/critical/critical
+        sev = list(log.events[TS_SEVERITY])
+        assert sev.count("critical") == 2
+        assert sev.count("warn") == 1
+        # standard attrs columns landed.
+        assert "ts_shape:method" in log.events.columns
+        assert (log.events["ts_shape:method"] == "lambda_threshold").all()
+        assert (log.events["ts_shape:threshold_high"] == 75.0).all()
+        # source_uuid auto-extracted as asset.
+        assert (log.relations[OCEL_TYPE] == "asset").all()
+        assert set(log.relations[OCEL_OID]) == {"asset-A"}
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+# ---------- end-to-end: interval ------------------------------------------
+
+def test_interval_rule_coalesces(bearing_df):
+    spec = _spec_bearing_hot("LambdaInterval1")
+    try:
+        det = register_lambda_rule(spec)
+        log = det.to_event_log(bearing_df)
+
+        # asset-A long window (4 samples × 15s = 45s gap → 45s) kept;
+        # asset-A short window (1 sample, 0s) dropped;
+        # asset-B has no hot samples → no events.
+        assert len(log.events) == 1
+        ev = log.events.iloc[0]
+        assert ev[OCEL_ACTIVITY] == "maintenance.bearing.hot"
+        # Duration is 45s (4 samples spaced 15s apart → first to last = 45s).
+        assert ev[TS_DURATION_S] == pytest.approx(45.0)
+        assert ev["ts_shape:lifecycle_state"] == "hot"
+        # Asset binding via source_uuid.
+        assert set(log.relations[OCEL_OID]) == {"asset-A"}
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+def test_interval_rule_drops_runs_shorter_than_min_duration():
+    df = pd.DataFrame({
+        "systime": pd.date_range("2026-05-07", periods=4, freq="5s", tz="UTC"),
+        "bearing_temp_c": [86, 87, 88, 80],  # 3 samples × 5s = 15s window
+        "source_uuid": ["asset-A"] * 4,
+    })
+    spec = _spec_bearing_hot("LambdaInterval2")
+    try:
+        det = register_lambda_rule(spec)
+        log = det.to_event_log(df)
+        # 15s window < min_duration_s=30 → dropped.
+        assert len(log.events) == 0
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+# ---------- canonical-pipeline round-trips ---------------------------------
+
+def test_lambda_log_passes_schema_validation(torque_df):
+    """to_event_log validates by default; reaching the assert means OK."""
+    spec = _spec_high_torque("LambdaSchema1")
+    try:
+        det = register_lambda_rule(spec)
+        log = det.to_event_log(torque_df)
+        assert len(log.events) > 0
+        # validate=True is the default; an invalid log would have raised.
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+def test_lambda_log_round_trips_to_flat_and_ocel(torque_df, bearing_df):
+    p_spec = _spec_high_torque("LambdaRound1")
+    i_spec = _spec_bearing_hot("LambdaRound2")
+    try:
+        p_det = register_lambda_rule(p_spec)
+        i_det = register_lambda_rule(i_spec)
+        log = concat(p_det.to_event_log(torque_df), i_det.to_event_log(bearing_df))
+
+        xes = to_flat_df(log, case_object_type="asset")
+        assert not xes.empty
+        assert "concept:name" in xes.columns
+
+        events_df, objects_df, relations_df = to_ocel_tables(log)
+        assert len(events_df) == len(log.events)
+        assert len(relations_df) == len(log.relations)
+    finally:
+        unregister_lambda_rule(p_spec.class_name, p_spec.method_name)
+        unregister_lambda_rule(i_spec.class_name, i_spec.method_name)
+
+
+# ---------- coverage-test compatibility ------------------------------------
+
+def test_adapter_coverage_orphan_check_exempts_lambdas(torque_df):
+    """Registering a lambda rule must not break test_no_orphan_registry_entries."""
+    from tests.eventlog.test_adapter_coverage import test_no_orphan_registry_entries
+
+    spec = _spec_high_torque("LambdaCoverage1")
+    try:
+        register_lambda_rule(spec)
+        # Should not raise — the test exempts class names starting with "Lambda".
+        test_no_orphan_registry_entries()
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+def test_adapter_coverage_archetype_completeness_with_lambdas():
+    from tests.eventlog.test_adapter_coverage import (
+        test_archetype_assignment_is_complete,
+    )
+
+    spec = _spec_bearing_hot("LambdaCoverage2")
+    try:
+        register_lambda_rule(spec)
+        test_archetype_assignment_is_complete()
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+# ---------- load_dicts (YAML-equivalent in-process) -----------------------
+
+def test_load_dicts_registers_multiple_rules(torque_df, bearing_df):
+    entries = [
+        {
+            "id": "high_torque",
+            "class_name": "LambdaLoadDict1",
+            "method_name": "high_torque",
+            "pack": "maintenance",
+            "shape": "point",
+            "archetype": "threshold",
+            "template": "maintenance.tool.high_torque",
+            "trigger": {"expression": "torque > 75"},
+            "standard_attrs": {
+                "ts_shape:method": "lambda_threshold",
+                "ts_shape:direction": "above",
+            },
+        },
+        {
+            "id": "bearing_hot",
+            "class_name": "LambdaLoadDict2",
+            "method_name": "hot_window",
+            "pack": "maintenance",
+            "shape": "interval",
+            "archetype": "interval",
+            "template": "maintenance.bearing.hot",
+            "trigger": {
+                "expression": "bearing_temp_c > 85",
+                "min_duration_s": 30,
+                "group_by": ["source_uuid"],
+            },
+            "standard_attrs": {"ts_shape:lifecycle_state": "hot"},
+        },
+    ]
+    detectors = load_dicts(entries)
+    try:
+        assert len(detectors) == 2
+        p_log = detectors[0].to_event_log(torque_df)
+        i_log = detectors[1].to_event_log(bearing_df)
+        merged = concat(p_log, i_log)
+        assert len(merged.events) >= 4  # 3 torque + 1 bearing
+    finally:
+        unregister_lambda_rule("LambdaLoadDict1", "high_torque")
+        unregister_lambda_rule("LambdaLoadDict2", "hot_window")
+
+
+# ---------- backtest -------------------------------------------------------
+
+def test_backtest_hit_count(torque_df):
+    spec = _spec_high_torque("LambdaBacktest1")
+    try:
+        det = register_lambda_rule(spec)
+        result = run_backtest(det, torque_df)
+        assert result.hit_count == 3
+        assert result.by_severity.get("critical", 0) == 2
+        assert result.by_severity.get("warn", 0) == 1
+        assert result.by_asset == {"asset-A": 3}
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)
+
+
+# ---------- to_event_log dispatch via taxonomy ----------------------------
+
+def test_to_event_log_resolves_lambda_via_registry(torque_df):
+    """Confirms LambdaDetector goes through the same dispatch as built-ins."""
+    spec = _spec_high_torque("LambdaDispatch1")
+    try:
+        det = register_lambda_rule(spec)
+        legacy = det.evaluate(torque_df)
+        # Direct call to the public to_event_log entry point.
+        log = to_event_log(legacy, detector="LambdaDispatch1.high_torque")
+        assert len(log.events) == 3
+    finally:
+        unregister_lambda_rule(spec.class_name, spec.method_name)


### PR DESCRIPTION
Lets users define detectors in YAML / dict form without writing a Python
class — rules compile into a LambdaDetector that registers dynamically
with the existing REGISTRY and flows through the same canonical-event-log
adapter as the 290 built-in detector methods. AST-restricted expression
compiler (no eval of arbitrary code) is the safety net for the planned
gen-AI authoring layer.

Includes runnable demo, doc guide with 5 mermaid infographics covering
both a simple threshold case and a complex interval/hysteresis/group-by
case, plus a refreshed high-level architecture chart in index.md and
concept.md that surfaces the new detection-layer pluggability.

https://claude.ai/code/session_013pEkJ2jnEDbnzSc41jpBfe