### PR TITLE
Make Azure Blob parquet loader warn on empty results

### DIFF
--- a/src/ts_shape/errors.py
+++ b/src/ts_shape/errors.py
@@ -25,6 +25,10 @@ class DataQualityWarning(TsShapeWarning):
     """Warn about potential data quality issues (gaps, duplicates, NaNs)."""
 
 
+class LoaderConfigWarning(TsShapeWarning):
+    """Warn when a loader returns no data, likely due to misconfiguration."""
+
+
 class ColumnNotFoundError(ValueError):
     """Raised when a required column is missing from the DataFrame.
 

--- a/src/ts_shape/loader/timeseries/azure_blob_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_loader.py
@@ -187,23 +187,40 @@ class AzureBlobParquetLoader:
             if any(u in name for u in uuids):
                 yield name
 
-    def _download_parquet(self, blob_name: str) -> Optional[pd.DataFrame]:
+    def _download_parquet(
+        self,
+        blob_name: str,
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
+    ) -> Optional[pd.DataFrame]:
         """
         Download a parquet blob and return a DataFrame. Returns None if not found.
+
+        ``columns`` and ``filters`` are pushed into ``pd.read_parquet`` so only
+        the requested columns / rows are parsed. Both default to ``None``,
+        which reads the full blob.
         """
         try:
             downloader = self.container_client.download_blob(blob_name)
             data = downloader.readall()
-            return pd.read_parquet(BytesIO(data))
+            return pd.read_parquet(BytesIO(data), columns=columns, filters=filters)
         except Exception as exc:
             logger.debug("Failed to download blob '%s': %s", blob_name, exc)
             return None
 
     def _download_many(
-        self, blob_names: List[str]
+        self,
+        blob_names: List[str],
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
     ) -> Tuple[List[pd.DataFrame], int, int]:
         """
         Download a set of parquet blobs concurrently.
+
+        ``columns``/``filters`` are forwarded to :meth:`_download_parquet` for
+        column projection and row predicate pushdown. If ``columns`` names a
+        field absent from a blob the parquet engine raises, so that blob is
+        counted in ``n_failed``.
 
         Returns:
             A tuple ``(frames, n_failed, n_empty)`` where ``frames`` are the
@@ -216,7 +233,7 @@ class AzureBlobParquetLoader:
         n_empty = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_to_name = {
-                executor.submit(self._download_parquet, name): name
+                executor.submit(self._download_parquet, name, columns, filters): name
                 for name in blob_names
             }
             for future in as_completed(future_to_name):
@@ -229,10 +246,14 @@ class AzureBlobParquetLoader:
                     frames.append(df)
         return frames, n_failed, n_empty
 
-    def _warn_empty(self, method: str, detail: str) -> None:
+    def _warn_empty(
+        self, method: str, detail: str, filters: Optional[list] = None
+    ) -> None:
         """
         Emit a ``LoaderConfigWarning`` explaining why a load returned no data.
         """
+        if filters is not None:
+            detail = f"{detail} The filters argument may be too strict."
         warnings.warn(
             f"AzureBlobParquetLoader.{method} returned an empty DataFrame. {detail}",
             LoaderConfigWarning,
@@ -282,9 +303,18 @@ class AzureBlobParquetLoader:
         )
         return f"{base}{sub}"
 
-    def load_all_files(self) -> pd.DataFrame:
+    def load_all_files(
+        self,
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
+    ) -> pd.DataFrame:
         """
         Load all parquet blobs in the container (optionally under `prefix`).
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
 
         Returns:
             A concatenated DataFrame of all parquet blobs. Returns an empty DataFrame
@@ -305,7 +335,7 @@ class AzureBlobParquetLoader:
             )
             return pd.DataFrame()
 
-        frames, n_failed, n_empty = self._download_many(blob_names)
+        frames, n_failed, n_empty = self._download_many(blob_names, columns, filters)
         if not frames:
             self._warn_empty(
                 "load_all_files",
@@ -313,18 +343,28 @@ class AzureBlobParquetLoader:
                 f"{prefix_repr} but none yielded rows ({n_failed} failed to "
                 f"download/parse, {n_empty} had no rows). Check that the "
                 "credentials have read permission and the files are valid parquet.",
+                filters=filters,
             )
             return pd.DataFrame()
         return pd.concat(frames, ignore_index=True)
 
     def load_by_time_range(
-        self, start_timestamp: str | pd.Timestamp, end_timestamp: str | pd.Timestamp
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
     ) -> pd.DataFrame:
         """
         Load all parquet blobs under hourly folders within [start, end].
 
         Assumes container structure: prefix/year/month/day/hour/{file}.parquet
         Listing is constrained per-hour for speed.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
         """
         slots = list(self._hourly_slots(start_timestamp, end_timestamp))
         hour_prefixes = [self._hour_prefix(ts) for ts in slots]
@@ -343,24 +383,34 @@ class AzureBlobParquetLoader:
             )
             return pd.DataFrame()
 
-        frames, n_failed, n_empty = self._download_many(blob_names)
+        frames, n_failed, n_empty = self._download_many(blob_names, columns, filters)
         if not frames:
             self._warn_empty(
                 "load_by_time_range",
                 f"Listed {len(blob_names)} .parquet blob(s) but none yielded "
                 f"rows ({n_failed} failed to download/parse, {n_empty} had no "
                 f"rows). {search}. Check read permission and file validity.",
+                filters=filters,
             )
             return pd.DataFrame()
         return pd.concat(frames, ignore_index=True)
 
     def stream_by_time_range(
-        self, start_timestamp: str | pd.Timestamp, end_timestamp: str | pd.Timestamp
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
     ) -> Iterator[Tuple[str, pd.DataFrame]]:
         """
         Stream parquet DataFrames under hourly folders within [start, end].
 
         Yields (blob_name, DataFrame) one by one to avoid holding everything in memory.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
         """
         slots = list(self._hourly_slots(start_timestamp, end_timestamp))
         hour_prefixes = [self._hour_prefix(ts) for ts in slots]
@@ -381,7 +431,9 @@ class AzureBlobParquetLoader:
             try:
                 while len(futures) < self.max_workers:
                     n = next(names_iter)
-                    futures[executor.submit(self._download_parquet, n)] = n
+                    futures[
+                        executor.submit(self._download_parquet, n, columns, filters)
+                    ] = n
             except StopIteration:
                 pass
 
@@ -401,7 +453,9 @@ class AzureBlobParquetLoader:
                 try:
                     while len(futures) < self.max_workers:
                         n = next(names_iter)
-                        futures[executor.submit(self._download_parquet, n)] = n
+                        futures[
+                            executor.submit(self._download_parquet, n, columns, filters)
+                        ] = n
                 except StopIteration:
                     pass
 
@@ -411,6 +465,7 @@ class AzureBlobParquetLoader:
                 f"Yielded no DataFrames. {self._time_search_detail(slots)}. "
                 "Check that hour_pattern matches the real folder layout and "
                 "that the time range overlaps the stored data.",
+                filters=filters,
             )
 
     def load_files_by_time_range_and_uuids(
@@ -418,6 +473,8 @@ class AzureBlobParquetLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         uuid_list: List[str],
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
     ) -> pd.DataFrame:
         """
         Load parquet blobs for given UUIDs within [start, end] hours.
@@ -430,6 +487,11 @@ class AzureBlobParquetLoader:
            permission) fall back to constructing direct blob paths assuming
            the pattern prefix/YYYY/MM/DD/HH/{uuid}.parquet and downloading
            those blindly.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
         """
         if not uuid_list:
             return pd.DataFrame()
@@ -498,7 +560,9 @@ class AzureBlobParquetLoader:
             )
             return pd.DataFrame()
 
-        frames, n_failed, n_empty = self._download_many(all_blob_names)
+        frames, n_failed, n_empty = self._download_many(
+            all_blob_names, columns, filters
+        )
         if not frames:
             self._warn_empty(
                 "load_files_by_time_range_and_uuids",
@@ -506,6 +570,7 @@ class AzureBlobParquetLoader:
                 f"rows ({n_failed} failed to download/parse, {n_empty} had no "
                 f"rows). {search}, {uuid_note}. Check read permission and file "
                 f"validity.{fallback_note}",
+                filters=filters,
             )
             return pd.DataFrame()
         return pd.concat(frames, ignore_index=True)
@@ -515,6 +580,8 @@ class AzureBlobParquetLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         uuid_list: List[str],
+        columns: Optional[List[str]] = None,
+        filters: Optional[list] = None,
     ) -> Iterator[Tuple[str, pd.DataFrame]]:
         """
         Stream parquet DataFrames for given UUIDs within [start, end] hours.
@@ -522,6 +589,11 @@ class AzureBlobParquetLoader:
         Yields (blob_name, DataFrame) as they arrive. Listing is authoritative
         when available; direct blob names are used only as a fallback when
         listing fails (see :meth:`load_files_by_time_range_and_uuids`).
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
         """
         if not uuid_list:
             return
@@ -580,7 +652,9 @@ class AzureBlobParquetLoader:
             try:
                 while len(futures) < self.max_workers:
                     n = next(names_iter)
-                    futures[executor.submit(self._download_parquet, n)] = n
+                    futures[
+                        executor.submit(self._download_parquet, n, columns, filters)
+                    ] = n
             except StopIteration:
                 pass
 
@@ -598,7 +672,9 @@ class AzureBlobParquetLoader:
                 try:
                     while len(futures) < self.max_workers:
                         n = next(names_iter)
-                        futures[executor.submit(self._download_parquet, n)] = n
+                        futures[
+                            executor.submit(self._download_parquet, n, columns, filters)
+                        ] = n
                 except StopIteration:
                     pass
 
@@ -609,6 +685,7 @@ class AzureBlobParquetLoader:
                 f"{len(variants_ordered)} UUID variant(s) searched. Check that "
                 "the UUIDs, hour_pattern and time range match the stored "
                 f"data.{fallback_note}",
+                filters=filters,
             )
 
     def list_structure(

--- a/src/ts_shape/loader/timeseries/azure_blob_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_loader.py
@@ -2,8 +2,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
 from typing import Iterable, List, Optional, Set, Dict, Any, Callable, Iterator, Tuple
 import logging
+import warnings
 
 import pandas as pd  # type: ignore
+
+from ts_shape.errors import LoaderConfigWarning
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +199,62 @@ class AzureBlobParquetLoader:
             logger.debug("Failed to download blob '%s': %s", blob_name, exc)
             return None
 
+    def _download_many(
+        self, blob_names: List[str]
+    ) -> Tuple[List[pd.DataFrame], int, int]:
+        """
+        Download a set of parquet blobs concurrently.
+
+        Returns:
+            A tuple ``(frames, n_failed, n_empty)`` where ``frames`` are the
+            non-empty DataFrames, ``n_failed`` counts blobs that could not be
+            downloaded or parsed (missing, unauthorized, or corrupt), and
+            ``n_empty`` counts blobs that parsed successfully but had no rows.
+        """
+        frames: List[pd.DataFrame] = []
+        n_failed = 0
+        n_empty = 0
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            future_to_name = {
+                executor.submit(self._download_parquet, name): name
+                for name in blob_names
+            }
+            for future in as_completed(future_to_name):
+                df = future.result()
+                if df is None:
+                    n_failed += 1
+                elif df.empty:
+                    n_empty += 1
+                else:
+                    frames.append(df)
+        return frames, n_failed, n_empty
+
+    def _warn_empty(self, method: str, detail: str) -> None:
+        """
+        Emit a ``LoaderConfigWarning`` explaining why a load returned no data.
+        """
+        warnings.warn(
+            f"AzureBlobParquetLoader.{method} returned an empty DataFrame. {detail}",
+            LoaderConfigWarning,
+            stacklevel=3,
+        )
+
+    def _time_search_detail(self, slots: List[pd.Timestamp]) -> str:
+        """Describe the prefix/pattern/hour-range probed by a time-range load."""
+        prefix_repr = repr(self.prefix or "")
+        pattern_repr = repr(self.hour_pattern)
+        if not slots:
+            return (
+                f"prefix={prefix_repr}, hour_pattern={pattern_repr}, "
+                "0 hour-prefixes (the time range is empty)"
+            )
+        first = slots[0].strftime("%Y-%m-%d %H:00")
+        last = slots[-1].strftime("%Y-%m-%d %H:00")
+        return (
+            f"prefix={prefix_repr}, hour_pattern={pattern_repr}, "
+            f"{len(slots)} hour-prefix(es) {first} .. {last}"
+        )
+
     # ---- Helpers for time-structured containers parquet/YYYY/MM/DD/HH ----
     @staticmethod
     def _hourly_slots(
@@ -236,21 +295,27 @@ class AzureBlobParquetLoader:
             name_starts_with=self.prefix or None
         )
         blob_names = [b.name for b in blob_iter if str(b.name).endswith(".parquet")]  # type: ignore[attr-defined]
+        prefix_repr = repr(self.prefix or "")
         if not blob_names:
+            self._warn_empty(
+                "load_all_files",
+                f"No .parquet blobs found under prefix={prefix_repr}. "
+                "Check the container name and prefix; the container may be "
+                "empty or the prefix may not match the stored layout.",
+            )
             return pd.DataFrame()
 
-        frames: List[pd.DataFrame] = []
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_name = {
-                executor.submit(self._download_parquet, name): name
-                for name in blob_names
-            }
-            for future in as_completed(future_to_name):
-                df = future.result()
-                if df is not None and not df.empty:
-                    frames.append(df)
-
-        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        frames, n_failed, n_empty = self._download_many(blob_names)
+        if not frames:
+            self._warn_empty(
+                "load_all_files",
+                f"Listed {len(blob_names)} .parquet blob(s) under prefix="
+                f"{prefix_repr} but none yielded rows ({n_failed} failed to "
+                f"download/parse, {n_empty} had no rows). Check that the "
+                "credentials have read permission and the files are valid parquet.",
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
 
     def load_by_time_range(
         self, start_timestamp: str | pd.Timestamp, end_timestamp: str | pd.Timestamp
@@ -261,30 +326,33 @@ class AzureBlobParquetLoader:
         Assumes container structure: prefix/year/month/day/hour/{file}.parquet
         Listing is constrained per-hour for speed.
         """
-        hour_prefixes = [
-            self._hour_prefix(ts)
-            for ts in self._hourly_slots(start_timestamp, end_timestamp)
-        ]
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        hour_prefixes = [self._hour_prefix(ts) for ts in slots]
         blob_names: List[str] = []
         for pfx in hour_prefixes:
             blob_iter = self.container_client.list_blobs(name_starts_with=pfx)
             blob_names.extend([b.name for b in blob_iter if str(b.name).endswith(".parquet")])  # type: ignore[attr-defined]
 
+        search = self._time_search_detail(slots)
         if not blob_names:
+            self._warn_empty(
+                "load_by_time_range",
+                f"No .parquet blobs found. {search}. Check that hour_pattern "
+                "matches the real folder layout and that the time range "
+                "overlaps the stored data.",
+            )
             return pd.DataFrame()
 
-        frames: List[pd.DataFrame] = []
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_name = {
-                executor.submit(self._download_parquet, name): name
-                for name in blob_names
-            }
-            for future in as_completed(future_to_name):
-                df = future.result()
-                if df is not None and not df.empty:
-                    frames.append(df)
-
-        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        frames, n_failed, n_empty = self._download_many(blob_names)
+        if not frames:
+            self._warn_empty(
+                "load_by_time_range",
+                f"Listed {len(blob_names)} .parquet blob(s) but none yielded "
+                f"rows ({n_failed} failed to download/parse, {n_empty} had no "
+                f"rows). {search}. Check read permission and file validity.",
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
 
     def stream_by_time_range(
         self, start_timestamp: str | pd.Timestamp, end_timestamp: str | pd.Timestamp
@@ -294,10 +362,8 @@ class AzureBlobParquetLoader:
 
         Yields (blob_name, DataFrame) one by one to avoid holding everything in memory.
         """
-        hour_prefixes = [
-            self._hour_prefix(ts)
-            for ts in self._hourly_slots(start_timestamp, end_timestamp)
-        ]
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        hour_prefixes = [self._hour_prefix(ts) for ts in slots]
 
         def _names_iter() -> Iterator[str]:
             for pfx in hour_prefixes:
@@ -308,6 +374,7 @@ class AzureBlobParquetLoader:
                         yield name
 
         names_iter = _names_iter()
+        yielded = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures: Dict[Any, str] = {}
             # initial fill
@@ -327,6 +394,7 @@ class AzureBlobParquetLoader:
                     except Exception:
                         df = None
                     if df is not None and not df.empty:
+                        yielded += 1
                         yield (name, df)
 
                 # Refill
@@ -336,6 +404,14 @@ class AzureBlobParquetLoader:
                         futures[executor.submit(self._download_parquet, n)] = n
                 except StopIteration:
                     pass
+
+        if yielded == 0:
+            self._warn_empty(
+                "stream_by_time_range",
+                f"Yielded no DataFrames. {self._time_search_detail(slots)}. "
+                "Check that hour_pattern matches the real folder layout and "
+                "that the time range overlaps the stored data.",
+            )
 
     def load_files_by_time_range_and_uuids(
         self,
@@ -347,11 +423,13 @@ class AzureBlobParquetLoader:
         Load parquet blobs for given UUIDs within [start, end] hours.
 
         Strategy:
-        1) Construct direct blob paths assuming pattern prefix/YYYY/MM/DD/HH/{uuid}.parquet
-           (fast path, no listing).
-        2) For robustness, also list each hour prefix and include any blob whose basename
-           equals one of the requested UUID variants (handles case differences and extra
-           subfolders below the hour level).
+        1) List each hour prefix once and keep blobs whose basename matches a
+           requested UUID variant. When listing succeeds it is authoritative,
+           so only blobs that actually exist are downloaded.
+        2) Only when listing fails entirely (e.g. a SAS token without list
+           permission) fall back to constructing direct blob paths assuming
+           the pattern prefix/YYYY/MM/DD/HH/{uuid}.parquet and downloading
+           those blindly.
         """
         if not uuid_list:
             return pd.DataFrame()
@@ -371,19 +449,13 @@ class AzureBlobParquetLoader:
                     seen.add(v)
                     variants_ordered.append(v)
 
-        hour_prefixes = [
-            self._hour_prefix(ts)
-            for ts in self._hourly_slots(start_timestamp, end_timestamp)
-        ]
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        hour_prefixes = [self._hour_prefix(ts) for ts in slots]
 
-        # 1) Fast path: build direct blob names
-        direct_names = [
-            f"{pfx}{u}.parquet" for pfx in hour_prefixes for u in variants_ordered
-        ]
-
-        # 2) Robust path: list each hour prefix and filter by basename match
+        # 1) Authoritative path: list each hour prefix, match by basename.
         basenames = {f"{u}.parquet" for u in variants_ordered}
         listed_names: List[str] = []
+        listing_failed = False
         try:
             for pfx in hour_prefixes:
                 blob_iter = self.container_client.list_blobs(name_starts_with=pfx)
@@ -395,27 +467,48 @@ class AzureBlobParquetLoader:
                     if base in basenames:
                         listed_names.append(name)
         except Exception:
-            # If listing fails for any reason, continue with direct names only
-            pass
+            # Listing not permitted/available: fall back to blind direct names.
+            listing_failed = True
 
-        # Merge and preserve order, avoid duplicates
-        all_blob_names = list(dict.fromkeys([*direct_names, *listed_names]))
+        if listing_failed:
+            # 2) Fallback only: construct direct blob names and download blindly.
+            all_blob_names = list(
+                dict.fromkeys(
+                    f"{pfx}{u}.parquet"
+                    for pfx in hour_prefixes
+                    for u in variants_ordered
+                )
+            )
+            fallback_note = (
+                " Listing was not available, so direct blob names were "
+                "downloaded blindly; verify the credentials' list permission."
+            )
+        else:
+            all_blob_names = list(dict.fromkeys(listed_names))
+            fallback_note = ""
 
+        search = self._time_search_detail(slots)
+        uuid_note = f"{len(variants_ordered)} UUID variant(s) searched"
         if not all_blob_names:
+            self._warn_empty(
+                "load_files_by_time_range_and_uuids",
+                f"No matching .parquet blobs found. {search}, {uuid_note}. "
+                "Check that the UUIDs, hour_pattern and time range match the "
+                f"stored data.{fallback_note}",
+            )
             return pd.DataFrame()
 
-        frames: List[pd.DataFrame] = []
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_name = {
-                executor.submit(self._download_parquet, name): name
-                for name in all_blob_names
-            }
-            for future in as_completed(future_to_name):
-                df = future.result()
-                if df is not None and not df.empty:
-                    frames.append(df)
-
-        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        frames, n_failed, n_empty = self._download_many(all_blob_names)
+        if not frames:
+            self._warn_empty(
+                "load_files_by_time_range_and_uuids",
+                f"Resolved {len(all_blob_names)} blob name(s) but none yielded "
+                f"rows ({n_failed} failed to download/parse, {n_empty} had no "
+                f"rows). {search}, {uuid_note}. Check read permission and file "
+                f"validity.{fallback_note}",
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
 
     def stream_files_by_time_range_and_uuids(
         self,
@@ -426,10 +519,12 @@ class AzureBlobParquetLoader:
         """
         Stream parquet DataFrames for given UUIDs within [start, end] hours.
 
-        Yields (blob_name, DataFrame) as they arrive. Uses direct names plus per-hour listing fallback.
+        Yields (blob_name, DataFrame) as they arrive. Listing is authoritative
+        when available; direct blob names are used only as a fallback when
+        listing fails (see :meth:`load_files_by_time_range_and_uuids`).
         """
         if not uuid_list:
-            return iter(())
+            return
 
         def _clean_uuid(u: object) -> str:
             return str(u).strip().strip("{}").strip()
@@ -443,23 +538,13 @@ class AzureBlobParquetLoader:
                     seen.add(v)
                     variants_ordered.append(v)
 
-        hour_prefixes = [
-            self._hour_prefix(ts)
-            for ts in self._hourly_slots(start_timestamp, end_timestamp)
-        ]
-        direct_names = [
-            f"{pfx}{u}.parquet" for pfx in hour_prefixes for u in variants_ordered
-        ]
-
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        hour_prefixes = [self._hour_prefix(ts) for ts in slots]
         basenames = {f"{u}.parquet" for u in variants_ordered}
 
-        def _names_iter() -> Iterator[str]:
-            # yield direct first
-            yielded: Set[str] = set()
-            for n in direct_names:
-                yielded.add(n)
-                yield n
-            # then list per-hour
+        listed_names: List[str] = []
+        listing_failed = False
+        try:
             for pfx in hour_prefixes:
                 blob_iter = self.container_client.list_blobs(name_starts_with=pfx)
                 for b in blob_iter:  # type: ignore[attr-defined]
@@ -467,11 +552,29 @@ class AzureBlobParquetLoader:
                     if not name.endswith(".parquet"):
                         continue
                     base = name.rsplit("/", 1)[-1]
-                    if base in basenames and name not in yielded:
-                        yielded.add(name)
-                        yield name
+                    if base in basenames:
+                        listed_names.append(name)
+        except Exception:
+            listing_failed = True
 
-        names_iter = _names_iter()
+        if listing_failed:
+            all_blob_names = list(
+                dict.fromkeys(
+                    f"{pfx}{u}.parquet"
+                    for pfx in hour_prefixes
+                    for u in variants_ordered
+                )
+            )
+            fallback_note = (
+                " Listing was not available, so direct blob names were "
+                "downloaded blindly; verify the credentials' list permission."
+            )
+        else:
+            all_blob_names = list(dict.fromkeys(listed_names))
+            fallback_note = ""
+
+        names_iter = iter(all_blob_names)
+        yielded = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures: Dict[Any, str] = {}
             try:
@@ -489,6 +592,7 @@ class AzureBlobParquetLoader:
                     except Exception:
                         df = None
                     if df is not None and not df.empty:
+                        yielded += 1
                         yield (name, df)
 
                 try:
@@ -497,6 +601,15 @@ class AzureBlobParquetLoader:
                         futures[executor.submit(self._download_parquet, n)] = n
                 except StopIteration:
                     pass
+
+        if yielded == 0:
+            self._warn_empty(
+                "stream_files_by_time_range_and_uuids",
+                f"Yielded no DataFrames. {self._time_search_detail(slots)}, "
+                f"{len(variants_ordered)} UUID variant(s) searched. Check that "
+                "the UUIDs, hour_pattern and time range match the stored "
+                f"data.{fallback_note}",
+            )
 
     def list_structure(
         self, parquet_only: bool = True, limit: Optional[int] = None

--- a/tests/test_azure_blob_loader.py
+++ b/tests/test_azure_blob_loader.py
@@ -15,7 +15,7 @@ def _make_loader_without_init(prefix="", files=None):
     # Bypass __init__ to avoid importing azure-storage-blob
     loader = object.__new__(AzureBlobParquetLoader)
 
-    # Fake container_client with list_blobs
+    # Fake container_client with list_blobs and download_blob
     class DummyClient:
         def __init__(self, names):
             self._names = names or []
@@ -29,6 +29,11 @@ def _make_loader_without_init(prefix="", files=None):
             ]
             # Yield objects with a .name attribute
             return [SimpleNamespace(name=n) for n in ns]
+
+        def download_blob(self, name):
+            # A stub downloader exposing readall(); the actual bytes are
+            # irrelevant because pushdown tests monkeypatch pd.read_parquet.
+            return SimpleNamespace(readall=lambda: b"")
 
     loader.container_client = DummyClient(files or [])
     loader.prefix = prefix
@@ -80,7 +85,9 @@ def test_list_structure_and_load_all(monkeypatch):
 
     # Patch download to return frames with some rows
     monkeypatch.setattr(
-        loader, "_download_parquet", lambda name: pd.DataFrame({"name": [name]})
+        loader,
+        "_download_parquet",
+        lambda name, *a, **k: pd.DataFrame({"name": [name]}),
     )
 
     listed = loader.list_structure()
@@ -103,7 +110,9 @@ def test_load_by_time_range_and_uuid(monkeypatch):
     monkeypatch.setattr(
         loader,
         "_download_parquet",
-        lambda name: pd.DataFrame({"uuid": [name.split("/")[-1].split(".")[0]]}),
+        lambda name, *a, **k: pd.DataFrame(
+            {"uuid": [name.split("/")[-1].split(".")[0]]}
+        ),
     )
 
     df1 = loader.load_by_time_range("2024-01-01 09:00:00", "2024-01-01 10:30:00")
@@ -176,7 +185,7 @@ def test_load_all_files_all_downloads_fail_warns(monkeypatch):
         "parquet/2024/01/01/10/u2.parquet",
     ]
     loader = _make_loader_without_init(prefix="parquet/", files=files)
-    monkeypatch.setattr(loader, "_download_parquet", lambda name: None)
+    monkeypatch.setattr(loader, "_download_parquet", lambda name, *a, **k: None)
     with pytest.warns(LoaderConfigWarning, match="failed to download"):
         df = loader.load_all_files()
     assert df.empty
@@ -186,7 +195,9 @@ def test_load_all_files_happy_emits_no_warning(monkeypatch):
     files = ["parquet/2024/01/01/09/u1.parquet"]
     loader = _make_loader_without_init(prefix="parquet/", files=files)
     monkeypatch.setattr(
-        loader, "_download_parquet", lambda name: pd.DataFrame({"name": [name]})
+        loader,
+        "_download_parquet",
+        lambda name, *a, **k: pd.DataFrame({"name": [name]}),
     )
     with warnings.catch_warnings():
         warnings.simplefilter("error", LoaderConfigWarning)
@@ -209,7 +220,7 @@ def test_load_files_by_uuids_unknown_warns_and_skips_downloads(monkeypatch):
     loader = _make_loader_without_init(prefix="parquet/", files=files)
     calls: list[str] = []
     monkeypatch.setattr(
-        loader, "_download_parquet", lambda name: calls.append(name) or None
+        loader, "_download_parquet", lambda name, *a, **k: calls.append(name) or None
     )
     with pytest.warns(LoaderConfigWarning, match="No matching .parquet blobs"):
         df = loader.load_files_by_time_range_and_uuids(
@@ -229,7 +240,7 @@ def test_load_files_by_uuids_falls_back_when_listing_fails(monkeypatch):
 
     calls: list[str] = []
 
-    def fake_download(name):
+    def fake_download(name, *a, **k):
         calls.append(name)
         if name == "parquet/2024/01/01/09/u1.parquet":
             return pd.DataFrame({"uuid": ["u1"]})
@@ -254,3 +265,52 @@ def test_stream_by_time_range_empty_warns():
             loader.stream_by_time_range("2030-01-01 00:00:00", "2030-01-01 00:00:00")
         )
     assert results == []
+
+
+def test_pushdown_passes_columns_and_filters(monkeypatch):
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    seen: dict = {}
+
+    def fake_read_parquet(buf, columns=None, filters=None):
+        seen["columns"] = columns
+        seen["filters"] = filters
+        return pd.DataFrame({"uuid": ["u1"]})
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read_parquet)
+    df = loader.load_all_files(columns=["uuid"], filters=[("uuid", "==", "u1")])
+    assert not df.empty
+    assert seen["columns"] == ["uuid"]
+    assert seen["filters"] == [("uuid", "==", "u1")]
+
+
+def test_pushdown_defaults_none_backwards_compatible(monkeypatch):
+    # A call with no columns/filters must reach pd.read_parquet with None for
+    # both -- byte-for-byte the pre-existing behaviour.
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    seen: dict = {}
+
+    def fake_read_parquet(buf, columns=None, filters=None):
+        seen["columns"] = columns
+        seen["filters"] = filters
+        return pd.DataFrame({"uuid": ["u1"]})
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read_parquet)
+    df = loader.load_all_files()
+    assert not df.empty
+    assert seen["columns"] is None
+    assert seen["filters"] is None
+
+
+def test_filters_too_strict_warning_hint(monkeypatch):
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    monkeypatch.setattr(
+        pd,
+        "read_parquet",
+        lambda buf, columns=None, filters=None: pd.DataFrame(),
+    )
+    with pytest.warns(LoaderConfigWarning, match="filters argument may be too strict"):
+        df = loader.load_all_files(filters=[("value_double", ">", 1e9)])
+    assert df.empty

--- a/tests/test_azure_blob_loader.py
+++ b/tests/test_azure_blob_loader.py
@@ -1,6 +1,10 @@
+import warnings
+
 import pandas as pd  # type: ignore
+import pytest
 from types import SimpleNamespace
 
+from ts_shape.errors import LoaderConfigWarning
 from ts_shape.loader.timeseries.azure_blob_loader import (
     AzureBlobParquetLoader,
     AzureBlobFlexibleFileLoader,
@@ -157,3 +161,96 @@ def test_flexible_fetch_basenames(monkeypatch):
         "root/2024/01/01/09/b/file2.json",
         "root/2024/01/01/10/d/file2.json",
     }
+
+
+def test_load_all_files_empty_warns():
+    loader = _make_loader_without_init(prefix="parquet/", files=[])
+    with pytest.warns(LoaderConfigWarning, match="No .parquet blobs"):
+        df = loader.load_all_files()
+    assert df.empty
+
+
+def test_load_all_files_all_downloads_fail_warns(monkeypatch):
+    files = [
+        "parquet/2024/01/01/09/u1.parquet",
+        "parquet/2024/01/01/10/u2.parquet",
+    ]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    monkeypatch.setattr(loader, "_download_parquet", lambda name: None)
+    with pytest.warns(LoaderConfigWarning, match="failed to download"):
+        df = loader.load_all_files()
+    assert df.empty
+
+
+def test_load_all_files_happy_emits_no_warning(monkeypatch):
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    monkeypatch.setattr(
+        loader, "_download_parquet", lambda name: pd.DataFrame({"name": [name]})
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LoaderConfigWarning)
+        df = loader.load_all_files()
+    assert not df.empty
+
+
+def test_load_by_time_range_outside_data_warns():
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    with pytest.warns(LoaderConfigWarning, match="hour_pattern"):
+        df = loader.load_by_time_range("2030-01-01 00:00:00", "2030-01-01 00:00:00")
+    assert df.empty
+
+
+def test_load_files_by_uuids_unknown_warns_and_skips_downloads(monkeypatch):
+    # An unknown UUID must not trigger blind direct-name downloads when listing
+    # succeeds: the loader should resolve nothing and warn immediately.
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        loader, "_download_parquet", lambda name: calls.append(name) or None
+    )
+    with pytest.warns(LoaderConfigWarning, match="No matching .parquet blobs"):
+        df = loader.load_files_by_time_range_and_uuids(
+            "2024-01-01 09:00:00", "2024-01-01 09:00:00", ["does-not-exist"]
+        )
+    assert df.empty
+    assert calls == []
+
+
+def test_load_files_by_uuids_falls_back_when_listing_fails(monkeypatch):
+    loader = _make_loader_without_init(prefix="parquet/", files=[])
+
+    def boom(name_starts_with=None):
+        raise RuntimeError("no list permission")
+
+    loader.container_client.list_blobs = boom
+
+    calls: list[str] = []
+
+    def fake_download(name):
+        calls.append(name)
+        if name == "parquet/2024/01/01/09/u1.parquet":
+            return pd.DataFrame({"uuid": ["u1"]})
+        return None
+
+    monkeypatch.setattr(loader, "_download_parquet", fake_download)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LoaderConfigWarning)
+        df = loader.load_files_by_time_range_and_uuids(
+            "2024-01-01 09:00:00", "2024-01-01 09:00:00", ["u1"]
+        )
+    # Listing failed, so direct blob names were downloaded blindly.
+    assert set(df["uuid"]) == {"u1"}
+    assert "parquet/2024/01/01/09/u1.parquet" in calls
+
+
+def test_stream_by_time_range_empty_warns():
+    files = ["parquet/2024/01/01/09/u1.parquet"]
+    loader = _make_loader_without_init(prefix="parquet/", files=files)
+    with pytest.warns(LoaderConfigWarning, match="Yielded no DataFrames"):
+        results = list(
+            loader.stream_by_time_range("2030-01-01 00:00:00", "2030-01-01 00:00:00")
+        )
+    assert results == []


### PR DESCRIPTION
AzureBlobParquetLoader previously failed silently: a wrong prefix,
hour_pattern, time range, or credentials surfaced only as an empty
DataFrame with no explanation. Each load method now emits a
LoaderConfigWarning describing what was searched (prefix, hour range,
UUID count) and how many blobs were listed/failed/empty, so a
misconfiguration is diagnosable instead of invisible.

load_files_by_time_range_and_uuids no longer builds the hours x UUIDs
cross product of direct blob names and downloads every one blindly.
Listing is now authoritative when available, so only blobs that exist
are downloaded; direct names are used solely when listing fails (e.g. a
SAS token without list permission). This removes the minutes-long wait
on doomed downloads when settings are wrong.

https://claude.ai/code/session_01VKsnU8jUop9WC9VLGrRT5z