### PR TITLE
docs: migrate domain pipeline docs to the Pipeline format

### DIFF
--- a/docs/pipelines/cycle-time-analysis.md
+++ b/docs/pipelines/cycle-time-analysis.md
@@ -1,6 +1,6 @@
 # Cycle Time Analysis Pipeline
 
-> From Azure Blob timeseries to cycle time statistics, slow cycle detection, trend analysis, and golden cycle comparison.
+> From Azure Blob timeseries to cycle time statistics, slow cycle detection, trend analysis, and cycle comparison — in one reusable `Pipeline`.
 
 **Signals needed:**
 
@@ -10,13 +10,14 @@
 | Part number | `part_number_signal` | `value_string` | Current part type being produced |
 | Machine state | `machine_run_state` | `value_bool` | True = running (optional, for filtering) |
 
-**Modules used:** [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [CycleExtractor](../reference/ts_shape/features/cycles/cycles_extractor.md) | [CycleTimeTracking](../reference/ts_shape/events/production/cycle_time_tracking.md) | [CycleDataProcessor](../reference/ts_shape/features/cycles/cycle_processor.md)
+**Modules used:** [Pipeline](../reference/ts_shape/pipeline.md) | [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [CycleTimeTracking](../reference/ts_shape/events/production/cycle_time_tracking.md) | [CycleExtractor](../reference/ts_shape/features/cycles/cycles_extractor.md) | [CycleDataProcessor](../reference/ts_shape/features/cycles/cycle_processor.md)
 
 ---
 
 ## Prerequisites
 
 ```python
+# -- The only things you customize --
 AZURE_CONNECTION = "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=..."
 CONTAINER = "timeseries-data"
 
@@ -30,200 +31,179 @@ START = "2024-06-01"
 END   = "2024-06-08"
 
 METADATA_PATH = "config/signal_metadata.json"
+
+TRIGGER_UUID = "cycle_complete"
+PART_UUID    = "part_number_signal"
+TREND_PART   = "PART_A"        # part type to trend
+
+# A cycle_uuid (from a prior extraction run) used as the comparison reference
+REFERENCE_CYCLE_UUID = "a1b2c3d4-0000-0000-0000-000000000000"
 ```
+
+!!! info "New to `Pipeline`?"
+    Read the [Pipeline guide](../guides/pipeline-builder.md) first — it explains
+    `.transform` vs `.detect` steps, the `$input` sentinel, and the debugging
+    tools used below.
 
 ---
 
-## Step 1: Load Data from Azure
+## Step 1: Load the data
+
+The Azure loader produces the DataFrame the pipeline runs on, so it stays
+outside the pipeline. Metadata is loaded the same way.
 
 ```python
 from ts_shape.loader.timeseries.azure_blob_loader import AzureBlobParquetLoader
+from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
 
 loader = AzureBlobParquetLoader(
     connection_string=AZURE_CONNECTION,
     container_name=CONTAINER,
 )
-
 df = loader.load_files_by_time_range_and_uuids(
     start_timestamp=START,
     end_timestamp=END,
     uuid_list=UUID_LIST,
 )
 
+meta_df = MetadataJsonLoader.from_file(METADATA_PATH).to_df()
+
 print(f"Loaded {len(df):,} rows, {df['uuid'].nunique()} signals")
 ```
 
 ---
 
-## Step 2: Enrich with Metadata
+## Step 2: Build the pipeline
+
+The pipeline runs in two stages on one signal. The `CycleTimeTracking`
+detectors run first against the enriched raw signal. Then `extract_cycles` —
+a `.transform` — reshapes the working signal into a validated cycle table,
+which the final `compare_cycles` step consumes.
+
+`extract_cycles` wraps `CycleExtractor` in a small `df -> df` helper so the
+same extractor instance both builds and validates the cycles.
 
 ```python
-from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
+from ts_shape import Pipeline
 from ts_shape.loader.context.context_enricher import ContextEnricher
-
-meta = MetadataJsonLoader.from_file(METADATA_PATH)
-enricher = ContextEnricher(df)
-df = enricher.enrich_with_metadata(meta.to_df(), columns=["description", "unit"])
-```
-
----
-
-## Step 3: Validate Data Quality
-
-```python
 from ts_shape.transform.harmonization import DataHarmonizer
-
-harmonizer = DataHarmonizer(df, value_column="value_double")
-gaps = harmonizer.detect_gaps(threshold="30s")
-
-if not gaps.empty:
-    print("Gaps per signal:")
-    print(gaps.groupby("uuid")["gap_duration"].agg(["count", "max"]))
-
-    # Fill small gaps to avoid false cycle breaks
-    df_clean = harmonizer.fill_gaps(strategy="ffill", max_gap="60s")
-else:
-    df_clean = df
-```
-
-!!! warning "Cycle trigger gaps"
-    Missing samples in the cycle trigger signal create phantom long cycles. Always check for gaps before extracting cycles.
-
----
-
-## Step 4: Extract Cycles
-
-Use `CycleExtractor` for fine-grained cycle detection, or `CycleTimeTracking` for quick part-based analysis. Here we show both approaches.
-
-### Option A: Quick Analysis with CycleTimeTracking
-
-```python
 from ts_shape.events.production.cycle_time_tracking import CycleTimeTracking
-
-tracker = CycleTimeTracking(df)
-
-# Cycle times per part number
-cycles = tracker.cycle_time_by_part(
-    part_id_uuid="part_number_signal",
-    cycle_trigger_uuid="cycle_complete",
-)
-
-print(f"Total cycles: {len(cycles)}")
-print(cycles[["systime", "part_number", "cycle_time_seconds"]].head(10))
-```
-
-### Option B: Advanced Extraction with CycleExtractor
-
-```python
 from ts_shape.features.cycles.cycles_extractor import CycleExtractor
-
-# Filter to cycle trigger signal
-trigger_df = df[df["uuid"] == "cycle_complete"].copy()
-
-extractor = CycleExtractor(
-    dataframe=trigger_df,
-    start_uuid="cycle_complete",
-)
-
-# Extract using trigger method (True -> False = one cycle)
-cycle_df = extractor.process_trigger_cycle()
-
-# Validate: remove unrealistic cycles
-cycle_df = extractor.validate_cycles(
-    cycle_df,
-    min_duration="10s",    # no cycle shorter than 10s
-    max_duration="10min",  # no cycle longer than 10 minutes
-)
-
-print(f"Valid cycles: {len(cycle_df)}")
-print(extractor.get_extraction_stats())
-```
-
----
-
-## Step 5: Cycle Time Statistics
-
-```python
-# Statistics per part number
-stats = tracker.cycle_time_statistics(
-    part_id_uuid="part_number_signal",
-    cycle_trigger_uuid="cycle_complete",
-)
-print(stats)
-# Columns: part_number, count, mean, median, std, min, max
-```
-
----
-
-## Step 6: Detect Slow Cycles
-
-```python
-slow = tracker.detect_slow_cycles(
-    part_id_uuid="part_number_signal",
-    cycle_trigger_uuid="cycle_complete",
-    threshold_factor=1.5,   # flag cycles > 1.5x median
-)
-
-print(f"Slow cycles: {len(slow)}")
-if not slow.empty:
-    print(slow[["systime", "part_number", "cycle_time_seconds", "deviation_factor"]].head())
-```
-
----
-
-## Step 7: Trend Analysis
-
-```python
-# Cycle time trend for a specific part
-trend = tracker.cycle_time_trend(
-    part_id_uuid="part_number_signal",
-    cycle_trigger_uuid="cycle_complete",
-    part_number="PART_A",
-    window_size=20,    # rolling window of 20 cycles
-)
-
-print(trend[["systime", "cycle_time_seconds", "moving_avg", "trend"]].tail(10))
-```
-
----
-
-## Step 8: Golden Cycle Comparison (Advanced)
-
-```python
 from ts_shape.features.cycles.cycle_processor import CycleDataProcessor
 
-processor = CycleDataProcessor(
-    cycles_df=cycle_df,
-    values_df=df,
-)
 
-# Find the most consistent cycles
-golden = processor.identify_golden_cycles(
-    metric="value_double",
-    method="low_variability",
-    top_n=5,
-)
-print(f"Golden cycle UUIDs: {golden}")
+def extract_cycles(df):
+    extractor = CycleExtractor(
+        df[df["uuid"] == TRIGGER_UUID].copy(), start_uuid=TRIGGER_UUID
+    )
+    cycles = extractor.process_trigger_cycle()
+    return extractor.validate_cycles(
+        cycles, min_duration="10s", max_duration="10min"
+    )
 
-# Compare all cycles against a reference
-comparison = processor.compare_cycles(
-    reference_cycle_uuid=golden[0],
-    metric="value_double",
+
+pipe = (
+    Pipeline(name="cycle-time")
+
+    # -- clean the signal --
+    .transform(lambda df: ContextEnricher(df).enrich_with_metadata(
+        meta_df, columns=["description", "unit"]),
+        name="enrich_metadata")
+    .detect(DataHarmonizer, "detect_gaps", name="gaps", threshold="30s")
+
+    # -- cycle time analysis on the raw signal --
+    .detect(CycleTimeTracking, "cycle_time_by_part", name="cycles",
+            part_id_uuid=PART_UUID, cycle_trigger_uuid=TRIGGER_UUID)
+    .detect(CycleTimeTracking, "cycle_time_statistics", name="stats",
+            part_id_uuid=PART_UUID, cycle_trigger_uuid=TRIGGER_UUID)
+    .detect(CycleTimeTracking, "detect_slow_cycles", name="slow_cycles",
+            part_id_uuid=PART_UUID, cycle_trigger_uuid=TRIGGER_UUID,
+            threshold_factor=1.5)
+    .detect(CycleTimeTracking, "cycle_time_trend", name="trend",
+            part_id_uuid=PART_UUID, cycle_trigger_uuid=TRIGGER_UUID,
+            part_number=TREND_PART, window_size=20)
+
+    # -- extract cycles, then compare against a reference --
+    .transform(extract_cycles, name="extract_cycles")
+    .detect(CycleDataProcessor, "compare_cycles", name="comparison",
+            values_df="$input", reference_cycle_uuid=REFERENCE_CYCLE_UUID)
 )
-print(comparison.head())
+```
+
+The `compare_cycles` step runs after `extract_cycles`, so the working signal
+is the validated cycle table — passed to the `CycleDataProcessor` constructor
+as `cycles_df`. The `$input` sentinel feeds the original raw DataFrame in as
+`values_df`.
+
+!!! warning "Cycle trigger gaps"
+    Missing samples in the cycle trigger signal create phantom long cycles.
+    Inspect the `gaps` result before trusting the cycle statistics.
+
+---
+
+## Step 3: Preview with `describe()`
+
+```python
+print(pipe.describe())
+```
+
+```
+Pipeline 'cycle-time' (8 steps):
+  0. [transform] enrich_metadata
+  1. [detect   ] gaps  threshold='30s'
+  2. [detect   ] cycles  part_id_uuid='part_number_signal', cycle_trigger_uuid='cycle_complete'
+  3. [detect   ] stats  part_id_uuid='part_number_signal', cycle_trigger_uuid='cycle_complete'
+  4. [detect   ] slow_cycles  part_id_uuid='part_number_signal', cycle_trigger_uuid='cycle_complete', threshold_factor=1.5
+  5. [detect   ] trend  part_id_uuid='part_number_signal', cycle_trigger_uuid='cycle_complete', part_number='PART_A', window_size=20
+  6. [transform] extract_cycles
+  7. [detect   ] comparison  values_df='$input', reference_cycle_uuid='a1b2c3d4-0000-0000-0000-000000000000'
+```
+
+---
+
+## Step 4: Run
+
+```python
+result = pipe.run(df)          # reusable — call .run() on any DataFrame
+
+print(result.events["stats"])        # mean/median/std per part type
+print(result.events["slow_cycles"])  # cycles exceeding 1.5x median
+print(result.events["trend"])        # rolling-window trend for PART_A
+```
+
+`result.data` holds the validated cycle table (the output of `extract_cycles`);
+every analysis table is keyed by its step name in `result.events`.
+
+!!! tip "Pick a reference cycle"
+    Run the pipeline once, inspect `result.data` for a representative cycle,
+    and copy its `cycle_uuid` into `REFERENCE_CYCLE_UUID` to make `comparison`
+    meaningful on the next run.
+
+---
+
+## Step 5: Debug with `run_steps()`
+
+To inspect every intermediate DataFrame, use `run_steps()` instead of `run()`:
+
+```python
+intermediates = pipe.run_steps(df)
+
+for name, step_df in intermediates.items():
+    print(f"{name:18s} -> {step_df.shape[0]:>6} rows x {step_df.shape[1]} cols")
 ```
 
 ---
 
 ## Results
 
-| Output | Description | Use case |
-|--------|-------------|----------|
+| `result.events` key | Description | Use case |
+|---------------------|-------------|----------|
 | `cycles` | Per-cycle times with part numbers | Raw cycle data |
 | `stats` | Mean, median, std per part type | Capacity planning |
-| `slow` | Cycles exceeding threshold | Loss investigation |
+| `slow_cycles` | Cycles exceeding threshold | Loss investigation |
 | `trend` | Rolling average + direction | Drift detection |
-| `golden` | Best reference cycles | Quality benchmarking |
+| `comparison` | Cycle-to-reference comparison | Quality benchmarking |
+| `gaps` | Detected time gaps per signal | Data trust check |
 
 ---
 

--- a/docs/pipelines/downtime-pareto.md
+++ b/docs/pipelines/downtime-pareto.md
@@ -1,6 +1,6 @@
 # Downtime Pareto Analysis Pipeline
 
-> From Azure Blob timeseries to Pareto-ranked downtime reasons, shift-level comparison, and availability trends.
+> From Azure Blob timeseries to Pareto-ranked downtime reasons, shift-level comparison, and availability trends — in one reusable `Pipeline`.
 
 **Signals needed:**
 
@@ -9,13 +9,14 @@
 | Machine state | `machine_state_str` | `value_string` | "Running", "Stopped", "Idle" |
 | Downtime reason | `downtime_reason` | `value_string` | Reason code (e.g., "Tool_Change", "Material_Shortage") |
 
-**Modules used:** [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [MachineStateEvents](../reference/ts_shape/events/production/machine_state.md) | [DowntimeTracking](../reference/ts_shape/events/production/downtime_tracking.md)
+**Modules used:** [Pipeline](../reference/ts_shape/pipeline.md) | [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [DowntimeTracking](../reference/ts_shape/events/production/downtime_tracking.md)
 
 ---
 
 ## Prerequisites
 
 ```python
+# -- The only things you customize --
 AZURE_CONNECTION = "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=..."
 CONTAINER = "timeseries-data"
 
@@ -36,23 +37,32 @@ SHIFT_DEFINITIONS = {
 }
 ```
 
+!!! info "New to `Pipeline`?"
+    Read the [Pipeline guide](../guides/pipeline-builder.md) first — it explains
+    `.transform` vs `.detect` steps and the debugging tools used below.
+
 ---
 
-## Step 1: Load Data from Azure
+## Step 1: Load the data
+
+The Azure loader produces the DataFrame the pipeline runs on, so it stays
+outside the pipeline. Metadata is loaded the same way.
 
 ```python
 from ts_shape.loader.timeseries.azure_blob_loader import AzureBlobParquetLoader
+from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
 
 loader = AzureBlobParquetLoader(
     connection_string=AZURE_CONNECTION,
     container_name=CONTAINER,
 )
-
 df = loader.load_files_by_time_range_and_uuids(
     start_timestamp=START,
     end_timestamp=END,
     uuid_list=UUID_LIST,
 )
+
+meta_df = MetadataJsonLoader.from_file(METADATA_PATH).to_df()
 
 print(f"Loaded {len(df):,} rows")
 print(f"Unique reason codes: {df[df['uuid'] == 'downtime_reason']['value_string'].nunique()}")
@@ -60,125 +70,123 @@ print(f"Unique reason codes: {df[df['uuid'] == 'downtime_reason']['value_string'
 
 ---
 
-## Step 2: Enrich with Metadata
+## Step 2: Build the pipeline
+
+One `Pipeline` captures the whole workflow. `.transform` steps clean the
+signal; every `.detect` step branches off a downtime table.
 
 ```python
-from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
+from ts_shape import Pipeline
 from ts_shape.loader.context.context_enricher import ContextEnricher
-
-meta = MetadataJsonLoader.from_file(METADATA_PATH)
-enricher = ContextEnricher(df)
-df = enricher.enrich_with_metadata(meta.to_df(), columns=["description", "area"])
-```
-
----
-
-## Step 3: Validate Data Quality
-
-```python
 from ts_shape.transform.harmonization import DataHarmonizer
-
-harmonizer = DataHarmonizer(df, value_column="value_double")
-gaps = harmonizer.detect_gaps(threshold="60s")
-
-if not gaps.empty:
-    print("Signal gaps detected:")
-    print(gaps.groupby("uuid")["gap_duration"].agg(["count", "max"]))
-```
-
-!!! tip "State signal continuity"
-    The machine state signal should be continuous (no gaps). Gaps are ambiguous — was the machine running or stopped? Fill with `ffill` for short gaps, flag long gaps as "Unknown".
-
-```python
-# Forward-fill small gaps in state signal
-df_clean = harmonizer.fill_gaps(strategy="ffill", max_gap="120s")
-```
-
----
-
-## Step 4: Downtime by Shift
-
-```python
 from ts_shape.events.production.downtime_tracking import DowntimeTracking
 
-tracker = DowntimeTracking(df, shift_definitions=SHIFT_DEFINITIONS)
+pipe = (
+    Pipeline(name="downtime-pareto")
 
-# Downtime duration per shift
-shift_downtime = tracker.downtime_by_shift(
-    state_uuid="machine_state_str",
-    running_value="Running",
+    # -- clean the signal --
+    .transform(lambda df: ContextEnricher(df).enrich_with_metadata(
+        meta_df, columns=["description", "area"]),
+        name="enrich_metadata")
+    .detect(DataHarmonizer, "detect_gaps", name="gaps", threshold="60s")
+    .transform(DataHarmonizer, "fill_gaps", strategy="ffill", max_gap="120s")
+
+    # -- downtime analysis --
+    .detect(DowntimeTracking, "downtime_by_shift", name="shift_downtime",
+            shift_definitions=SHIFT_DEFINITIONS,
+            state_uuid="machine_state_str", running_value="Running")
+    .detect(DowntimeTracking, "downtime_by_reason", name="reason_analysis",
+            shift_definitions=SHIFT_DEFINITIONS,
+            state_uuid="machine_state_str", reason_uuid="downtime_reason",
+            stopped_value="Stopped")
+    .detect(DowntimeTracking, "top_downtime_reasons", name="top_reasons",
+            shift_definitions=SHIFT_DEFINITIONS,
+            state_uuid="machine_state_str", reason_uuid="downtime_reason",
+            top_n=5, stopped_value="Stopped")
+    .detect(DowntimeTracking, "availability_trend", name="availability",
+            shift_definitions=SHIFT_DEFINITIONS,
+            state_uuid="machine_state_str", running_value="Running",
+            window="1D")
 )
+```
 
-print("--- Downtime by Shift ---")
-print(shift_downtime)
-# Columns: date, shift, total_time_minutes, downtime_minutes, availability_pct
+`shift_definitions` is routed to the `DowntimeTracking` constructor; the
+remaining keyword arguments reach each method.
+
+!!! tip "State signal continuity"
+    The machine state signal should be continuous (no gaps). Gaps are ambiguous
+    — was the machine running or stopped? `fill_gaps` with `ffill` covers short
+    gaps; inspect the `gaps` result for long ones.
+
+---
+
+## Step 3: Preview with `describe()`
+
+```python
+print(pipe.describe())
+```
+
+```
+Pipeline 'downtime-pareto' (7 steps):
+  0. [transform] enrich_metadata
+  1. [detect   ] gaps  threshold='60s'
+  2. [transform] fill_gaps  strategy='ffill', max_gap='120s'
+  3. [detect   ] shift_downtime  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, state_uuid='machine_state_str', running_value='Running'
+  4. [detect   ] reason_analysis  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, state_uuid='machine_state_str', reason_uuid='downtime_reason', stopped_value='Stopped'
+  5. [detect   ] top_reasons  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, state_uuid='machine_state_str', reason_uuid='downtime_reason', top_n=5, stopped_value='Stopped'
+  6. [detect   ] availability  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, state_uuid='machine_state_str', running_value='Running', window='1D'
 ```
 
 ---
 
-## Step 5: Downtime by Reason (Pareto)
+## Step 4: Run
 
 ```python
-# Break down by reason code
-reason_analysis = tracker.downtime_by_reason(
-    state_uuid="machine_state_str",
-    reason_uuid="downtime_reason",
-    stopped_value="Stopped",
-)
+result = pipe.run(df)          # reusable — call .run() on any DataFrame
 
-print("--- Downtime by Reason ---")
-print(reason_analysis)
-```
-
-```python
-# Top reasons (Pareto ranking)
-top_reasons = tracker.top_downtime_reasons(
-    state_uuid="machine_state_str",
-    reason_uuid="downtime_reason",
-    top_n=5,
-    stopped_value="Stopped",
-)
-
-print("--- Top 5 Downtime Reasons (Pareto) ---")
-print(top_reasons)
+print(result.events["top_reasons"])
 # Columns: reason, total_minutes, occurrence_count, pct_of_total, cumulative_pct
+
+print(result.events["shift_downtime"])   # downtime minutes per shift
+print(result.events["availability"])     # daily availability trend
 ```
 
 !!! info "The 80/20 rule"
-    In most plants, 2-3 reason codes account for 80% of downtime. Focus improvement efforts on these first.
+    In most plants, 2-3 reason codes account for 80% of downtime. The
+    `cumulative_pct` column in `top_reasons` shows where that line falls —
+    focus improvement efforts there first.
 
 ---
 
-## Step 6: Availability Trend
+## Step 5: Debug with `run_steps()`
+
+To inspect every intermediate DataFrame, use `run_steps()` instead of `run()`:
 
 ```python
-# Daily availability trend
-availability = tracker.availability_trend(
-    state_uuid="machine_state_str",
-    running_value="Running",
-    window="1D",
-)
+intermediates = pipe.run_steps(df)
 
-print("--- Daily Availability Trend ---")
-print(availability)
-# Columns: period, running_minutes, total_minutes, availability_pct
+for name, step_df in intermediates.items():
+    print(f"{name:20s} -> {step_df.shape[0]:>6} rows x {step_df.shape[1]} cols")
 ```
 
 ---
 
 ## Results
 
-| Output | Description | Merge key |
-|--------|-------------|-----------|
+| `result.events` key | Description | Merge key |
+|---------------------|-------------|-----------|
 | `shift_downtime` | Downtime minutes and availability per shift | `date`, `shift` |
 | `reason_analysis` | Downtime broken down by reason code | `reason` |
 | `top_reasons` | Pareto-ranked reasons with cumulative % | `reason` |
 | `availability` | Daily availability trend | `period` |
+| `gaps` | Detected time gaps per signal | — |
 
 !!! tip "Merge with production data"
-    Join `shift_downtime` with [OEE Dashboard](oee-dashboard.md) `shift_prod` on `[date, shift]` for a complete shift handover report:
+    Join `result.events["shift_downtime"]` with the [OEE Dashboard](oee-dashboard.md)
+    `shift_prod` table on `[date, shift]` for a complete shift handover report:
     ```python
-    report = shift_prod.merge(shift_downtime, on=["date", "shift"])
+    report = oee_result.events["shift_prod"].merge(
+        result.events["shift_downtime"], on=["date", "shift"])
     ```
 
 ---

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -10,17 +10,20 @@ End-to-end workflows that turn raw Azure timeseries into actionable production i
 
 ## Common Pattern
 
-Every pipeline follows the same flow:
+Every pipeline is a single, reusable [`Pipeline`](../guides/pipeline-builder.md)
+object: data is loaded once, then `.transform` steps clean the signal and
+`.detect` steps branch off KPI tables.
 
 ```mermaid
 graph LR
     A[Azure Blob Storage] --> B[Load by UUIDs + Time Range]
-    B --> C[Enrich with Metadata]
-    C --> D[Validate Data Quality]
-    D --> E[Harmonize & Transform]
-    E --> F[Event Detection / Analytics]
-    F --> G[Results & KPIs]
+    B --> C["Pipeline — .transform steps clean the signal"]
+    C --> D["Pipeline — .detect steps branch off analytics"]
+    D --> E["PipelineResult — .data + .events"]
 ```
+
+See the [Pipeline guide](../guides/pipeline-builder.md) for the step types,
+sentinels, and debugging tools every pipeline below uses.
 
 ---
 

--- a/docs/pipelines/oee-dashboard.md
+++ b/docs/pipelines/oee-dashboard.md
@@ -1,6 +1,6 @@
 # OEE Dashboard Pipeline
 
-> From Azure Blob timeseries to daily OEE breakdown by shift — availability, performance, and quality.
+> From Azure Blob timeseries to daily OEE breakdown by shift — availability, performance, and quality — in one reusable `Pipeline`.
 
 **Signals needed:**
 
@@ -11,7 +11,7 @@
 | Total counter | `total_counter` | `value_integer` | Total parts (good + bad) |
 | Reject counter | `reject_counter` | `value_integer` | Rejected parts counter |
 
-**Modules used:** [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [MachineStateEvents](../reference/ts_shape/events/production/machine_state.md) | [OEECalculator](../reference/ts_shape/events/production/oee_calculator.md) | [ShiftReporting](../reference/ts_shape/events/production/shift_reporting.md)
+**Modules used:** [Pipeline](../reference/ts_shape/pipeline.md) | [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [MachineStateEvents](../reference/ts_shape/events/production/machine_state.md) | [OEECalculator](../reference/ts_shape/events/production/oee_calculator.md) | [ShiftReporting](../reference/ts_shape/events/production/shift_reporting.md)
 
 ---
 
@@ -34,6 +34,8 @@ END   = "2024-06-08"
 
 METADATA_PATH = "config/signal_metadata.json"
 
+IDEAL_CYCLE_TIME = 30.0   # seconds per part (from engineering spec)
+
 SHIFT_DEFINITIONS = {
     "day":       ("06:00", "14:00"),
     "afternoon": ("14:00", "22:00"),
@@ -41,26 +43,34 @@ SHIFT_DEFINITIONS = {
 }
 ```
 
+!!! info "New to `Pipeline`?"
+    Read the [Pipeline guide](../guides/pipeline-builder.md) first — it explains
+    `.transform` vs `.detect` steps and the debugging tools used below.
+
 ---
 
-## Step 1: Load Data from Azure
+## Step 1: Load the data
+
+The Azure loader produces the DataFrame the pipeline runs on, so it stays
+outside the pipeline. Metadata is loaded the same way.
 
 ```python
 from ts_shape.loader.timeseries.azure_blob_loader import AzureBlobParquetLoader
+from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
 
 loader = AzureBlobParquetLoader(
     connection_string=AZURE_CONNECTION,
     container_name=CONTAINER,
 )
-
 df = loader.load_files_by_time_range_and_uuids(
     start_timestamp=START,
     end_timestamp=END,
     uuid_list=UUID_LIST,
 )
 
+meta_df = MetadataJsonLoader.from_file(METADATA_PATH).to_df()
+
 print(f"Loaded {len(df):,} rows, {df['uuid'].nunique()} signals")
-print(f"Time range: {df['systime'].min()} to {df['systime'].max()}")
 ```
 
 !!! tip "Check your data shape"
@@ -68,161 +78,139 @@ print(f"Time range: {df['systime'].min()} to {df['systime'].max()}")
 
 ---
 
-## Step 2: Enrich with Metadata
+## Step 2: Build the pipeline
+
+One `Pipeline` captures the whole workflow. `.transform` steps clean the
+signal; every `.detect` step branches off a KPI table and leaves the signal
+untouched.
 
 ```python
-from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
+from ts_shape import Pipeline
 from ts_shape.loader.context.context_enricher import ContextEnricher
-
-# Load signal metadata (descriptions, units, areas)
-meta = MetadataJsonLoader.from_file(METADATA_PATH)
-meta_df = meta.to_df()
-
-# Enrich timeseries with metadata columns
-enricher = ContextEnricher(df)
-df = enricher.enrich_with_metadata(
-    meta_df,
-    columns=["description", "unit", "area"],
-)
-
-print(df[["uuid", "description", "unit"]].drop_duplicates())
-```
-
-!!! info "Why enrich?"
-    Metadata enrichment attaches human-readable signal names, engineering units, and plant area codes. Downstream reports use these for labeling instead of raw UUIDs.
-
----
-
-## Step 3: Validate Data Quality
-
-```python
 from ts_shape.transform.harmonization import DataHarmonizer
-
-harmonizer = DataHarmonizer(df, value_column="value_double")
-
-# Check for time gaps per signal
-gaps = harmonizer.detect_gaps(threshold="60s")
-print(f"Gaps found: {len(gaps)}")
-if not gaps.empty:
-    print(gaps.groupby("uuid")["gap_duration"].agg(["count", "max"]))
-```
-
-!!! warning "Handle gaps before analysis"
-    Gaps in the machine state signal directly affect availability calculations. If gaps are large (> 5 minutes), investigate the data source before proceeding.
-
-```python
-# Fill small gaps (under 2 minutes) with forward-fill
-df_clean = harmonizer.fill_gaps(
-    strategy="ffill",
-    max_gap="120s",
-)
-```
-
----
-
-## Step 4: Detect Machine States
-
-```python
 from ts_shape.events.production.machine_state import MachineStateEvents
-
-machine = MachineStateEvents(
-    dataframe=df,
-    run_state_uuid="machine_run_state",
-)
-
-# Get run/idle intervals (ignore glitches under 5 seconds)
-intervals = machine.detect_run_idle(min_duration="5s")
-print(f"Run intervals: {(intervals['state'] == 'run').sum()}")
-print(f"Idle intervals: {(intervals['state'] == 'idle').sum()}")
-
-# Check for signal noise
-metrics = machine.state_quality_metrics()
-print(f"Coverage: {metrics['coverage_pct']:.1f}%")
-print(f"Rapid transitions: {metrics.get('rapid_transition_count', 0)}")
-```
-
----
-
-## Step 5: Calculate OEE
-
-```python
 from ts_shape.events.production.oee_calculator import OEECalculator
-
-oee = OEECalculator(df)
-
-# Individual components
-availability = oee.calculate_availability("machine_run_state")
-performance = oee.calculate_performance(
-    "part_counter",
-    ideal_cycle_time=30.0,       # seconds per part (from engineering spec)
-    run_state_uuid="machine_run_state",
-)
-quality = oee.calculate_quality("total_counter", "reject_counter")
-
-print("--- Availability ---")
-print(availability)
-print("\n--- Performance ---")
-print(performance)
-print("\n--- Quality ---")
-print(quality)
-```
-
-```python
-# Combined daily OEE
-daily_oee = oee.calculate_oee(
-    run_state_uuid="machine_run_state",
-    counter_uuid="part_counter",
-    ideal_cycle_time=30.0,
-    total_uuid="total_counter",
-    reject_uuid="reject_counter",
-)
-
-print("\n--- Daily OEE ---")
-print(daily_oee)
-# Columns: start, end, duration_seconds, availability, performance, quality, oee
-```
-
----
-
-## Step 6: Shift Reports
-
-```python
 from ts_shape.events.production.shift_reporting import ShiftReporting
 
-reporter = ShiftReporting(df, shift_definitions=SHIFT_DEFINITIONS)
+pipe = (
+    Pipeline(name="oee-dashboard")
 
-# Production per shift
-shift_prod = reporter.shift_production(counter_uuid="part_counter")
-print(shift_prod)
+    # -- clean the signal --
+    .transform(lambda df: ContextEnricher(df).enrich_with_metadata(
+        meta_df, columns=["description", "unit", "area"]),
+        name="enrich_metadata")
+    .detect(DataHarmonizer, "detect_gaps", name="gaps", threshold="60s")
+    .transform(DataHarmonizer, "fill_gaps", strategy="ffill", max_gap="120s")
 
-# Compare shifts over the week
-comparison = reporter.shift_comparison(counter_uuid="part_counter", days=7)
-print(comparison)
+    # -- machine state --
+    .detect(MachineStateEvents, "detect_run_idle", name="intervals",
+            run_state_uuid="machine_run_state", min_duration="5s")
 
-# Check against targets
-targets = {"day": 500, "afternoon": 480, "night": 450}
-target_results = reporter.shift_targets(
-    counter_uuid="part_counter",
-    targets=targets,
+    # -- OEE components --
+    .detect(OEECalculator, "calculate_availability", name="availability",
+            run_state_uuid="machine_run_state")
+    .detect(OEECalculator, "calculate_performance", name="performance",
+            counter_uuid="part_counter", ideal_cycle_time=IDEAL_CYCLE_TIME,
+            run_state_uuid="machine_run_state")
+    .detect(OEECalculator, "calculate_quality", name="quality",
+            total_uuid="total_counter", reject_uuid="reject_counter")
+    .detect(OEECalculator, "calculate_oee", name="daily_oee",
+            run_state_uuid="machine_run_state", counter_uuid="part_counter",
+            ideal_cycle_time=IDEAL_CYCLE_TIME, total_uuid="total_counter",
+            reject_uuid="reject_counter")
+
+    # -- shift reports --
+    .detect(ShiftReporting, "shift_production", name="shift_prod",
+            shift_definitions=SHIFT_DEFINITIONS, counter_uuid="part_counter")
+    .detect(ShiftReporting, "shift_comparison", name="shift_comparison",
+            shift_definitions=SHIFT_DEFINITIONS, counter_uuid="part_counter",
+            days=7)
+    .detect(ShiftReporting, "shift_targets", name="shift_targets",
+            shift_definitions=SHIFT_DEFINITIONS, counter_uuid="part_counter",
+            targets={"day": 500, "afternoon": 480, "night": 450})
 )
-print(target_results)
+```
+
+Keyword arguments are routed automatically: `run_state_uuid` reaches the
+detector method, `shift_definitions` reaches the `ShiftReporting` constructor.
+`detect_gaps` is a `.detect` step — it reports gaps without changing the
+signal — while `fill_gaps` is a `.transform` that every later step builds on.
+
+!!! warning "Handle gaps before analysis"
+    Gaps in the machine state signal directly affect availability. Inspect the
+    `gaps` result first; if gaps are large (> 5 minutes), investigate the data
+    source before trusting the OEE numbers.
+
+---
+
+## Step 3: Preview with `describe()`
+
+```python
+print(pipe.describe())
+```
+
+```
+Pipeline 'oee-dashboard' (11 steps):
+  0. [transform] enrich_metadata
+  1. [detect   ] gaps  threshold='60s'
+  2. [transform] fill_gaps  strategy='ffill', max_gap='120s'
+  3. [detect   ] intervals  run_state_uuid='machine_run_state', min_duration='5s'
+  4. [detect   ] availability  run_state_uuid='machine_run_state'
+  5. [detect   ] performance  counter_uuid='part_counter', ideal_cycle_time=30.0, run_state_uuid='machine_run_state'
+  6. [detect   ] quality  total_uuid='total_counter', reject_uuid='reject_counter'
+  7. [detect   ] daily_oee  run_state_uuid='machine_run_state', counter_uuid='part_counter', ideal_cycle_time=30.0, total_uuid='total_counter', reject_uuid='reject_counter'
+  8. [detect   ] shift_prod  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, counter_uuid='part_counter'
+  9. [detect   ] shift_comparison  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, counter_uuid='part_counter', days=7
+  10. [detect   ] shift_targets  shift_definitions={'day': ('06:00', '14:00'), 'afternoon': ('14:00', '22:00'), 'night': ('22:00', '06:00')}, counter_uuid='part_counter', targets={'day': 500, 'afternoon': 480, 'night': 450}
+```
+
+---
+
+## Step 4: Run
+
+```python
+result = pipe.run(df)          # reusable — call .run() on any DataFrame
+
+print(result.events["daily_oee"])
+# Columns: start, end, duration_seconds, availability, performance, quality, oee
+
+print(result.events["shift_prod"])      # production per shift
+print(result.events["shift_targets"])   # target vs actual per shift
+```
+
+`result.data` holds the cleaned signal after `fill_gaps`; every KPI table is
+keyed by its step name in `result.events`.
+
+---
+
+## Step 5: Debug with `run_steps()`
+
+To inspect every intermediate DataFrame, use `run_steps()` instead of `run()`:
+
+```python
+intermediates = pipe.run_steps(df)
+
+for name, step_df in intermediates.items():
+    print(f"{name:20s} -> {step_df.shape[0]:>6} rows x {step_df.shape[1]} cols")
 ```
 
 ---
 
 ## Results
 
-At the end of this pipeline you have:
-
-| Output | Description | Merge key |
-|--------|-------------|-----------|
+| `result.events` key | Description | Merge key |
+|---------------------|-------------|-----------|
 | `daily_oee` | Daily OEE with A/P/Q breakdown | `start` (midnight per day) |
+| `availability` / `performance` / `quality` | Individual OEE components | `start` |
 | `shift_prod` | Production quantity per shift | `date`, `shift` |
-| `comparison` | Cross-shift performance comparison | `shift` |
-| `target_results` | Target vs actual per shift | `date`, `shift` |
+| `shift_comparison` | Cross-shift performance comparison | `shift` |
+| `shift_targets` | Target vs actual per shift | `date`, `shift` |
 | `intervals` | Run/idle intervals with durations | timestamp range |
+| `gaps` | Detected time gaps per signal | — |
 
-These DataFrames can be exported to CSV, fed into a dashboard tool, or merged with outputs from other pipelines (e.g., [Downtime Pareto](downtime-pareto.md) for root cause analysis).
+These DataFrames can be exported to CSV, fed into a dashboard tool, or merged
+with outputs from other pipelines (e.g., [Downtime Pareto](downtime-pareto.md)
+for root cause analysis).
 
 ---
 

--- a/docs/pipelines/process-engineering.md
+++ b/docs/pipelines/process-engineering.md
@@ -1,6 +1,6 @@
 # Process Engineering Pipeline
 
-> From Azure Blob timeseries to setpoint adherence, startup detection, control loop health, and process stability scores.
+> From Azure Blob timeseries to setpoint adherence, startup detection, control loop health, and process stability scores — in one reusable `Pipeline`.
 
 **Signals needed:**
 
@@ -8,22 +8,23 @@
 |------|-------------|------|-------------|
 | Setpoint | `temperature_setpoint` | `value_double` | Target value from recipe/PLC |
 | Actual value | `temperature_actual` | `value_double` | Measured process value (PV) |
-| Controller output | `temperature_output` | `value_double` | Control valve position / PID output (optional) |
+| Controller output | `temperature_output` | `value_double` | Control valve position / PID output |
 
-**Modules used:** [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [SetpointChangeEvents](../reference/ts_shape/events/engineering/setpoint_events.md) | [StartupDetectionEvents](../reference/ts_shape/events/engineering/startup_events.md) | [SteadyStateDetectionEvents](../reference/ts_shape/events/engineering/steady_state_detection.md) | [ControlLoopHealthEvents](../reference/ts_shape/events/engineering/control_loop_health.md) | [ProcessStabilityIndex](../reference/ts_shape/events/engineering/process_stability_index.md)
+**Modules used:** [Pipeline](../reference/ts_shape/pipeline.md) | [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [SetpointChangeEvents](../reference/ts_shape/events/engineering/setpoint_events.md) | [StartupDetectionEvents](../reference/ts_shape/events/engineering/startup_events.md) | [SteadyStateDetectionEvents](../reference/ts_shape/events/engineering/steady_state_detection.md) | [ControlLoopHealthEvents](../reference/ts_shape/events/engineering/control_loop_health.md) | [ProcessStabilityIndex](../reference/ts_shape/events/engineering/process_stability_index.md)
 
 ---
 
 ## Prerequisites
 
 ```python
+# -- The only things you customize --
 AZURE_CONNECTION = "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=..."
 CONTAINER = "timeseries-data"
 
 UUID_LIST = [
     "temperature_setpoint",   # double: target value
     "temperature_actual",     # double: process value (PV)
-    "temperature_output",     # double: controller output (optional)
+    "temperature_output",     # double: controller output
 ]
 
 START = "2024-06-01"
@@ -37,257 +38,229 @@ UPPER_SPEC = 105.0
 LOWER_SPEC = 95.0
 ```
 
+!!! info "New to `Pipeline`?"
+    Read the [Pipeline guide](../guides/pipeline-builder.md) first — it explains
+    `.transform` vs `.detect` steps and the debugging tools used below.
+
 ---
 
-## Step 1: Load Data from Azure
+## Step 1: Load the data
+
+The Azure loader produces the DataFrame the pipeline runs on, so it stays
+outside the pipeline. Metadata is loaded the same way.
 
 ```python
 from ts_shape.loader.timeseries.azure_blob_loader import AzureBlobParquetLoader
+from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
 
 loader = AzureBlobParquetLoader(
     connection_string=AZURE_CONNECTION,
     container_name=CONTAINER,
 )
-
 df = loader.load_files_by_time_range_and_uuids(
     start_timestamp=START,
     end_timestamp=END,
     uuid_list=UUID_LIST,
 )
 
+meta_df = MetadataJsonLoader.from_file(METADATA_PATH).to_df()
+
 print(f"Loaded {len(df):,} rows, {df['uuid'].nunique()} signals")
 ```
 
 ---
 
-## Step 2: Enrich with Metadata
+## Step 2: Build the pipeline
+
+One `Pipeline` captures the whole workflow. `.transform` steps clean the
+signal; every `.detect` step branches off an analysis table.
+
+`ProcessStabilityIndex` takes a `target` argument, which collides with the
+pipeline's own `target` parameter — so its three steps are wrapped in small
+`df -> df` helper functions, the plain-callable step form.
 
 ```python
-from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
+from ts_shape import Pipeline
 from ts_shape.loader.context.context_enricher import ContextEnricher
-
-meta = MetadataJsonLoader.from_file(METADATA_PATH)
-enricher = ContextEnricher(df)
-df = enricher.enrich_with_metadata(meta.to_df(), columns=["description", "unit", "area"])
-```
-
----
-
-## Step 3: Validate Data Quality & Harmonize
-
-```python
 from ts_shape.transform.harmonization import DataHarmonizer
-
-harmonizer = DataHarmonizer(df, value_column="value_double")
-
-# Check for gaps in both signals
-gaps = harmonizer.detect_gaps(threshold="10s")
-if not gaps.empty:
-    print("Signal gaps:")
-    print(gaps.groupby("uuid")["gap_duration"].agg(["count", "max"]))
-
-# Resample to uniform 1-second grid for clean alignment
-df_uniform = harmonizer.resample_to_uniform(freq="1s", method="linear")
-print(f"Uniform grid: {len(df_uniform)} rows")
-```
-
-!!! tip "Why harmonize?"
-    Setpoint and actual value signals often arrive at different rates (setpoint changes only on recipe switch, PV updates every second). Resampling to a uniform grid ensures correct SP-PV alignment for control loop analysis.
-
-```python
-# Align setpoint and actual for side-by-side analysis
-aligned = harmonizer.align_asof(
-    left_uuid="temperature_setpoint",
-    right_uuid="temperature_actual",
-    tolerance="2s",
-    direction="nearest",
-)
-print(aligned.head())
-```
-
----
-
-## Step 4: Detect Setpoint Changes
-
-```python
 from ts_shape.events.engineering.setpoint_events import SetpointChangeEvents
-
-sp_events = SetpointChangeEvents(
-    dataframe=df,
-    setpoint_uuid="temperature_setpoint",
-)
-
-# Detect step changes (magnitude >= 1.0 degree)
-steps = sp_events.detect_setpoint_steps(min_delta=1.0, min_hold="30s")
-print(f"Setpoint steps detected: {len(steps)}")
-if not steps.empty:
-    print(steps[["start", "magnitude", "prev_level", "new_level"]].head())
-```
-
-```python
-# Measure how well the process follows setpoint changes
-settling = sp_events.settling_time(
-    actual_uuid="temperature_actual",
-    min_delta=1.0,
-    band_pct=0.02,     # 2% settling band
-    max_window="5min",
-)
-print(f"Average settling time: {settling['settling_seconds'].mean():.1f}s")
-
-# Overshoot analysis
-overshoot = sp_events.overshoot(
-    actual_uuid="temperature_actual",
-    min_delta=1.0,
-    max_window="5min",
-)
-print(f"Average overshoot: {overshoot['overshoot_pct'].mean():.1f}%")
-```
-
----
-
-## Step 5: Startup Detection
-
-```python
 from ts_shape.events.engineering.startup_events import StartupDetectionEvents
-
-startup = StartupDetectionEvents(
-    dataframe=df,
-    target_uuid="temperature_actual",
+from ts_shape.events.engineering.steady_state_detection import (
+    SteadyStateDetectionEvents,
 )
-
-# Detect startups by threshold crossing
-startups = startup.detect_startup_by_threshold(
-    threshold=50.0,          # process considered "started" above 50 degrees
-    min_above="60s",         # must stay above for 1 minute
-)
-
-print(f"Startup events: {len(startups)}")
-if not startups.empty:
-    print(startups[["start", "end"]].head())
-```
-
-!!! info "Startup vs steady state"
-    Startup detection identifies *when* the process begins. Combine with steady-state detection (next step) to find *when* the process stabilizes after startup.
-
----
-
-## Step 6: Steady-State Detection
-
-```python
-from ts_shape.events.engineering.steady_state_detection import SteadyStateDetectionEvents
-
-steady = SteadyStateDetectionEvents(
-    dataframe=df,
-    signal_uuid="temperature_actual",
-)
-
-# Find steady-state intervals (low variance periods)
-steady_intervals = steady.detect_steady_state(
-    window="60s",
-    threshold=0.5,          # rolling std below 0.5 = steady
-    min_duration="120s",    # must be steady for at least 2 minutes
-)
-print(f"Steady-state intervals: {len(steady_intervals)}")
-
-# Find transient (dynamic) periods
-transients = steady.detect_transient_periods(
-    window="60s",
-    threshold=0.5,
-)
-print(f"Transient periods: {len(transients)}")
-
-# Summary statistics
-stats = steady.steady_state_statistics(window="60s", threshold=0.5)
-print(f"Steady-state time: {stats['steady_pct']:.1f}%")
-print(f"Transient time: {stats['transient_pct']:.1f}%")
-```
-
----
-
-## Step 7: Control Loop Health
-
-```python
 from ts_shape.events.engineering.control_loop_health import ControlLoopHealthEvents
-
-loop = ControlLoopHealthEvents(
-    dataframe=df,
-    setpoint_uuid="temperature_setpoint",
-    actual_uuid="temperature_actual",
-    output_uuid="temperature_output",   # optional: controller output
-)
-
-# Error integrals per shift (8-hour windows)
-integrals = loop.error_integrals(window="8h")
-print("--- Error Integrals per Shift ---")
-print(integrals)
-# Columns: window_start, IAE, ISE, ITAE, bias
-
-# Detect sustained oscillation in the error signal
-oscillation = loop.detect_oscillation(
-    window="30min",
-    min_cycles=3,
-)
-print(f"Oscillation events: {len(oscillation)}")
-
-# Check for valve saturation (output pegged at 0% or 100%)
-if "temperature_output" in UUID_LIST:
-    saturation = loop.output_saturation(
-        low_pct=2.0,      # below 2% = saturated low
-        high_pct=98.0,     # above 98% = saturated high
-        min_duration="60s",
-    )
-    print(f"Saturation events: {len(saturation)}")
-
-# Shift-level report card
-summary = loop.loop_health_summary(window="8h")
-print("\n--- Loop Health Summary ---")
-print(summary)
-```
-
----
-
-## Step 8: Process Stability Score
-
-```python
 from ts_shape.events.engineering.process_stability_index import ProcessStabilityIndex
 
-stability = ProcessStabilityIndex(
-    dataframe=df,
-    signal_uuid="temperature_actual",
-    target=TARGET_VALUE,
-    upper_spec=UPPER_SPEC,
-    lower_spec=LOWER_SPEC,
+
+def stability_scores(df):
+    return ProcessStabilityIndex(
+        df, signal_uuid="temperature_actual", target=TARGET_VALUE,
+        upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC,
+    ).stability_score(window="8h")
+
+
+def stability_trend(df):
+    return ProcessStabilityIndex(
+        df, signal_uuid="temperature_actual", target=TARGET_VALUE,
+        upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC,
+    ).score_trend(window="8h")
+
+
+def stability_worst_periods(df):
+    return ProcessStabilityIndex(
+        df, signal_uuid="temperature_actual", target=TARGET_VALUE,
+        upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC,
+    ).worst_periods(window="8h", n=3)
+
+
+pipe = (
+    Pipeline(name="process-engineering")
+
+    # -- clean & harmonize the signal --
+    .transform(lambda df: ContextEnricher(df).enrich_with_metadata(
+        meta_df, columns=["description", "unit", "area"]),
+        name="enrich_metadata")
+    .detect(DataHarmonizer, "detect_gaps", name="gaps", threshold="10s")
+    .transform(DataHarmonizer, "resample_to_uniform", freq="1s")
+    .detect(DataHarmonizer, "align_asof", name="aligned",
+            left_uuid="temperature_setpoint", right_uuid="temperature_actual",
+            tolerance="2s", direction="nearest")
+
+    # -- setpoint behaviour --
+    .detect(SetpointChangeEvents, "detect_setpoint_steps", name="setpoint_steps",
+            setpoint_uuid="temperature_setpoint", min_delta=1.0, min_hold="30s")
+    .detect(SetpointChangeEvents, "time_to_settle", name="settling",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual", settle_pct=0.02, hold="10s",
+            lookahead="5min")
+    .detect(SetpointChangeEvents, "overshoot_metrics", name="overshoot",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual", window="5min")
+
+    # -- startup & steady state --
+    .detect(StartupDetectionEvents, "detect_startup_by_threshold",
+            name="startups", target_uuid="temperature_actual",
+            threshold=50.0, min_above="60s")
+    .detect(SteadyStateDetectionEvents, "detect_steady_state",
+            name="steady_intervals", signal_uuid="temperature_actual",
+            window="60s", std_threshold=0.5, min_duration="120s")
+    .detect(SteadyStateDetectionEvents, "detect_transient_periods",
+            name="transients", signal_uuid="temperature_actual",
+            window="60s", std_threshold=0.5)
+
+    # -- control loop health --
+    .detect(ControlLoopHealthEvents, "error_integrals", name="error_integrals",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual",
+            output_uuid="temperature_output", window="8h")
+    .detect(ControlLoopHealthEvents, "detect_oscillation", name="oscillation",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual",
+            output_uuid="temperature_output", window="30min", min_crossings=6)
+    .detect(ControlLoopHealthEvents, "output_saturation", name="saturation",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual",
+            output_uuid="temperature_output", high_limit=98.0, low_limit=2.0,
+            window="8h")
+    .detect(ControlLoopHealthEvents, "loop_health_summary", name="loop_health",
+            setpoint_uuid="temperature_setpoint",
+            actual_uuid="temperature_actual",
+            output_uuid="temperature_output", window="8h")
+
+    # -- process stability score --
+    .detect(stability_scores, name="stability_scores")
+    .detect(stability_trend, name="stability_trend")
+    .detect(stability_worst_periods, name="worst_periods")
 )
+```
 
-# Composite 0-100 stability score per shift
-scores = stability.stability_score(window="8h")
-print("--- Stability Scores ---")
-print(scores)
+`resample_to_uniform` is a `.transform` — setpoint and actual signals arrive
+at different rates, so every downstream detector runs on a clean uniform
+grid. `detect_gaps` and `align_asof` are `.detect` steps: they produce
+diagnostic tables without disturbing the working signal.
 
-# Is stability improving or degrading?
-trend = stability.score_trend(window="8h")
-print(f"Trend direction: {trend['direction'].iloc[-1]}")
+!!! tip "Why harmonize?"
+    Setpoint changes only on a recipe switch; the PV updates every second.
+    Resampling to a uniform grid ensures correct SP–PV alignment for control
+    loop analysis.
 
-# Worst periods for investigation
-worst = stability.worst_periods(window="8h", n=3)
-print("--- Worst 3 Periods ---")
-print(worst)
+---
+
+## Step 3: Preview with `describe()`
+
+```python
+print(pipe.describe())
+```
+
+```
+Pipeline 'process-engineering' (17 steps):
+  0. [transform] enrich_metadata
+  1. [detect   ] gaps  threshold='10s'
+  2. [transform] resample_to_uniform  freq='1s'
+  3. [detect   ] aligned  left_uuid='temperature_setpoint', right_uuid='temperature_actual', tolerance='2s', direction='nearest'
+  4. [detect   ] setpoint_steps  setpoint_uuid='temperature_setpoint', min_delta=1.0, min_hold='30s'
+  5. [detect   ] settling  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', settle_pct=0.02, hold='10s', lookahead='5min'
+  6. [detect   ] overshoot  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', window='5min'
+  7. [detect   ] startups  target_uuid='temperature_actual', threshold=50.0, min_above='60s'
+  8. [detect   ] steady_intervals  signal_uuid='temperature_actual', window='60s', std_threshold=0.5, min_duration='120s'
+  9. [detect   ] transients  signal_uuid='temperature_actual', window='60s', std_threshold=0.5
+  10. [detect   ] error_integrals  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', output_uuid='temperature_output', window='8h'
+  11. [detect   ] oscillation  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', output_uuid='temperature_output', window='30min', min_crossings=6
+  12. [detect   ] saturation  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', output_uuid='temperature_output', high_limit=98.0, low_limit=2.0, window='8h'
+  13. [detect   ] loop_health  setpoint_uuid='temperature_setpoint', actual_uuid='temperature_actual', output_uuid='temperature_output', window='8h'
+  14. [detect   ] stability_scores
+  15. [detect   ] stability_trend
+  16. [detect   ] worst_periods
+```
+
+---
+
+## Step 4: Run
+
+```python
+result = pipe.run(df)          # reusable — call .run() on any DataFrame
+
+print(result.events["setpoint_steps"])    # detected setpoint changes
+print(result.events["loop_health"])       # shift-level loop report card
+print(result.events["stability_scores"])  # 0-100 stability score per shift
+```
+
+`result.data` holds the cleaned, uniform-grid signal; every analysis table is
+keyed by its step name in `result.events`.
+
+!!! info "Startup vs steady state"
+    `startups` identifies *when* the process begins; `steady_intervals` finds
+    *when* it stabilizes afterwards. Combine the two to exclude warm-up from
+    your KPIs.
+
+---
+
+## Step 5: Debug with `run_steps()`
+
+To inspect every intermediate DataFrame, use `run_steps()` instead of `run()`:
+
+```python
+intermediates = pipe.run_steps(df)
+
+for name, step_df in intermediates.items():
+    print(f"{name:20s} -> {step_df.shape[0]:>6} rows x {step_df.shape[1]} cols")
 ```
 
 ---
 
 ## Results
 
-| Output | Description | Use case |
-|--------|-------------|----------|
-| `steps` | Setpoint change events with magnitude | Recipe tracking |
+| `result.events` key | Description | Use case |
+|---------------------|-------------|----------|
+| `setpoint_steps` | Setpoint change events with magnitude | Recipe tracking |
 | `settling` | Time-to-settle per setpoint change | Tuning assessment |
-| `overshoot` | Overshoot % per change | Control quality |
+| `overshoot` | Overshoot / undershoot metrics per change | Control quality |
 | `startups` | Equipment startup intervals | Startup optimization |
-| `steady_intervals` | Steady-state vs transient periods | Process efficiency |
-| `integrals` | IAE/ISE/ITAE per window | Loop performance KPIs |
-| `oscillation` | Oscillation detection events | Tuning issues |
-| `scores` | 0-100 stability score per shift | Daily process health |
+| `steady_intervals` / `transients` | Steady-state vs dynamic periods | Process efficiency |
+| `error_integrals` | IAE/ISE/ITAE per window | Loop performance KPIs |
+| `oscillation` / `saturation` | Oscillation and valve-saturation events | Tuning issues |
+| `loop_health` | Shift-level loop report card | Daily loop health |
+| `stability_scores` / `stability_trend` / `worst_periods` | 0-100 stability score, trend, worst windows | Daily process health |
 
 ---
 

--- a/docs/pipelines/quality-spc.md
+++ b/docs/pipelines/quality-spc.md
@@ -1,6 +1,6 @@
 # Quality & SPC Pipeline
 
-> From Azure Blob measurement data to outlier detection, SPC rule checks, tolerance analysis, and capability trending (Cp/Cpk).
+> From Azure Blob measurement data to outlier detection, SPC rule checks, tolerance analysis, and capability trending — in one reusable `Pipeline`.
 
 **Signals needed:**
 
@@ -10,255 +10,232 @@
 | Upper spec limit | `temperature_usl` | `value_double` | Upper specification limit (or provide as fixed value) |
 | Lower spec limit | `temperature_lsl` | `value_double` | Lower specification limit (or provide as fixed value) |
 
-**Modules used:** [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [SignalQualityEvents](../reference/ts_shape/events/quality/signal_quality.md) | [DoubleFilter](../reference/ts_shape/transform/filter/numeric_filter.md) | [OutlierDetectionEvents](../reference/ts_shape/events/quality/outlier_detection.md) | [StatisticalProcessControlRuleBased](../reference/ts_shape/events/quality/statistical_process_control.md) | [ToleranceDeviationEvents](../reference/ts_shape/events/quality/tolerance_deviation.md) | [CapabilityTrendingEvents](../reference/ts_shape/events/quality/capability_trending.md)
+**Modules used:** [Pipeline](../reference/ts_shape/pipeline.md) | [AzureBlobParquetLoader](../reference/ts_shape/loader/timeseries/azure_blob_loader.md) | [MetadataJsonLoader](../reference/ts_shape/loader/metadata/metadata_json_loader.md) | [ContextEnricher](../reference/ts_shape/loader/context/context_enricher.md) | [DataHarmonizer](../reference/ts_shape/transform/harmonization.md) | [DoubleFilter](../reference/ts_shape/transform/filter/numeric_filter.md) | [SignalQualityEvents](../reference/ts_shape/events/quality/signal_quality.md) | [OutlierDetectionEvents](../reference/ts_shape/events/quality/outlier_detection.md) | [StatisticalProcessControlRuleBased](../reference/ts_shape/events/quality/statistical_process_control.md) | [ToleranceDeviationEvents](../reference/ts_shape/events/quality/tolerance_deviation.md) | [CapabilityTrendingEvents](../reference/ts_shape/events/quality/capability_trending.md)
 
 ---
 
 ## Prerequisites
 
 ```python
+# -- The only things you customize --
 AZURE_CONNECTION = "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=..."
 CONTAINER = "timeseries-data"
 
-# Measurement signal + spec limits
 UUID_LIST = [
     "temperature_actual",   # double: process measurement
     "temperature_usl",      # double: upper spec limit (if stored as signal)
     "temperature_lsl",      # double: lower spec limit (if stored as signal)
 ]
 
-# Or use fixed spec limits instead of UUID signals:
-UPPER_SPEC = 105.0   # engineering specification
-LOWER_SPEC = 95.0
-
 START = "2024-06-01"
 END   = "2024-06-08"
 
 METADATA_PATH = "config/signal_metadata.json"
+
+UPPER_SPEC = 105.0   # engineering specification
+LOWER_SPEC = 95.0
 ```
+
+!!! info "New to `Pipeline`?"
+    Read the [Pipeline guide](../guides/pipeline-builder.md) first — it explains
+    `.transform` vs `.detect` steps and the debugging tools used below.
 
 ---
 
-## Step 1: Load Data from Azure
+## Step 1: Load the data
+
+The Azure loader produces the DataFrame the pipeline runs on, so it stays
+outside the pipeline. Metadata is loaded the same way.
 
 ```python
 from ts_shape.loader.timeseries.azure_blob_loader import AzureBlobParquetLoader
+from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
 
 loader = AzureBlobParquetLoader(
     connection_string=AZURE_CONNECTION,
     container_name=CONTAINER,
 )
-
 df = loader.load_files_by_time_range_and_uuids(
     start_timestamp=START,
     end_timestamp=END,
     uuid_list=UUID_LIST,
 )
 
+meta_df = MetadataJsonLoader.from_file(METADATA_PATH).to_df()
+
 print(f"Loaded {len(df):,} rows, {df['uuid'].nunique()} signals")
 ```
 
 ---
 
-## Step 2: Enrich with Metadata & Tolerances
+## Step 2: Build the pipeline
+
+One `Pipeline` captures the whole workflow. `.transform` steps clean the
+signal; every `.detect` step branches off a quality table.
 
 ```python
-from ts_shape.loader.metadata.metadata_json_loader import MetadataJsonLoader
+from ts_shape import Pipeline
 from ts_shape.loader.context.context_enricher import ContextEnricher
-
-meta = MetadataJsonLoader.from_file(METADATA_PATH)
-enricher = ContextEnricher(df)
-
-# Add signal descriptions and units
-df = enricher.enrich_with_metadata(meta.to_df(), columns=["description", "unit"])
-
-# If tolerances are in metadata, add them directly
-# enricher = ContextEnricher(df)
-# df = enricher.enrich_with_tolerances(
-#     tolerance_df,
-#     low_col="low_limit",
-#     high_col="high_limit",
-# )
-```
-
----
-
-## Step 3: Validate Signal Quality
-
-```python
-from ts_shape.events.quality.signal_quality import SignalQualityEvents
-
-sq = SignalQualityEvents(df, signal_uuid="temperature_actual")
-
-# Check for missing data
-missing = sq.detect_missing_data(expected_freq="1s", tolerance_factor=2.0)
-print(f"Data gaps found: {len(missing)}")
-if not missing.empty:
-    print(missing[["start", "end", "gap_duration"]].head())
-
-# Check sampling regularity
-regularity = sq.sampling_regularity(window="1h")
-print(regularity.head())
-
-# Check data completeness
-completeness = sq.data_completeness(expected_freq="1s", window="1h")
-print(f"Average completeness: {completeness['completeness_pct'].mean():.1f}%")
-```
-
-!!! warning "Low completeness = unreliable SPC"
-    If completeness drops below 90%, SPC calculations become unreliable. Investigate data source issues before running control charts.
-
----
-
-## Step 4: Filter and Clean
-
-```python
 from ts_shape.transform.filter.numeric_filter import DoubleFilter
 from ts_shape.transform.harmonization import DataHarmonizer
-
-# Remove NaN values
-df_clean = DoubleFilter.filter_nan_value_double(df, column_name="value_double")
-
-# Detect and fill small gaps
-harmonizer = DataHarmonizer(df_clean, value_column="value_double")
-gaps = harmonizer.detect_gaps(threshold="10s")
-if not gaps.empty:
-    df_clean = harmonizer.fill_gaps(strategy="interpolate", max_gap="30s")
-
-print(f"Clean data: {len(df_clean):,} rows")
-```
-
----
-
-## Step 5: Outlier Detection
-
-```python
+from ts_shape.events.quality.signal_quality import SignalQualityEvents
 from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
-
-detector = OutlierDetectionEvents(
-    df_clean,
-    value_column="value_double",
-    event_uuid="quality:outlier",
+from ts_shape.events.quality.statistical_process_control import (
+    StatisticalProcessControlRuleBased,
 )
-
-# Z-score for normally distributed signals
-outliers_z = detector.detect_outliers_zscore(threshold=3.0)
-print(f"Z-score outliers: {len(outliers_z)}")
-
-# IQR for skewed distributions
-outliers_iqr = detector.detect_outliers_iqr(threshold=(1.5, 1.5))
-print(f"IQR outliers: {len(outliers_iqr)}")
-```
-
-!!! tip "Choose the right detection method"
-    - **Z-score**: Best for normally distributed signals (most process measurements)
-    - **IQR**: Better for skewed data (flow rates, energy consumption)
-    - **MAD**: Robust against extreme outliers (sensor spikes)
-    - **Isolation Forest**: Complex multivariate patterns
-
----
-
-## Step 6: SPC Rule Checks
-
-```python
-from ts_shape.events.quality.statistical_process_control import StatisticalProcessControlRuleBased
-
-spc = StatisticalProcessControlRuleBased(
-    dataframe=df_clean,
-    value_column="value_double",
-    tolerance_uuid="temperature_usl",    # UUID for tolerance signal
-    actual_uuid="temperature_actual",    # UUID for measurement signal
-    event_uuid="quality:spc_violation",
-)
-
-# Calculate control limits
-limits = spc.calculate_control_limits()
-print("Control limits:")
-print(limits)
-
-# Dynamic control limits (adapts over time)
-dynamic_limits = spc.calculate_dynamic_control_limits(
-    method="moving_range",
-    window=20,
-)
-
-# Detect SPC rule violations (Western Electric Rules)
-violations = spc.detect_violations()
-print(f"SPC violations: {len(violations)}")
-if not violations.empty:
-    print(violations[["systime", "value_double", "rule", "severity"]].head())
-```
-
----
-
-## Step 7: Tolerance Deviation Analysis
-
-```python
 from ts_shape.events.quality.tolerance_deviation import ToleranceDeviationEvents
-
-tolerance = ToleranceDeviationEvents(
-    dataframe=df_clean,
-    tolerance_column="value_double",
-    actual_column="value_double",
-    actual_uuid="temperature_actual",
-    event_uuid="quality:tolerance",
-    upper_tolerance_uuid="temperature_usl",
-    lower_tolerance_uuid="temperature_lsl",
-    warning_threshold=0.8,   # warn at 80% of tolerance band
-)
-
-# Detect out-of-tolerance events
-deviations = tolerance.detect_tolerance_deviations()
-print(f"Out-of-tolerance events: {len(deviations)}")
-
-# Process capability indices
-capability = tolerance.calculate_capability()
-print(f"Cp: {capability['Cp']:.3f}, Cpk: {capability['Cpk']:.3f}")
-```
-
----
-
-## Step 8: Capability Trending
-
-```python
 from ts_shape.events.quality.capability_trending import CapabilityTrendingEvents
 
-cap_trend = CapabilityTrendingEvents(
-    dataframe=df_clean,
-    signal_uuid="temperature_actual",
-    upper_spec=UPPER_SPEC,
-    lower_spec=LOWER_SPEC,
+pipe = (
+    Pipeline(name="quality-spc")
+
+    # -- clean the signal --
+    .transform(lambda df: ContextEnricher(df).enrich_with_metadata(
+        meta_df, columns=["description", "unit"]),
+        name="enrich_metadata")
+    .transform(DoubleFilter, "filter_nan_value_double",
+               column_name="value_double")
+    .detect(DataHarmonizer, "detect_gaps", name="gaps", threshold="10s")
+    .transform(DataHarmonizer, "fill_gaps", strategy="interpolate",
+               max_gap="30s")
+
+    # -- signal quality diagnostics --
+    .detect(SignalQualityEvents, "detect_missing_data", name="missing_data",
+            signal_uuid="temperature_actual", expected_freq="1s",
+            tolerance_factor=2.0)
+    .detect(SignalQualityEvents, "sampling_regularity", name="regularity",
+            signal_uuid="temperature_actual", window="1h")
+    .detect(SignalQualityEvents, "data_completeness", name="completeness",
+            signal_uuid="temperature_actual", window="1h", expected_freq="1s")
+
+    # -- outlier detection --
+    .detect(OutlierDetectionEvents, "detect_outliers_zscore",
+            name="outliers_zscore", value_column="value_double", threshold=3.0)
+    .detect(OutlierDetectionEvents, "detect_outliers_iqr",
+            name="outliers_iqr", value_column="value_double",
+            threshold=(1.5, 1.5))
+
+    # -- SPC rule checks --
+    .detect(StatisticalProcessControlRuleBased, "calculate_control_limits",
+            name="control_limits", value_column="value_double",
+            tolerance_uuid="temperature_usl",
+            actual_uuid="temperature_actual", event_uuid="quality:spc")
+    .detect(StatisticalProcessControlRuleBased,
+            "calculate_dynamic_control_limits", name="dynamic_limits",
+            value_column="value_double", tolerance_uuid="temperature_usl",
+            actual_uuid="temperature_actual", event_uuid="quality:spc",
+            window=20)
+    .detect(StatisticalProcessControlRuleBased, "process", name="violations",
+            value_column="value_double", tolerance_uuid="temperature_usl",
+            actual_uuid="temperature_actual", event_uuid="quality:spc",
+            include_severity=True)
+
+    # -- tolerance & capability --
+    .detect(ToleranceDeviationEvents, "process_and_group_data_with_events",
+            name="tolerance_deviations", tolerance_column="value_double",
+            actual_column="value_double", actual_uuid="temperature_actual",
+            event_uuid="quality:tolerance",
+            upper_tolerance_uuid="temperature_usl",
+            lower_tolerance_uuid="temperature_lsl", warning_threshold=0.8)
+    .detect(CapabilityTrendingEvents, "capability_over_time",
+            name="capability_over_time", signal_uuid="temperature_actual",
+            upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC, window="4h")
+    .detect(CapabilityTrendingEvents, "detect_capability_drop",
+            name="capability_drops", signal_uuid="temperature_actual",
+            upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC, window="4h",
+            min_cpk=1.33)
+    .detect(CapabilityTrendingEvents, "capability_forecast",
+            name="capability_forecast", signal_uuid="temperature_actual",
+            upper_spec=UPPER_SPEC, lower_spec=LOWER_SPEC, window="4h",
+            horizon=12, threshold=1.0)
 )
+```
 
-# Cp/Cpk over rolling time windows
-capability_over_time = cap_trend.capability_over_time(window="4h")
-print(capability_over_time.head())
+Each detector's constructor and method keyword arguments are passed flat —
+the pipeline routes them by name. The SPC `process` step applies the Western
+Electric rules; `include_severity=True` adds the `rule` and `severity` columns.
 
-# Alert on capability drops
-drops = cap_trend.detect_capability_drop(threshold=1.33, window="4h")
-print(f"Capability drops (Cpk < 1.33): {len(drops)}")
+!!! tip "Choose the right outlier method"
+    - **Z-score**: normally distributed signals (most process measurements)
+    - **IQR**: skewed data (flow rates, energy consumption)
 
-# Forecast: when will Cpk breach threshold?
-forecast = cap_trend.capability_forecast(
-    threshold=1.0,
-    window="4h",
-    horizon_windows=12,
-)
-print(forecast)
+!!! warning "Low completeness = unreliable SPC"
+    Inspect the `completeness` result first. If completeness drops below 90%,
+    SPC calculations become unreliable — investigate the data source before
+    trusting the control charts.
+
+---
+
+## Step 3: Preview with `describe()`
+
+```python
+print(pipe.describe())
+```
+
+```
+Pipeline 'quality-spc' (16 steps):
+  0. [transform] enrich_metadata
+  1. [transform] filter_nan_value_double  column_name='value_double'
+  2. [detect   ] gaps  threshold='10s'
+  3. [transform] fill_gaps  strategy='interpolate', max_gap='30s'
+  4. [detect   ] missing_data  signal_uuid='temperature_actual', expected_freq='1s', tolerance_factor=2.0
+  5. [detect   ] regularity  signal_uuid='temperature_actual', window='1h'
+  6. [detect   ] completeness  signal_uuid='temperature_actual', window='1h', expected_freq='1s'
+  7. [detect   ] outliers_zscore  value_column='value_double', threshold=3.0
+  8. [detect   ] outliers_iqr  value_column='value_double', threshold=(1.5, 1.5)
+  9. [detect   ] control_limits  value_column='value_double', tolerance_uuid='temperature_usl', actual_uuid='temperature_actual', event_uuid='quality:spc'
+  10. [detect   ] dynamic_limits  value_column='value_double', tolerance_uuid='temperature_usl', actual_uuid='temperature_actual', event_uuid='quality:spc', window=20
+  11. [detect   ] violations  value_column='value_double', tolerance_uuid='temperature_usl', actual_uuid='temperature_actual', event_uuid='quality:spc', include_severity=True
+  12. [detect   ] tolerance_deviations  tolerance_column='value_double', actual_column='value_double', actual_uuid='temperature_actual', event_uuid='quality:tolerance', upper_tolerance_uuid='temperature_usl', lower_tolerance_uuid='temperature_lsl', warning_threshold=0.8
+  13. [detect   ] capability_over_time  signal_uuid='temperature_actual', upper_spec=105.0, lower_spec=95.0, window='4h'
+  14. [detect   ] capability_drops  signal_uuid='temperature_actual', upper_spec=105.0, lower_spec=95.0, window='4h', min_cpk=1.33
+  15. [detect   ] capability_forecast  signal_uuid='temperature_actual', upper_spec=105.0, lower_spec=95.0, window='4h', horizon=12, threshold=1.0
+```
+
+---
+
+## Step 4: Run
+
+```python
+result = pipe.run(df)          # reusable — call .run() on any DataFrame
+
+print(f"Z-score outliers: {len(result.events['outliers_zscore'])}")
+print(f"SPC violations:   {len(result.events['violations'])}")
+
+print(result.events["capability_over_time"])   # Cp/Cpk per 4h window
+print(result.events["capability_drops"])       # windows with Cpk < 1.33
+```
+
+`result.data` holds the cleaned signal after `fill_gaps`; every quality table
+is keyed by its step name in `result.events`.
+
+---
+
+## Step 5: Debug with `run_steps()`
+
+To inspect every intermediate DataFrame, use `run_steps()` instead of `run()`:
+
+```python
+intermediates = pipe.run_steps(df)
+
+for name, step_df in intermediates.items():
+    print(f"{name:22s} -> {step_df.shape[0]:>6} rows x {step_df.shape[1]} cols")
 ```
 
 ---
 
 ## Results
 
-| Output | Description | Use case |
-|--------|-------------|----------|
-| `outliers_z` / `outliers_iqr` | Detected outlier events | Immediate investigation |
+| `result.events` key | Description | Use case |
+|---------------------|-------------|----------|
+| `outliers_zscore` / `outliers_iqr` | Detected outlier events | Immediate investigation |
 | `violations` | SPC rule violations (Western Electric) | Control chart alerts |
-| `deviations` | Out-of-tolerance measurements | Quality escape prevention |
+| `control_limits` / `dynamic_limits` | Static and adaptive control limits | Control charts |
+| `tolerance_deviations` | Out-of-tolerance measurements | Quality escape prevention |
 | `capability_over_time` | Cp/Cpk per window | Capability monitoring |
-| `drops` | Capability degradation alerts | Predictive quality |
-| `forecast` | Cpk trend extrapolation | Maintenance planning |
+| `capability_drops` | Capability degradation alerts | Predictive quality |
+| `capability_forecast` | Cpk trend extrapolation | Maintenance planning |
+| `missing_data` / `regularity` / `completeness` | Signal quality diagnostics | Data trust check |
 
 ---
 


### PR DESCRIPTION
Rewrite the five domain pipeline guides (OEE, cycle time, downtime,
quality/SPC, process engineering) around a single reusable Pipeline
object, matching feature-pipeline.md. Each doc now loads data once, then
builds one declarative .transform/.detect chain previewed with
describe() and executed with run().

Drop method calls that return dicts or lists instead of DataFrames
(state_quality_metrics, get_extraction_stats, identify_golden_cycles,
calculate_capability, steady_state_statistics), since they cannot be
Pipeline steps. Also correct several stale keyword arguments the old
step-by-step docs passed to detector methods.

https://claude.ai/code/session_01DKN7tKKpspZE7s6k3DL9pL