### PR TITLE
feat: usability + consistency improvements (validation, catalog, datasets)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,26 @@
+# May 20, 2026
+add: ts_shape.make_timeseries() -- public synthetic-data generator for trying
+  detectors and transforms without real data or loaders.
+add: ts_shape.list_detectors() -- programmatic catalog of every top-level
+  class, grouped by pack/category.
+add: Base.__repr__ -- detector and instance classes now print a useful
+  summary (row count + configured uuid/value_column).
+changed: OutlierDetectionEvents emits the canonical point shape (systime,
+  uuid, source_uuid) via events/_output.py -- completes the May 14 output
+  standardization. uuid carries the event id, source_uuid the source signal.
+changed: event detectors validate their configured UUID up front
+  (Base._validate_uuid) -- a typo'd UUID now raises a clear error listing the
+  available UUIDs instead of silently returning empty results.
+fix: DatapointAPI HTTP requests now send a timeout (default 30s) so an
+  unresponsive server can no longer hang the loader.
+fix: TimescaleDBDataAccess uses bound SQL parameters instead of f-string
+  interpolation.
+fix: CycleExtractor uses Base's sorted, defensive copy -- it no longer
+  mutates the caller's DataFrame.
+fix: README quick-start and pack examples corrected to match real
+  constructor signatures (SPC, ToleranceDeviationEvents, DataIntegratorHybrid,
+  TimeGroupedStatistics).
+
 # May 14, 2026
 BREAKING: event-detector outputs standardized across all packs (quality,
   production, engineering, maintenance, supplychain, energy, correlation).

--- a/README.md
+++ b/README.md
@@ -43,24 +43,25 @@ Optional integrations:
 
 ## Quick Start
 
-```python
-import pandas as pd
-from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
-from ts_shape.events.quality.statistical_process_control import StatisticalProcessControlRuleBased
+This snippet runs as-is -- no data files, no setup:
 
-# Load your timeseries data
-df = pd.read_parquet("my_data.parquet")
+```python
+import ts_shape
+
+# Generate a sample dataset (or load your own via pandas / a ts-shape loader)
+df = ts_shape.make_timeseries(["sensor:temp"], n_points=2000, n_outliers=6)
+
+# Discover what is available -- 60+ detectors across 7 packs
+ts_shape.list_detectors("events.quality")
 
 # Detect outliers
-detector = OutlierDetectionEvents(df, value_column="value_double")
+detector = ts_shape.OutlierDetectionEvents(df, value_column="value_double")
 outliers = detector.detect_outliers_zscore(threshold=3.0)
-
-# Run SPC analysis
-spc = StatisticalProcessControlRuleBased(
-    df, actual_uuid="sensor:temp", tolerance_uuid="limit:temp"
-)
-violations = spc.process()
+print(outliers)
 ```
+
+Every script under [`examples/`](examples/) is likewise self-contained -- run any
+of them straight after install, e.g. `python examples/quality_events_demo.py`.
 
 ---
 
@@ -130,11 +131,24 @@ outliers = OutlierDetectionEvents(df, value_column="value_double")
 result = outliers.detect_outliers_zscore(threshold=3.0)
 
 # Statistical Process Control -- 8 Western Electric rules
-spc = StatisticalProcessControlRuleBased(df, actual_uuid="sensor", tolerance_uuid="limit")
+spc = StatisticalProcessControlRuleBased(
+    df,
+    value_column="value_double",
+    tolerance_uuid="limit",
+    actual_uuid="sensor",
+    event_uuid="spc_violation",
+)
 violations = spc.process()
 
 # Tolerance deviation with severity classification
-tol = ToleranceDeviationEvents(df, actual_uuid="sensor", tolerance_uuid="limit")
+tol = ToleranceDeviationEvents(
+    df,
+    tolerance_column="value_double",
+    actual_column="value_double",
+    actual_uuid="sensor",
+    tolerance_uuid="limit",
+    event_uuid="tolerance_deviation",
+)
 deviations = tol.process_and_group_data_with_events()
 ```
 
@@ -248,7 +262,9 @@ df_range = ParquetLoader.load_by_time_range("/data/timeseries", start, end)
 
 # Load metadata and combine
 meta = MetadataJsonLoader.from_file("metadata.json")
-combined = DataIntegratorHybrid.combine_data(timeseries_df=df, metadata_df=meta.to_df())
+combined = DataIntegratorHybrid.combine_data(
+    timeseries_sources=[df], metadata_sources=[meta.to_df()]
+)
 ```
 
 ### Features & Statistics
@@ -263,8 +279,13 @@ from ts_shape.features.cycles.cycles_extractor import CycleExtractor
 stats = NumericStatistics.summary_as_dict(df, "value_double")
 
 # Time-windowed aggregations
-tgs = TimeGroupedStatistics(df, value_column="value_double")
-hourly = tgs.calculate_statistic(freq="1h", stat="mean")
+hourly = TimeGroupedStatistics.calculate_statistic(
+    df,
+    time_column="systime",
+    value_column="value_double",
+    freq="1h",
+    stat_method="mean",
+)
 
 # Cycle extraction (6 detection methods)
 extractor = CycleExtractor(df, start_uuid="cycle:trigger")

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -239,7 +239,7 @@ flowchart TB
 ```
 
 !!! info "Merge Keys"
-    Classes connect through **shared DataFrame columns**: `date`, `shift`, `part_number`, `uuid`. When one class produces a column, the next class can join on it. See each guide for specific merge key documentation.
+    Classes connect through **shared DataFrame columns**. Daily-tracking classes join on `date`, `shift`, `part_number`, `uuid`; canonical event detectors emit `start` / `end` interval boundaries (plus `duration_seconds`). When one class produces a column, the next class can join on it. See each guide for specific merge key documentation.
 
 ---
 

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -116,6 +116,9 @@ _LAZY: dict[str, str] = {
     "DatapointDB": "ts_shape.loader.metadata.metadata_db_loader",
     "DataIntegratorHybrid": "ts_shape.loader.combine.integrator",
     "ContextEnricher": "ts_shape.loader.context.context_enricher",
+    # -- top-level utilities --------------------------------------------
+    "list_detectors": "ts_shape.catalog",
+    "make_timeseries": "ts_shape.datasets",
 }
 
 # The eventlog package re-exports its whole public surface from its own

--- a/src/ts_shape/catalog.py
+++ b/src/ts_shape/catalog.py
@@ -1,0 +1,55 @@
+"""Programmatic catalog of ts-shape's public classes.
+
+``list_detectors()`` lets a power user discover the 60+ event detectors and
+loaders from a REPL or notebook instead of scanning the docs::
+
+    import ts_shape
+    ts_shape.list_detectors("events.quality")
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd  # type: ignore
+
+
+def _category_for(module: str) -> str:
+    """Map a defining module path to a short catalog category."""
+    if module.startswith("ts_shape.events."):
+        # e.g. ts_shape.events.quality.outlier_detection -> events.quality
+        return ".".join(module.split(".")[1:3])
+    if module.startswith("ts_shape.loader."):
+        return "loader"
+    if module == "ts_shape.eventlog":
+        return "eventlog"
+    parts = module.split(".")
+    return parts[1] if len(parts) > 1 else module
+
+
+def list_detectors(category: Optional[str] = None) -> pd.DataFrame:
+    """Return a catalog of ts-shape's top-level public classes.
+
+    Args:
+        category: Optional filter matched as a prefix against the ``category``
+            column -- e.g. ``"events"``, ``"events.quality"``, ``"loader"``.
+
+    Returns:
+        DataFrame with columns ``name``, ``category`` and ``module`` -- one row
+        per class re-exported from ``ts_shape``, sorted by category then name.
+    """
+    from ts_shape import _LAZY  # local import avoids an import cycle
+
+    rows = [
+        {"name": name, "category": _category_for(module), "module": module}
+        for name, module in _LAZY.items()
+    ]
+    df = (
+        pd.DataFrame(rows, columns=["name", "category", "module"])
+        .drop_duplicates("name")
+        .sort_values(["category", "name"])
+        .reset_index(drop=True)
+    )
+    if category is not None:
+        df = df[df["category"].str.startswith(category)].reset_index(drop=True)
+    return df

--- a/src/ts_shape/datasets.py
+++ b/src/ts_shape/datasets.py
@@ -1,0 +1,96 @@
+"""Synthetic timeseries generators for trying out ts-shape.
+
+These helpers produce DataFrames in the standard ts-shape schema
+(``systime``, ``uuid``, ``value_*``, ``is_delta``) so any detector,
+transform, or statistic can be exercised without real data or loaders::
+
+    import ts_shape
+    df = ts_shape.make_timeseries(["sensor:temp"], n_outliers=4)
+    ts_shape.OutlierDetectionEvents(df, value_column="value_double") \\
+        .detect_outliers_zscore()
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+_VALUE_COLUMNS = ("value_double", "value_integer", "value_bool")
+
+
+def make_timeseries(
+    uuids: Sequence[str] = ("sensor:signal",),
+    *,
+    n_points: int = 1000,
+    freq: str = "30s",
+    start: str = "2025-01-01 00:00:00",
+    baseline: float = 100.0,
+    noise: float = 1.0,
+    drift: float = 0.0,
+    n_outliers: int = 0,
+    value_column: str = "value_double",
+    seed: Optional[int] = 42,
+) -> pd.DataFrame:
+    """Generate a standard-schema synthetic timeseries DataFrame.
+
+    Args:
+        uuids: Signal identifiers; one block of ``n_points`` rows per uuid.
+        n_points: Number of samples generated per uuid.
+        freq: Pandas offset alias for the sampling interval (e.g. ``"30s"``).
+        start: Timestamp of the first sample.
+        baseline: Mean level of the generated signal.
+        noise: Standard deviation of the Gaussian noise added to the signal.
+        drift: Total linear drift applied across the series (tool-wear style).
+        n_outliers: Number of large spike outliers injected per uuid.
+        value_column: Which value column to populate -- one of
+            ``value_double``, ``value_integer`` or ``value_bool``.
+        seed: Seed for reproducibility; pass ``None`` for fresh randomness.
+
+    Returns:
+        DataFrame with columns ``systime``, ``uuid``, ``value_bool``,
+        ``value_integer``, ``value_double``, ``value_string`` and ``is_delta``.
+
+    Raises:
+        ValueError: If ``value_column`` is not a supported value column, or
+            ``n_points`` is not positive.
+    """
+    if value_column not in _VALUE_COLUMNS:
+        raise ValueError(
+            f"value_column must be one of {_VALUE_COLUMNS}; got {value_column!r}"
+        )
+    if n_points <= 0:
+        raise ValueError(f"n_points must be positive; got {n_points}")
+
+    rng = np.random.default_rng(seed)
+    frames = []
+    for uuid in uuids:
+        times = pd.date_range(start=start, periods=n_points, freq=freq)
+        signal = baseline + rng.normal(0.0, noise, n_points)
+        if drift:
+            signal = signal + np.linspace(0.0, drift, n_points)
+        if n_outliers > 0:
+            idx = rng.choice(n_points, size=min(n_outliers, n_points), replace=False)
+            signal[idx] += rng.choice([-1.0, 1.0], size=len(idx)) * noise * 12.0
+
+        frame = pd.DataFrame(
+            {
+                "systime": times,
+                "uuid": uuid,
+                "value_bool": pd.NA,
+                "value_integer": pd.NA,
+                "value_double": np.nan,
+                "value_string": pd.NA,
+                "is_delta": True,
+            }
+        )
+        if value_column == "value_double":
+            frame["value_double"] = np.round(signal, 6)
+        elif value_column == "value_integer":
+            frame["value_integer"] = signal.round().astype("int64")
+        else:  # value_bool
+            frame["value_bool"] = signal > baseline
+        frames.append(frame)
+
+    return pd.concat(frames, ignore_index=True)

--- a/src/ts_shape/errors.py
+++ b/src/ts_shape/errors.py
@@ -25,5 +25,10 @@ class DataQualityWarning(TsShapeWarning):
     """Warn about potential data quality issues (gaps, duplicates, NaNs)."""
 
 
-class ColumnNotFoundError(KeyError):
-    """Raised when a required column is missing from the DataFrame."""
+class ColumnNotFoundError(ValueError):
+    """Raised when a required column is missing from the DataFrame.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` handlers keep
+    working, while callers that want to react specifically to a missing
+    column can catch this narrower type.
+    """

--- a/src/ts_shape/events/engineering/startup_events.py
+++ b/src/ts_shape/events/engineering/startup_events.py
@@ -32,6 +32,7 @@ class StartupDetectionEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, target_uuid)
 
         self.series = (
             self.dataframe[self.dataframe["uuid"] == self.target_uuid]

--- a/src/ts_shape/events/maintenance/degradation_detection.py
+++ b/src/ts_shape/events/maintenance/degradation_detection.py
@@ -30,6 +30,7 @@ class DegradationDetectionEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, signal_uuid)
 
         # Isolate signal series and ensure proper dtypes/sort
         self.signal = (

--- a/src/ts_shape/events/maintenance/vibration_analysis.py
+++ b/src/ts_shape/events/maintenance/vibration_analysis.py
@@ -29,6 +29,7 @@ class VibrationAnalysisEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, signal_uuid)
 
         # Isolate signal series and ensure proper dtypes/sort
         self.signal = (

--- a/src/ts_shape/events/production/alarm_management.py
+++ b/src/ts_shape/events/production/alarm_management.py
@@ -52,6 +52,7 @@ class AlarmManagementEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, alarm_uuid)
 
         self.series = (
             self.dataframe[self.dataframe["uuid"] == self.alarm_uuid]

--- a/src/ts_shape/events/production/batch_tracking.py
+++ b/src/ts_shape/events/production/batch_tracking.py
@@ -51,6 +51,7 @@ class BatchTrackingEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, batch_uuid)
 
         self.series = (
             self.dataframe[self.dataframe["uuid"] == self.batch_uuid]

--- a/src/ts_shape/events/quality/outlier_detection.py
+++ b/src/ts_shape/events/quality/outlier_detection.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.stats import zscore
 from typing import Optional
 from ts_shape.utils.base import Base
+from ts_shape.events._output import empty_event_df, finalize_point_df
 
 logger = logging.getLogger(__name__)
 
@@ -53,20 +54,14 @@ class OutlierDetectionEvents(Base):
             include_singles (bool): Whether to include single outliers in the output. Default is True.
 
         Returns:
-            pd.DataFrame: A DataFrame of grouped outlier events.
+            pd.DataFrame: Canonical ``point``-shape event DataFrame
+            (``systime``, ``uuid``, ``source_uuid``) plus ``<value_column>``,
+            ``severity`` and ``is_delta``. ``uuid`` carries the event id and
+            ``source_uuid`` the originating signal id.
         """
+        extra_cols = [self.value_column, "severity", "is_delta"]
         if outliers_df.empty:
-            # Return empty DataFrame with consistent schema
-            empty_df = pd.DataFrame(
-                columns=[
-                    "systime",
-                    self.value_column,
-                    "is_delta",
-                    "uuid",
-                    "severity",
-                ]
-            )
-            return empty_df
+            return empty_event_df("point", extra_cols=extra_cols)
 
         # Grouping outliers that are close to each other in terms of time
         outliers_df["group_id"] = (
@@ -91,30 +86,24 @@ class OutlierDetectionEvents(Base):
             events_data.append(singles_df)
 
         # Convert list of DataFrame slices to a single DataFrame
-        if events_data:
-            events_df = pd.concat(events_data)
-        else:
-            # Create empty DataFrame with consistent schema
-            events_df = pd.DataFrame(
-                columns=[
-                    "systime",
-                    self.value_column,
-                    "is_delta",
-                    "uuid",
-                    "severity",
-                ]
-            )
-            return events_df
+        if not events_data:
+            return empty_event_df("point", extra_cols=extra_cols)
+        events_df = pd.concat(events_data)
 
         # Ensure consistent schema
         events_df["is_delta"] = True
-        events_df["uuid"] = self.event_uuid
-
-        # Preserve severity if it exists, otherwise set to NaN
         if "severity" not in events_df.columns:
             events_df["severity"] = np.nan
 
-        return events_df.drop(["outlier", "group_id"], axis=1, errors="ignore")
+        # Preserve the originating signal id as source_uuid before the
+        # canonical helper broadcasts the event id into the uuid column.
+        if "source_uuid" in events_df.columns:
+            events_df = events_df.drop(columns=["uuid"], errors="ignore")
+        elif "uuid" in events_df.columns:
+            events_df = events_df.rename(columns={"uuid": "source_uuid"})
+        events_df = events_df.drop(columns=["outlier", "group_id"], errors="ignore")
+
+        return finalize_point_df(events_df, uuid=self.event_uuid, source_uuid=None)
 
     def detect_outliers_zscore(
         self, threshold: float = 3.0, include_singles: bool = True

--- a/src/ts_shape/events/quality/statistical_process_control.py
+++ b/src/ts_shape/events/quality/statistical_process_control.py
@@ -37,6 +37,10 @@ class StatisticalProcessControlRuleBased(Base):
         self.tolerance_uuid: str = tolerance_uuid
         self.actual_uuid: str = actual_uuid
         self.event_uuid: str = event_uuid
+        if not self.dataframe.empty:
+            self._validate_column(self.dataframe, value_column)
+            self._validate_uuid(self.dataframe, tolerance_uuid)
+            self._validate_uuid(self.dataframe, actual_uuid)
 
     def calculate_control_limits(self) -> pd.DataFrame:
         """

--- a/src/ts_shape/events/supplychain/demand_pattern.py
+++ b/src/ts_shape/events/supplychain/demand_pattern.py
@@ -49,6 +49,7 @@ class DemandPatternEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, demand_uuid)
 
         # Isolate the demand series
         self.demand = (

--- a/src/ts_shape/events/supplychain/inventory_monitoring.py
+++ b/src/ts_shape/events/supplychain/inventory_monitoring.py
@@ -51,6 +51,7 @@ class InventoryMonitoringEvents(Base):
         self.event_uuid = event_uuid
         self.value_column = value_column
         self.time_column = time_column
+        self._validate_uuid(self.dataframe, level_uuid)
 
         # Isolate the inventory level series
         self.levels = (

--- a/src/ts_shape/features/cycles/cycles_extractor.py
+++ b/src/ts_shape/features/cycles/cycles_extractor.py
@@ -27,13 +27,13 @@ class CycleExtractor(Base):
         """
         super().__init__(dataframe)
 
-        # Validate input types
-        if not isinstance(dataframe, pd.DataFrame):
-            raise ValueError("dataframe must be a pandas DataFrame")
+        # Validate input types (Base already guards the DataFrame type).
         if not isinstance(start_uuid, str):
             raise ValueError("start_uuid must be a string")
 
-        self.df = dataframe  # Use the provided DataFrame directly
+        # Use Base's processed frame: a sorted, defensive copy. This avoids
+        # mutating the caller's DataFrame and guarantees chronological order.
+        self.df = self.dataframe
         self.start_uuid = start_uuid
         self.end_uuid = end_uuid if end_uuid else start_uuid
         self.value_change_threshold = abs(value_change_threshold)

--- a/src/ts_shape/loader/metadata/metadata_api_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_api_loader.py
@@ -36,6 +36,7 @@ class DatapointAPI:
         output_path: str = "data",
         required_uuid_list: Optional[List[str]] = None,
         filter_enabled: bool = True,
+        timeout: int = 30,
     ):
         """
         :param device_names: Device names to collect datapoints for.
@@ -44,11 +45,14 @@ class DatapointAPI:
         :param output_path: Directory to write per-device JSON exports.
         :param required_uuid_list: Optional allowlist; only matching UUIDs are kept.
         :param filter_enabled: When True, only datapoints with ``enabled=True`` are kept.
+        :param timeout: Per-request timeout in seconds; prevents an unresponsive
+            server from hanging the loader indefinitely.
         """
         self.device_names = device_names
         self.base_url = base_url.rstrip("/")
         self.api_token = api_token
         self.output_path = output_path
+        self.timeout = timeout
         self.required_uuid_list: List[str] = required_uuid_list or []
         self.filter_enabled = filter_enabled
         self.device_metadata: Dict[str, pd.DataFrame] = {}
@@ -65,7 +69,7 @@ class DatapointAPI:
 
     def _get(self, path: str) -> list:
         url = f"{self.base_url}{path}"
-        response = requests.get(url, headers=self._headers)
+        response = requests.get(url, headers=self._headers, timeout=self.timeout)
         response.raise_for_status()
         return response.json()
 

--- a/src/ts_shape/loader/timeseries/timescale_loader.py
+++ b/src/ts_shape/loader/timeseries/timescale_loader.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 import pandas as pd  # type: ignore
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
@@ -24,14 +24,26 @@ class TimescaleDBDataAccess:
         )
 
     def _fetch_data(self, uuid: str) -> pd.DataFrame:
-        query = f"""
-            SELECT uuid::text, systime, value_integer, value_string, value_double, value_bool, is_delta 
-            FROM telemetry 
-            WHERE uuid = '{uuid}' 
-              AND systime BETWEEN '{self.start_timestamp}' AND '{self.end_timestamp}' 
+        # Bound parameters keep values out of the SQL text — this avoids
+        # injection and quoting bugs (e.g. a uuid containing an apostrophe).
+        query = text("""
+            SELECT uuid::text, systime, value_integer, value_string,
+                   value_double, value_bool, is_delta
+            FROM telemetry
+            WHERE uuid = :uuid
+              AND systime BETWEEN :start_ts AND :end_ts
             ORDER BY systime ASC
-        """
-        return pd.read_sql(query, self.engine, chunksize=10000)
+            """)
+        return pd.read_sql(
+            query,
+            self.engine,
+            params={
+                "uuid": uuid,
+                "start_ts": self.start_timestamp,
+                "end_ts": self.end_timestamp,
+            },
+            chunksize=10000,
+        )
 
     def fetch_data_as_parquet(self, output_dir: str):
         for uuid in self.uuids:

--- a/src/ts_shape/utils/base.py
+++ b/src/ts_shape/utils/base.py
@@ -35,7 +35,7 @@ the right one based on the complexity of the operation:
 import logging
 import warnings
 import pandas as pd  # type: ignore
-from ts_shape.errors import DataQualityWarning
+from ts_shape.errors import ColumnNotFoundError, DataQualityWarning
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +46,35 @@ class Base:
         """Validate that a column exists in the DataFrame.
 
         Raises:
-            ValueError: If column_name is not in dataframe.columns.
+            ColumnNotFoundError: If column_name is not in dataframe.columns.
+                This subclasses ``ValueError``.
         """
         if column_name not in dataframe.columns:
-            raise ValueError(
+            raise ColumnNotFoundError(
                 f"Column '{column_name}' not found. "
                 f"Available columns: {list(dataframe.columns)}"
+            )
+
+    @staticmethod
+    def _validate_uuid(
+        dataframe: pd.DataFrame, uuid: str, uuid_column: str = "uuid"
+    ) -> None:
+        """Validate that ``uuid`` is present in ``uuid_column``.
+
+        A no-op when the DataFrame is empty or carries no uuid column, so each
+        detector keeps full control over empty-input handling.
+
+        Raises:
+            ValueError: If ``uuid_column`` exists, the frame is non-empty, and
+                ``uuid`` is absent. The message lists the available UUIDs.
+        """
+        if dataframe.empty or uuid_column not in dataframe.columns:
+            return
+        if uuid not in dataframe[uuid_column].values:
+            available = sorted(str(u) for u in dataframe[uuid_column].dropna().unique())
+            raise ValueError(
+                f"UUID '{uuid}' not found in column '{uuid_column}'. "
+                f"Available UUIDs: {available}"
             )
 
     def __init__(self, dataframe: pd.DataFrame, column_name: str = "systime") -> None:
@@ -131,3 +154,19 @@ class Base:
     def get_dataframe(self) -> pd.DataFrame:
         """Returns the processed DataFrame."""
         return self.dataframe
+
+    def __repr__(self) -> str:
+        """Concise, interactive-friendly summary of the instance.
+
+        Shows the row count plus any configured ``value_column`` / ``*_uuid``
+        attributes, so ``print(detector)`` in a REPL or notebook is useful.
+        """
+        df = getattr(self, "dataframe", None)
+        n_rows = len(df) if isinstance(df, pd.DataFrame) else 0
+        parts = [f"rows={n_rows}"]
+        for key, val in self.__dict__.items():
+            if isinstance(val, str) and (
+                key.endswith("_uuid") or key == "value_column"
+            ):
+                parts.append(f"{key}={val!r}")
+        return f"{type(self).__name__}({', '.join(parts)})"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,7 @@
 import pandas as pd  # type: ignore
+import pytest
+
+from ts_shape.errors import ColumnNotFoundError
 from ts_shape.utils.base import Base
 
 
@@ -28,3 +31,32 @@ def test_base_detects_time_column_when_not_provided():
     assert list(out["created_time"]) == sorted(
         pd.to_datetime(df["created_time"]).tolist()
     )
+
+
+def test_validate_uuid_raises_with_available_list():
+    df = pd.DataFrame(
+        {"systime": pd.to_datetime(["2024-01-01", "2024-01-02"]), "uuid": ["a", "b"]}
+    )
+    with pytest.raises(ValueError, match="missing"):
+        Base._validate_uuid(df, "missing")
+
+
+def test_validate_uuid_is_noop_on_empty_or_missing_uuid_column():
+    # Empty frame and uuid-less frame must not raise.
+    Base._validate_uuid(pd.DataFrame(columns=["uuid"]), "anything")
+    Base._validate_uuid(pd.DataFrame({"x": [1]}), "anything")
+
+
+def test_validate_column_raises_column_not_found_error():
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(ColumnNotFoundError):
+        Base._validate_column(df, "b")
+    # Backwards compatible: ColumnNotFoundError subclasses ValueError.
+    with pytest.raises(ValueError):
+        Base._validate_column(df, "b")
+
+
+def test_repr_reports_rows_and_class():
+    df = pd.DataFrame({"systime": pd.to_datetime(["2024-01-01"]), "value_integer": [1]})
+    r = repr(Base(df))
+    assert r.startswith("Base(") and "rows=1" in r

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,34 @@
+"""Tests for the programmatic detector catalog."""
+
+import ts_shape
+from ts_shape.catalog import list_detectors
+
+
+def test_list_detectors_returns_expected_columns():
+    df = list_detectors()
+    assert list(df.columns) == ["name", "category", "module"]
+    assert len(df) > 50
+    assert "OutlierDetectionEvents" in set(df["name"])
+
+
+def test_list_detectors_category_filter():
+    quality = list_detectors("events.quality")
+    assert len(quality) > 0
+    assert (quality["category"] == "events.quality").all()
+    assert "OutlierDetectionEvents" in set(quality["name"])
+
+
+def test_list_detectors_events_prefix_filter():
+    events = list_detectors("events")
+    assert (events["category"].str.startswith("events")).all()
+    assert len(events) > len(list_detectors("events.quality"))
+
+
+def test_list_detectors_is_sorted_and_unique():
+    df = list_detectors()
+    assert df["name"].is_unique
+    assert list(df["category"]) == sorted(df["category"])
+
+
+def test_list_detectors_exported_at_top_level():
+    assert ts_shape.list_detectors is list_detectors

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,67 @@
+"""Tests for the public synthetic-data generator."""
+
+import pandas as pd  # type: ignore
+import pytest
+
+import ts_shape
+from ts_shape.datasets import make_timeseries
+
+_SCHEMA = (
+    "systime",
+    "uuid",
+    "value_bool",
+    "value_integer",
+    "value_double",
+    "value_string",
+    "is_delta",
+)
+
+
+def test_make_timeseries_standard_schema():
+    df = make_timeseries(["s1"], n_points=50)
+    assert len(df) == 50
+    for col in _SCHEMA:
+        assert col in df.columns
+    assert pd.api.types.is_datetime64_any_dtype(df["systime"])
+
+
+def test_make_timeseries_multiple_uuids():
+    df = make_timeseries(["a", "b"], n_points=100, n_outliers=3)
+    assert set(df["uuid"]) == {"a", "b"}
+    assert len(df) == 200
+
+
+def test_make_timeseries_is_reproducible_with_seed():
+    a = make_timeseries(["s"], n_points=20, seed=7)
+    b = make_timeseries(["s"], n_points=20, seed=7)
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_make_timeseries_integer_and_bool_columns():
+    di = make_timeseries(["s"], n_points=10, value_column="value_integer")
+    assert pd.api.types.is_integer_dtype(di["value_integer"])
+    db = make_timeseries(["s"], n_points=10, value_column="value_bool")
+    assert pd.api.types.is_bool_dtype(db["value_bool"])
+
+
+def test_make_timeseries_rejects_unsupported_value_column():
+    with pytest.raises(ValueError):
+        make_timeseries(["s"], value_column="value_string")
+
+
+def test_make_timeseries_rejects_non_positive_n_points():
+    with pytest.raises(ValueError):
+        make_timeseries(["s"], n_points=0)
+
+
+def test_make_timeseries_exported_at_top_level():
+    assert ts_shape.make_timeseries is make_timeseries
+
+
+def test_make_timeseries_feeds_a_detector():
+    # The headline use case: generate data, run a detector, no setup.
+    df = make_timeseries(["sensor:temp"], n_points=200, n_outliers=4)
+    events = ts_shape.OutlierDetectionEvents(
+        df, value_column="value_double"
+    ).detect_outliers_zscore()
+    assert "source_uuid" in events.columns

--- a/tests/test_metadata_api_loader.py
+++ b/tests/test_metadata_api_loader.py
@@ -65,7 +65,7 @@ def make_fake_get(datatrons=None, devices=None, datapoints=None):
     dv = devices if devices is not None else DEVICES
     dp = datapoints if datapoints is not None else DATAPOINTS
 
-    def fake_get(url, headers=None):
+    def fake_get(url, headers=None, timeout=None):
         if "data_points" in url:
             return DummyResp(dp)
         if (
@@ -243,7 +243,7 @@ def test_filter_enabled_false(monkeypatch, tmp_path):
 def test_bearer_token_in_headers(monkeypatch):
     captured = {}
 
-    def capturing_get(url, headers=None):
+    def capturing_get(url, headers=None, timeout=None):
         captured["headers"] = headers
         return DummyResp(
             DATATRONS

--- a/tests/test_outlier_detection.py
+++ b/tests/test_outlier_detection.py
@@ -19,3 +19,23 @@ def test_outlier_detection_zscore_and_iqr():
 
     i = det.detect_outliers_iqr(threshold=(1.5, 1.5))
     assert "uuid" in i.columns
+
+
+def test_outlier_output_is_canonical_point_shape():
+    df = pd.DataFrame(
+        {
+            "systime": pd.date_range("2024-01-01", periods=10, freq="min"),
+            "uuid": ["sensor:x"] * 10,
+            "value_double": [1, 1, 1, 1, 50, 1, 1, 1, 1, 1],
+        }
+    )
+    det = OutlierDetectionEvents(
+        df, value_column="value_double", event_uuid="outlier_evt"
+    )
+    z = det.detect_outliers_zscore(threshold=2.0)
+    # Canonical point schema: systime / uuid / source_uuid.
+    for col in ("systime", "uuid", "source_uuid"):
+        assert col in z.columns
+    assert not z.empty
+    assert (z["uuid"] == "outlier_evt").all()
+    assert (z["source_uuid"] == "sensor:x").all()

--- a/tests/test_production_oee_alarm_batch.py
+++ b/tests/test_production_oee_alarm_batch.py
@@ -335,10 +335,11 @@ class TestAlarmManagementEvents:
         result = alarms.standing_alarms(min_duration="3h")
         assert result.empty
 
-    def test_no_alarms_for_wrong_uuid(self, alarm_data):
-        alarms = AlarmManagementEvents(alarm_data, alarm_uuid="nonexistent")
-        assert alarms.alarm_frequency().empty
-        assert alarms.alarm_duration_stats().empty
+    def test_wrong_uuid_raises_with_available_list(self, alarm_data):
+        # A typo'd UUID is reported up front instead of silently yielding
+        # empty results — the available UUIDs are listed in the message.
+        with pytest.raises(ValueError, match="nonexistent"):
+            AlarmManagementEvents(alarm_data, alarm_uuid="nonexistent")
 
 
 # ============================================================================


### PR DESCRIPTION
Functional correctness & consistency:
- OutlierDetectionEvents emits the canonical point shape (systime, uuid,
  source_uuid) via events/_output.py, completing the May 14 output
  standardization.
- Event detectors validate their configured UUID up front
  (Base._validate_uuid): a typo'd UUID raises a clear error listing the
  available UUIDs instead of silently returning empty results.
- ColumnNotFoundError is wired into Base._validate_column (subclasses
  ValueError, so existing handlers keep working).
- CycleExtractor uses Base's sorted, defensive copy; no longer mutates
  the caller's DataFrame.
- DatapointAPI HTTP requests send a timeout (default 30s).
- TimescaleDBDataAccess uses bound SQL parameters instead of f-string
  interpolation.

Docs & onboarding:
- Fixed broken README/Quick Start examples that failed on copy-paste
  (SPC, ToleranceDeviationEvents, DataIntegratorHybrid,
  TimeGroupedStatistics).
- Quick Start is now zero-setup runnable via make_timeseries.
- Refreshed the stale merge-keys callout in docs/guides/index.md.

New power-user features:
- ts_shape.make_timeseries(): public synthetic-data generator.
- ts_shape.list_detectors(): programmatic catalog of public classes.
- Base.__repr__: detectors print a useful interactive summary.

https://claude.ai/code/session_011gAKpRqjh9mfNmUrej8R9P