### PR TITLE
ci: add non-blocking deprecation & vulnerability scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests with coverage
+        env:
+          PYTHONDEVMODE: "1"
         run: |
           pytest --cov=ts_shape --cov-report=xml --cov-report=term -v
 
@@ -111,4 +113,68 @@ jobs:
         with:
           name: coverage-report-py${{ matrix.python-version }}
           path: coverage.xml
+          retention-days: 14
+
+  scan:
+    name: Deprecation & vulnerability scan
+    runs-on: ubuntu-latest
+    needs: [pip-compile]
+    if: always() && (needs.pip-compile.result == 'success' || needs.pip-compile.result == 'skipped')
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install package, dev extras, and scan tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" pip-audit
+
+      - name: Capture runtime DeprecationWarnings from tests
+        continue-on-error: true
+        run: |
+          pytest -W error::DeprecationWarning -W error::PendingDeprecationWarning \
+            --tb=line -q 2>&1 | tee deprecation-warnings.txt
+
+      - name: Pyupgrade scan (ruff UP rules, advisory)
+        continue-on-error: true
+        run: |
+          ruff check --select UP src/ tests/ 2>&1 | tee ruff-pyupgrade.txt
+
+      - name: Static @deprecated detection (mypy PEP 702)
+        continue-on-error: true
+        run: |
+          mypy 2>&1 | tee mypy-deprecated.txt
+
+      - name: Vulnerability scan (pip-audit)
+        continue-on-error: true
+        run: |
+          pip-audit --format=json --output pip-audit.json || true
+          pip-audit | tee pip-audit.txt || true
+
+      - name: Outdated dependencies
+        continue-on-error: true
+        run: |
+          pip list --outdated --format=json > outdated.json || true
+          pip list --outdated | tee outdated.txt || true
+
+      - name: Upload scan artefacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: deprecation-scan
+          path: |
+            deprecation-warnings.txt
+            ruff-pyupgrade.txt
+            mypy-deprecated.txt
+            pip-audit.json
+            pip-audit.txt
+            outdated.json
+            outdated.txt
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,15 +142,11 @@ jobs:
           pytest -W error::DeprecationWarning -W error::PendingDeprecationWarning \
             --tb=line -q 2>&1 | tee deprecation-warnings.txt
 
-      - name: Pyupgrade scan (ruff UP rules, advisory)
-        continue-on-error: true
-        run: |
-          ruff check --select UP src/ tests/ 2>&1 | tee ruff-pyupgrade.txt
-
       - name: Static @deprecated detection (mypy PEP 702)
         continue-on-error: true
         run: |
-          mypy 2>&1 | tee mypy-deprecated.txt
+          mypy 2>&1 | tee mypy-full.txt
+          grep '\[deprecated\]' mypy-full.txt | tee mypy-deprecated.txt || true
 
       - name: Vulnerability scan (pip-audit)
         continue-on-error: true
@@ -171,8 +167,8 @@ jobs:
           name: deprecation-scan
           path: |
             deprecation-warnings.txt
-            ruff-pyupgrade.txt
             mypy-deprecated.txt
+            mypy-full.txt
             pip-audit.json
             pip-audit.txt
             outdated.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ target-version = ["py311"]
 [tool.ruff]
 target-version = "py311"
 
+[tool.ruff.lint]
+extend-select = ["UP"]
+
 [tool.mypy]
 python_version = "3.11"
 files = ["src/ts_shape"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ fallback_version = "0.1.0"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"
+filterwarnings = [
+    "default::DeprecationWarning",
+    "default::PendingDeprecationWarning",
+]
 
 [tool.coverage.run]
 source = ["ts_shape"]
@@ -95,3 +99,9 @@ target-version = ["py311"]
 
 [tool.ruff]
 target-version = "py311"
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src/ts_shape"]
+ignore_missing_imports = true
+enable_error_code = ["deprecated"]

--- a/renovate.json
+++ b/renovate.json
@@ -37,10 +37,10 @@
   "python": {
     "fileMatch": ["(^|/)pyproject\\.toml$"]
   },
-  "schedule": ["before 9am on Monday", "before 9am on Thursday"],
+  "schedule": ["before 9am on Friday"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 9am on Monday"]
+    "schedule": ["before 9am on Friday"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -5,15 +5,28 @@
     "Covers pep621, pip_requirements, pip_setup, github-actions, and python-version managers.",
     "To reuse: move this file to a jakobgabriel/renovate-config repo and extend via github>jakobgabriel/renovate-config."
   ],
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    ":enableVulnerabilityAlertsWithLabel(security)",
+    "security:openssf-scorecard"
+  ],
   "dependencyDashboard": true,
   "osvVulnerabilityAlerts": true,
+  "transitiveRemediation": true,
+  "rangeStrategy": "bump",
   "minimumReleaseAge": "3 days",
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 10,
   "assignees": ["jakobgabriel"],
   "commitMessagePrefix": "chore(deps):",
   "platformAutomerge": true,
   "automergeType": "pr",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": true,
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days",
+    "schedule": ["at any time"]
+  },
   "enabledManagers": [
     "pep621",
     "pip_requirements",
@@ -79,11 +92,12 @@
       "labels": ["major-update"]
     },
     {
-      "description": "Vulnerability fixes bypass schedule and get security label",
+      "description": "Vulnerability fixes bypass schedule and auto-merge with security label",
       "matchCategories": ["security"],
       "schedule": ["at any time"],
       "labels": ["security"],
-      "automerge": false
+      "automerge": true,
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Pin and auto-update GitHub Actions by SHA digest",
@@ -92,6 +106,12 @@
       "automerge": true,
       "groupName": "github actions",
       "labels": ["ci"]
+    },
+    {
+      "description": "Tag non-zerover stable releases with deprecation-watch so they show up in the dashboard for review",
+      "matchUpdateTypes": ["minor", "patch", "major"],
+      "matchCurrentVersion": "!/^0/",
+      "addLabels": ["deprecation-watch"]
     }
   ]
 }

--- a/scripts/scan_deprecations.sh
+++ b/scripts/scan_deprecations.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -u
+
+pip install -e ".[dev]" pip-audit >/dev/null
+
+echo "== pytest deprecations =="
+pytest -W error::DeprecationWarning -W error::PendingDeprecationWarning --tb=line -q || true
+
+echo
+echo "== ruff pyupgrade (UP) =="
+ruff check --select UP src/ tests/ || true
+
+echo
+echo "== mypy @deprecated (PEP 702) =="
+mypy || true
+
+echo
+echo "== pip-audit =="
+pip-audit || true
+
+echo
+echo "== outdated packages =="
+pip list --outdated || true

--- a/scripts/scan_deprecations.sh
+++ b/scripts/scan_deprecations.sh
@@ -7,12 +7,8 @@ echo "== pytest deprecations =="
 pytest -W error::DeprecationWarning -W error::PendingDeprecationWarning --tb=line -q || true
 
 echo
-echo "== ruff pyupgrade (UP) =="
-ruff check --select UP src/ tests/ || true
-
-echo
 echo "== mypy @deprecated (PEP 702) =="
-mypy || true
+mypy 2>&1 | tee /tmp/mypy-full.txt | grep '\[deprecated\]' || echo "(none)"
 
 echo
 echo "== pip-audit =="

--- a/src/ts_shape/catalog.py
+++ b/src/ts_shape/catalog.py
@@ -9,7 +9,6 @@ loaders from a REPL or notebook instead of scanning the docs::
 
 from __future__ import annotations
 
-from typing import Optional
 
 import pandas as pd  # type: ignore
 

--- a/src/ts_shape/catalog.py
+++ b/src/ts_shape/catalog.py
@@ -27,7 +27,7 @@ def _category_for(module: str) -> str:
     return parts[1] if len(parts) > 1 else module
 
 
-def list_detectors(category: Optional[str] = None) -> pd.DataFrame:
+def list_detectors(category: str | None = None) -> pd.DataFrame:
     """Return a catalog of ts-shape's top-level public classes.
 
     Args:

--- a/src/ts_shape/datasets.py
+++ b/src/ts_shape/datasets.py
@@ -12,7 +12,7 @@ transform, or statistic can be exercised without real data or loaders::
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore

--- a/src/ts_shape/datasets.py
+++ b/src/ts_shape/datasets.py
@@ -31,7 +31,7 @@ def make_timeseries(
     drift: float = 0.0,
     n_outliers: int = 0,
     value_column: str = "value_double",
-    seed: Optional[int] = 42,
+    seed: int | None = 42,
 ) -> pd.DataFrame:
     """Generate a standard-schema synthetic timeseries DataFrame.
 

--- a/src/ts_shape/eventlog/adapters.py
+++ b/src/ts_shape/eventlog/adapters.py
@@ -12,7 +12,7 @@ for the few detectors whose legacy schema does not fit any standard shape.
 from __future__ import annotations
 
 import uuid as _uuid
-from typing import Callable, Mapping
+from collections.abc import Callable, Mapping
 
 import pandas as pd
 

--- a/src/ts_shape/eventlog/lambda_rules/backtest.py
+++ b/src/ts_shape/eventlog/lambda_rules/backtest.py
@@ -11,7 +11,7 @@ domain-specific drill-down).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping
+from collections.abc import Mapping
 
 import pandas as pd
 

--- a/src/ts_shape/eventlog/lambda_rules/detector.py
+++ b/src/ts_shape/eventlog/lambda_rules/detector.py
@@ -14,7 +14,7 @@ at registration time, ``to_event_log`` finds it without any new code path.
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 import pandas as pd
 

--- a/src/ts_shape/eventlog/lambda_rules/expression.py
+++ b/src/ts_shape/eventlog/lambda_rules/expression.py
@@ -24,7 +24,7 @@ Why an AST whitelist over ``pandas.eval`` or ``polars.expr``?
 from __future__ import annotations
 
 import ast
-from typing import Callable
+from collections.abc import Callable
 
 import pandas as pd
 

--- a/src/ts_shape/eventlog/lambda_rules/loader.py
+++ b/src/ts_shape/eventlog/lambda_rules/loader.py
@@ -18,7 +18,8 @@ lambda rules do not need a real Python class on disk.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any
+from collections.abc import Iterable, Mapping
 
 from ..archetypes import ARCHETYPE_BY_METHOD
 from ..schema import STANDARD_ATTR_KEYS

--- a/src/ts_shape/eventlog/lambda_rules/spec.py
+++ b/src/ts_shape/eventlog/lambda_rules/spec.py
@@ -15,7 +15,7 @@ understands without any special-case code.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping
+from collections.abc import Mapping
 
 _VALID_SHAPES: frozenset[str] = frozenset({"point", "interval", "summary", "static"})
 _VALID_PACKS: frozenset[str] = frozenset(

--- a/src/ts_shape/eventlog/model.py
+++ b/src/ts_shape/eventlog/model.py
@@ -35,7 +35,7 @@ class EventLog:
             f"objects={len(self.objects)}, relations={len(self.relations)})"
         )
 
-    def filter_by_pack(self, pack: str) -> "EventLog":
+    def filter_by_pack(self, pack: str) -> EventLog:
         events = self.events[self.events[schema.TS_PACK] == pack]
         eids = set(events[schema.OCEL_EID])
         relations = self.relations[self.relations[schema.OCEL_EID].isin(eids)]
@@ -55,7 +55,7 @@ class EventLog:
             relations.reset_index(drop=True),
         )
 
-    def filter_by_object(self, oid: str, type_: str | None = None) -> "EventLog":
+    def filter_by_object(self, oid: str, type_: str | None = None) -> EventLog:
         rel = self.relations
         mask = rel[schema.OCEL_OID] == oid
         if type_ is not None:

--- a/src/ts_shape/eventlog/normalizer.py
+++ b/src/ts_shape/eventlog/normalizer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 import pandas as pd
 

--- a/src/ts_shape/eventlog/schema.py
+++ b/src/ts_shape/eventlog/schema.py
@@ -186,7 +186,7 @@ def empty_relations() -> pd.DataFrame:
 # ---- Validation -------------------------------------------------------------
 
 
-def validate(eventlog: "EventLog") -> None:
+def validate(eventlog: EventLog) -> None:
     """Raise ``ValueError`` if the event log violates the canonical schema."""
     events, objects, relations = eventlog.events, eventlog.objects, eventlog.relations
 

--- a/src/ts_shape/eventlog/taxonomy.py
+++ b/src/ts_shape/eventlog/taxonomy.py
@@ -26,7 +26,7 @@ A :class:`LabelRule` describes:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping
+from collections.abc import Mapping
 
 
 @dataclass(frozen=True)

--- a/src/ts_shape/events/_output.py
+++ b/src/ts_shape/events/_output.py
@@ -17,7 +17,8 @@ the same column names regardless of detector pack or method.
 
 from __future__ import annotations
 
-from typing import Iterable, Literal, Sequence
+from typing import Literal
+from collections.abc import Iterable, Sequence
 
 import pandas as pd  # type: ignore
 

--- a/src/ts_shape/events/correlation/anomaly_correlation.py
+++ b/src/ts_shape/events/correlation/anomaly_correlation.py
@@ -66,7 +66,7 @@ class AnomalyCorrelationEvents(Base):
 
     def coincident_anomalies(
         self,
-        signal_uuids: List[str],
+        signal_uuids: list[str],
         *,
         z_threshold: float = 3.0,
         coincidence_window: str = "5min",
@@ -106,7 +106,7 @@ class AnomalyCorrelationEvents(Base):
         combined = combined.sort_values(self.time_column)
 
         window_td = pd.to_timedelta(coincidence_window)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         processed = set()
 
         for i, row in combined.iterrows():
@@ -178,7 +178,7 @@ class AnomalyCorrelationEvents(Base):
             )
 
         max_delay_td = pd.to_timedelta(max_delay)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         used_followers = set()
 
         for _, lrow in leader_anom.iterrows():
@@ -209,7 +209,7 @@ class AnomalyCorrelationEvents(Base):
 
     def root_cause_ranking(
         self,
-        signal_uuids: List[str],
+        signal_uuids: list[str],
         *,
         z_threshold: float = 3.0,
         max_delay: str = "10min",
@@ -240,8 +240,8 @@ class AnomalyCorrelationEvents(Base):
                 ]
             )
 
-        leader_counts: Dict[str, int] = {uid: 0 for uid in signal_uuids}
-        follower_counts: Dict[str, int] = {uid: 0 for uid in signal_uuids}
+        leader_counts: dict[str, int] = {uid: 0 for uid in signal_uuids}
+        follower_counts: dict[str, int] = {uid: 0 for uid in signal_uuids}
 
         for i, uid_a in enumerate(signal_uuids):
             for uid_b in signal_uuids[i + 1 :]:

--- a/src/ts_shape/events/correlation/anomaly_correlation.py
+++ b/src/ts_shape/events/correlation/anomaly_correlation.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/correlation/signal_correlation.py
+++ b/src/ts_shape/events/correlation/signal_correlation.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/correlation/signal_correlation.py
+++ b/src/ts_shape/events/correlation/signal_correlation.py
@@ -157,7 +157,7 @@ class SignalCorrelationEvents(Base):
         corr_df["group"] = (corr_df["below"] != corr_df["below"].shift()).cumsum()
 
         breakdowns = corr_df[corr_df["below"]].groupby("group")
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, grp in breakdowns:
             rows.append(
                 {
@@ -205,7 +205,7 @@ class SignalCorrelationEvents(Base):
         b = aligned["signal_b"].values
         n = len(a)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for lag in range(-max_lag, max_lag + 1):
             if lag < 0:
                 corr = np.corrcoef(a[:lag], b[-lag:])[0, 1]

--- a/src/ts_shape/events/energy/carbon_intensity.py
+++ b/src/ts_shape/events/energy/carbon_intensity.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Dict, Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/energy/carbon_intensity.py
+++ b/src/ts_shape/events/energy/carbon_intensity.py
@@ -49,9 +49,9 @@ class CarbonIntensityEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        emission_factors: Dict[str, float],
+        emission_factors: dict[str, float],
         *,
-        scope_map: Optional[Dict[str, int]] = None,
+        scope_map: dict[str, int] | None = None,
         event_uuid: str = "energy:carbon",
         time_column: str = "systime",
         uuid_column: str = "uuid",

--- a/src/ts_shape/events/energy/consumption_analysis.py
+++ b/src/ts_shape/events/energy/consumption_analysis.py
@@ -54,7 +54,7 @@ class EnergyConsumptionEvents(Base):
         series_id: str,
         time_column: str = "time",
         value_column: str = "value",
-        id_column: Optional[str] = None,
+        id_column: str | None = None,
     ) -> pd.DataFrame:
         """Convert a raw energy DataFrame to the standard ts-shape schema.
 
@@ -144,7 +144,7 @@ class EnergyConsumptionEvents(Base):
         *,
         value_column: str = "value_double",
         window: str = "15min",
-        threshold: Optional[float] = None,
+        threshold: float | None = None,
         percentile: float = 0.95,
     ) -> pd.DataFrame:
         """Detect peak demand periods exceeding a threshold.

--- a/src/ts_shape/events/energy/consumption_analysis.py
+++ b/src/ts_shape/events/energy/consumption_analysis.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/energy/efficiency_tracking.py
+++ b/src/ts_shape/events/energy/efficiency_tracking.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Dict, Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/energy/efficiency_tracking.py
+++ b/src/ts_shape/events/energy/efficiency_tracking.py
@@ -53,7 +53,7 @@ class EnergyEfficiencyEvents(Base):
         series_id: str,
         time_column: str = "time",
         value_column: str = "value",
-        id_column: Optional[str] = None,
+        id_column: str | None = None,
     ) -> pd.DataFrame:
         """Convert a raw energy DataFrame to the standard ts-shape schema.
 
@@ -405,7 +405,7 @@ class EnergyEfficiencyEvents(Base):
         *,
         energy_column: str = "value_double",
         counter_column: str = "value_integer",
-        shift_definitions: Optional[Dict[str, tuple]] = None,
+        shift_definitions: dict[str, tuple] | None = None,
     ) -> pd.DataFrame:
         """Compare energy efficiency across shifts.
 

--- a/src/ts_shape/events/energy/energy_performance_indicator.py
+++ b/src/ts_shape/events/energy/energy_performance_indicator.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/energy/energy_performance_indicator.py
+++ b/src/ts_shape/events/energy/energy_performance_indicator.py
@@ -166,7 +166,7 @@ class EnergyPerformanceIndicatorEvents(Base):
 
     def enpi_by_hierarchy(
         self,
-        meter_uuids: List[str],
+        meter_uuids: list[str],
         counter_uuid: str,
         *,
         energy_column: str = "value_double",

--- a/src/ts_shape/events/energy/idle_energy_detection.py
+++ b/src/ts_shape/events/energy/idle_energy_detection.py
@@ -7,7 +7,7 @@ from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_SHIFTS: Dict[str, Tuple[str, str]] = {
+_DEFAULT_SHIFTS: dict[str, tuple[str, str]] = {
     "shift_1": ("06:00", "14:00"),
     "shift_2": ("14:00", "22:00"),
     "shift_3": ("22:00", "06:00"),
@@ -132,7 +132,7 @@ class IdleEnergyDetectionEvents(Base):
         *,
         energy_column: str = "value_double",
         state_column: str = "value_bool",
-        shift_definitions: Optional[Dict[str, Tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> pd.DataFrame:
         """Aggregate idle energy waste per shift across all dates.
 

--- a/src/ts_shape/events/energy/idle_energy_detection.py
+++ b/src/ts_shape/events/energy/idle_energy_detection.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Dict, Optional, Tuple
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/control_loop_health.py
+++ b/src/ts_shape/events/engineering/control_loop_health.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/control_loop_health.py
+++ b/src/ts_shape/events/engineering/control_loop_health.py
@@ -28,7 +28,7 @@ class ControlLoopHealthEvents(Base):
         setpoint_uuid: str,
         actual_uuid: str,
         *,
-        output_uuid: Optional[str] = None,
+        output_uuid: str | None = None,
         event_uuid: str = "eng:control_loop_health",
         value_column: str = "value_double",
         time_column: str = "systime",
@@ -92,7 +92,7 @@ class ControlLoopHealthEvents(Base):
         df = self._aligned.set_index(self.time_column)
         groups = df.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             if len(group) < 2:
                 continue
@@ -151,7 +151,7 @@ class ControlLoopHealthEvents(Base):
         td = pd.Timedelta(window)
         groups = df.resample(window)
 
-        osc_windows: List[Dict[str, Any]] = []
+        osc_windows: list[dict[str, Any]] = []
         for start, group in groups:
             if len(group) < 4:
                 continue
@@ -206,7 +206,7 @@ class ControlLoopHealthEvents(Base):
             return pd.DataFrame(columns=cols)
 
         # Merge contiguous oscillating windows
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         current = osc_windows[0].copy()
         for i in range(1, len(osc_windows)):
             w = osc_windows[i]
@@ -253,7 +253,7 @@ class ControlLoopHealthEvents(Base):
         groups = out.resample(window)
         tol = (high_limit - low_limit) * 0.01  # 1% of range
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             if group.empty:
                 continue
@@ -308,7 +308,7 @@ class ControlLoopHealthEvents(Base):
         osc = self.detect_oscillation()
         sat = self.output_saturation(window=window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, row in integrals.iterrows():
             ws = row["start"]
             we = ws + pd.Timedelta(window)

--- a/src/ts_shape/events/engineering/disturbance_recovery.py
+++ b/src/ts_shape/events/engineering/disturbance_recovery.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/disturbance_recovery.py
+++ b/src/ts_shape/events/engineering/disturbance_recovery.py
@@ -26,7 +26,7 @@ class DisturbanceRecoveryEvents(Base):
         dataframe: pd.DataFrame,
         signal_uuid: str,
         *,
-        setpoint_uuid: Optional[str] = None,
+        setpoint_uuid: str | None = None,
         event_uuid: str = "eng:disturbance_recovery",
         value_column: str = "value_double",
         time_column: str = "systime",
@@ -142,7 +142,7 @@ class DisturbanceRecoveryEvents(Base):
         min_td = pd.Timedelta(min_duration)
         groups = (exceeded != exceeded.shift()).cumsum()
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, seg_idx in exceeded.groupby(groups):
             if not seg_idx.iloc[0]:
                 continue
@@ -227,7 +227,7 @@ class DisturbanceRecoveryEvents(Base):
         max_td = pd.Timedelta(max_recovery)
         recovery_threshold = 1.0 - recovery_pct
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, dist in disturbances.iterrows():
             d_start = dist["start"]
             d_end = dist["end"]
@@ -312,7 +312,7 @@ class DisturbanceRecoveryEvents(Base):
         windows = pd.date_range(start=t_min, end=t_max, freq=window)
         window_td = pd.Timedelta(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ws in windows:
             we = ws + window_td
             if not disturbances.empty:
@@ -381,7 +381,7 @@ class DisturbanceRecoveryEvents(Base):
         sig = self.signal.set_index(self.time_column)[self.value_column]
         comp_td = pd.Timedelta(comparison_window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, dist in disturbances.iterrows():
             d_start = dist["start"]
             d_end = dist["end"]

--- a/src/ts_shape/events/engineering/material_balance.py
+++ b/src/ts_shape/events/engineering/material_balance.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/material_balance.py
+++ b/src/ts_shape/events/engineering/material_balance.py
@@ -24,8 +24,8 @@ class MaterialBalanceEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        input_uuids: List[str],
-        output_uuids: List[str],
+        input_uuids: list[str],
+        output_uuids: list[str],
         *,
         event_uuid: str = "eng:material_balance",
         value_column: str = "value_double",
@@ -42,9 +42,9 @@ class MaterialBalanceEvents(Base):
             self.dataframe[self.time_column]
         )
 
-    def _resample_signals(self, uuids: List[str], window: str) -> pd.DataFrame:
+    def _resample_signals(self, uuids: list[str], window: str) -> pd.DataFrame:
         """Resample each UUID to window and return sum per window."""
-        frames: List[pd.Series] = []
+        frames: list[pd.Series] = []
         for uid in uuids:
             sig = self.dataframe[self.dataframe["uuid"] == uid]
             if sig.empty:
@@ -190,7 +190,7 @@ class MaterialBalanceEvents(Base):
         min_td = pd.Timedelta(min_duration)
 
         groups = (unbalanced != unbalanced.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for _, seg_idx in unbalanced.groupby(groups):
             if not seg_idx.iloc[0]:
@@ -243,7 +243,7 @@ class MaterialBalanceEvents(Base):
         if inputs.empty and outputs.empty:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         if not inputs.empty:
             for ws in inputs.index:

--- a/src/ts_shape/events/engineering/operating_range.py
+++ b/src/ts_shape/events/engineering/operating_range.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/operating_range.py
+++ b/src/ts_shape/events/engineering/operating_range.py
@@ -65,7 +65,7 @@ class OperatingRangeEvents(Base):
         indexed = self.signal.set_index(self.time_column)[self.value_column]
         groups = indexed.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             if group.empty:
                 continue
@@ -117,7 +117,7 @@ class OperatingRangeEvents(Base):
         indexed = self.signal.set_index(self.time_column)[self.value_column]
         groups = indexed.resample(window)
 
-        window_stats: List[Dict[str, Any]] = []
+        window_stats: list[dict[str, Any]] = []
         for start, group in groups:
             vals = group.dropna()
             if len(vals) < 2:
@@ -133,7 +133,7 @@ class OperatingRangeEvents(Base):
         if len(window_stats) < 2:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i in range(1, len(window_stats)):
             prev = window_stats[i - 1]
             curr = window_stats[i]
@@ -175,7 +175,7 @@ class OperatingRangeEvents(Base):
         indexed = self.signal.set_index(self.time_column)[self.value_column]
         groups = indexed.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             vals = group.dropna()
             if vals.empty:
@@ -213,7 +213,7 @@ class OperatingRangeEvents(Base):
         counts, bin_edges = np.histogram(vals, bins=n_bins)
         total = int(counts.sum())
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         cum = 0
         for i in range(len(counts)):
             c = int(counts[i])

--- a/src/ts_shape/events/engineering/process_stability_index.py
+++ b/src/ts_shape/events/engineering/process_stability_index.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/process_stability_index.py
+++ b/src/ts_shape/events/engineering/process_stability_index.py
@@ -26,9 +26,9 @@ class ProcessStabilityIndex(Base):
         dataframe: pd.DataFrame,
         signal_uuid: str,
         *,
-        target: Optional[float] = None,
-        lower_spec: Optional[float] = None,
-        upper_spec: Optional[float] = None,
+        target: float | None = None,
+        lower_spec: float | None = None,
+        upper_spec: float | None = None,
         event_uuid: str = "eng:stability_index",
         value_column: str = "value_double",
         time_column: str = "systime",
@@ -96,7 +96,7 @@ class ProcessStabilityIndex(Base):
         spec_range = self.upper_spec - self.lower_spec
         half_range = spec_range / 2.0 if spec_range > 0 else 1.0
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             vals = group.dropna()
             if len(vals) < 2:

--- a/src/ts_shape/events/engineering/process_window.py
+++ b/src/ts_shape/events/engineering/process_window.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/process_window.py
+++ b/src/ts_shape/events/engineering/process_window.py
@@ -68,7 +68,7 @@ class ProcessWindowEvents(Base):
         indexed = self.signal.set_index(self.time_column)[self.value_column]
         groups = indexed.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             vals = group.dropna()
             if vals.empty:
@@ -116,7 +116,7 @@ class ProcessWindowEvents(Base):
         if len(stats) < 2:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i in range(1, len(stats)):
             prev = stats.iloc[i - 1]
             curr = stats.iloc[i]
@@ -164,7 +164,7 @@ class ProcessWindowEvents(Base):
         if len(stats) < 2:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i in range(1, len(stats)):
             prev = stats.iloc[i - 1]
             curr = stats.iloc[i]

--- a/src/ts_shape/events/engineering/rate_of_change.py
+++ b/src/ts_shape/events/engineering/rate_of_change.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/rate_of_change.py
+++ b/src/ts_shape/events/engineering/rate_of_change.py
@@ -76,7 +76,7 @@ class RateOfChangeEvents(Base):
             return pd.DataFrame(columns=cols)
 
         groups = (rapid != rapid.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for _, seg in rate_df.groupby(groups):
             seg_rapid = rapid.loc[seg.index]
@@ -158,7 +158,7 @@ class RateOfChangeEvents(Base):
         )
         max_td = pd.to_timedelta(max_duration)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         values = sig[self.value_column].values
         times = sig[self.time_column].values
 

--- a/src/ts_shape/events/engineering/setpoint_events.py
+++ b/src/ts_shape/events/engineering/setpoint_events.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/setpoint_events.py
+++ b/src/ts_shape/events/engineering/setpoint_events.py
@@ -42,7 +42,7 @@ class SetpointChangeEvents(Base):
         self.sp[self.time_column] = pd.to_datetime(self.sp[self.time_column])
 
         # Cache for performance optimization
-        self._actual_cache: Dict[str, pd.DataFrame] = {}
+        self._actual_cache: dict[str, pd.DataFrame] = {}
 
     def _get_actual(self, actual_uuid: str) -> pd.DataFrame:
         """
@@ -123,7 +123,7 @@ class SetpointChangeEvents(Base):
         ) | next_change_times.isna()
         valid_change_times = change_times[hold_ok]
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for t in valid_change_times:
             row = sp.loc[sp[self.time_column] == t].iloc[0]
             rows.append(
@@ -172,7 +172,7 @@ class SetpointChangeEvents(Base):
 
         # group contiguous True segments
         group_id = (rate_mask != rate_mask.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         min_d = pd.to_timedelta(min_duration)
         for gid, seg in sp.groupby(group_id):
             seg_mask_true = rate_mask.loc[seg.index]
@@ -203,7 +203,7 @@ class SetpointChangeEvents(Base):
         self,
         *,
         min_delta: float = 0.0,
-        min_rate: Optional[float] = None,
+        min_rate: float | None = None,
         min_hold: str = "0s",
         min_duration: str = "0s",
     ) -> pd.DataFrame:
@@ -286,7 +286,7 @@ class SetpointChangeEvents(Base):
         actual_uuid: str,
         *,
         tol: float = 0.0,
-        settle_pct: Optional[float] = None,
+        settle_pct: float | None = None,
         hold: str = "0s",
         lookahead: str = "10m",
     ) -> pd.DataFrame:
@@ -322,7 +322,7 @@ class SetpointChangeEvents(Base):
             sp["delta"].abs() > 0, [self.time_column, self.value_column, "delta"]
         ].reset_index(drop=True)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, c in change_times.iterrows():
             t0 = c[self.time_column]
             s_new = float(c[self.value_column])
@@ -431,7 +431,7 @@ class SetpointChangeEvents(Base):
             [self.time_column, self.value_column, "delta", "prev"],
         ]
 
-        out_rows: List[Dict[str, Any]] = []
+        out_rows: list[dict[str, Any]] = []
         for _, r in changes.iterrows():
             t0 = r[self.time_column]
             s_new = float(r[self.value_column])
@@ -592,7 +592,7 @@ class SetpointChangeEvents(Base):
             sp["delta"].abs() > 0, [self.time_column, self.value_column]
         ].reset_index(drop=True)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, c in change_times.iterrows():
             t0 = c[self.time_column]
             window = actual[
@@ -711,7 +711,7 @@ class SetpointChangeEvents(Base):
             [self.time_column, self.value_column, "delta", "prev"],
         ].reset_index(drop=True)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, c in changes.iterrows():
             t0 = c[self.time_column]
             s_new = float(c[self.value_column])
@@ -817,7 +817,7 @@ class SetpointChangeEvents(Base):
             sp["delta"].abs() > 0, [self.time_column, self.value_column]
         ].reset_index(drop=True)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, c in changes.iterrows():
             t0 = c[self.time_column]
             s_new = float(c[self.value_column])
@@ -937,7 +937,7 @@ class SetpointChangeEvents(Base):
             sp["delta"].abs() > 0, [self.time_column, self.value_column]
         ].reset_index(drop=True)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, c in changes.iterrows():
             t0 = c[self.time_column]
             s_new = float(c[self.value_column])
@@ -1018,7 +1018,7 @@ class SetpointChangeEvents(Base):
         actual_uuid: str,
         *,
         tol: float = 0.0,
-        settle_pct: Optional[float] = None,
+        settle_pct: float | None = None,
         hold: str = "0s",
         lookahead: str = "10m",
         rate_threshold: float = 0.01,
@@ -1095,7 +1095,7 @@ class SetpointChangeEvents(Base):
             sp["delta"].abs() > 0, [self.time_column, self.value_column]
         ].reset_index(drop=True)
 
-        ss_error_rows: List[Dict[str, Any]] = []
+        ss_error_rows: list[dict[str, Any]] = []
         for _, c in changes.iterrows():
             t0 = c[self.time_column]
             s_new = float(c[self.value_column])

--- a/src/ts_shape/events/engineering/signal_comparison.py
+++ b/src/ts_shape/events/engineering/signal_comparison.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/signal_comparison.py
+++ b/src/ts_shape/events/engineering/signal_comparison.py
@@ -110,7 +110,7 @@ class SignalComparisonEvents(Base):
 
         min_td = pd.Timedelta(min_duration)
         groups = (exceeded != exceeded.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for _, seg in merged.groupby(groups):
             seg_exc = exceeded.loc[seg.index]
@@ -153,7 +153,7 @@ class SignalComparisonEvents(Base):
         indexed = merged.set_index(self.time_column)
         groups = indexed.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             if group.empty:
                 continue
@@ -215,7 +215,7 @@ class SignalComparisonEvents(Base):
         indexed = merged.set_index(self.time_column)
         groups = indexed.resample(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for start, group in groups:
             if len(group) < 2:
                 continue

--- a/src/ts_shape/events/engineering/startup_events.py
+++ b/src/ts_shape/events/engineering/startup_events.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/startup_events.py
+++ b/src/ts_shape/events/engineering/startup_events.py
@@ -70,7 +70,7 @@ class StartupDetectionEvents(Base):
         rising = (~above_enter.shift(fill_value=False)) & above_enter
         rise_times = s.loc[rising, self.time_column]
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for t0 in rise_times:
             # ensure dwell above exit threshold for min_above
             win = s[
@@ -128,7 +128,7 @@ class StartupDetectionEvents(Base):
 
         gid = (mask != mask.shift()).cumsum()
         min_d = pd.to_timedelta(min_duration)
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, seg in s.groupby(gid):
             seg_mask = mask.loc[seg.index]
             if not seg_mask.any():
@@ -154,7 +154,7 @@ class StartupDetectionEvents(Base):
 
     def detect_startup_multi_signal(
         self,
-        signals: Dict[str, Dict[str, Any]],
+        signals: dict[str, dict[str, Any]],
         logic: str = "all",
         *,
         time_tolerance: str = "30s",
@@ -177,7 +177,7 @@ class StartupDetectionEvents(Base):
             raise ValueError(f"logic must be 'all' or 'any', got '{logic}'")
 
         # Detect startups for each signal
-        signal_events: Dict[str, pd.DataFrame] = {}
+        signal_events: dict[str, pd.DataFrame] = {}
         for sig_uuid, config in signals.items():
             # Temporarily store original settings
             orig_uuid = self.target_uuid
@@ -343,7 +343,7 @@ class StartupDetectionEvents(Base):
         s = self.series[[self.time_column, self.value_column]].copy()
         s = s.sort_values(self.time_column).reset_index(drop=True)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         # Calculate rolling statistics
         s["rolling_mean"] = (
@@ -535,7 +535,7 @@ class StartupDetectionEvents(Base):
 
     def track_startup_phases(
         self,
-        phases: List[Dict[str, Any]],
+        phases: list[dict[str, Any]],
         *,
         min_phase_duration: str = "5s",
     ) -> pd.DataFrame:
@@ -671,7 +671,7 @@ class StartupDetectionEvents(Base):
 
         return pd.DataFrame(phase_results)
 
-    def _check_phase_condition(self, row: pd.Series, phase: Dict[str, Any]) -> bool:
+    def _check_phase_condition(self, row: pd.Series, phase: dict[str, Any]) -> bool:
         """Helper method to check if a row satisfies a phase condition."""
         condition = phase.get("condition", "threshold")
         value = row[self.value_column]
@@ -698,7 +698,7 @@ class StartupDetectionEvents(Base):
         threshold: float,
         min_rise_duration: str = "5s",
         max_completion_time: str = "5m",
-        completion_threshold: Optional[float] = None,
+        completion_threshold: float | None = None,
         required_stability: str = "10s",
     ) -> pd.DataFrame:
         """
@@ -748,7 +748,7 @@ class StartupDetectionEvents(Base):
         rising = (~above_threshold.shift(fill_value=False)) & above_threshold
         rise_times = s.loc[rising, self.time_column]
 
-        failed_events: List[Dict[str, Any]] = []
+        failed_events: list[dict[str, Any]] = []
 
         for t0 in rise_times:
             # Get data for potential startup period

--- a/src/ts_shape/events/engineering/steady_state_detection.py
+++ b/src/ts_shape/events/engineering/steady_state_detection.py
@@ -50,14 +50,14 @@ class SteadyStateDetectionEvents(Base):
 
     def _intervalize(
         self, mask: pd.Series, min_duration: str = "0s"
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Convert a boolean mask (indexed by timestamp) into intervals."""
         if mask.empty or not mask.any():
             return []
 
         min_td = pd.Timedelta(min_duration)
         groups = (mask != mask.shift()).cumsum()
-        intervals: List[Dict[str, Any]] = []
+        intervals: list[dict[str, Any]] = []
 
         for _, seg in mask.groupby(groups):
             if not seg.iloc[0]:
@@ -106,7 +106,7 @@ class SteadyStateDetectionEvents(Base):
             return pd.DataFrame(columns=cols)
 
         sig = self.signal.set_index(self.time_column)[self.value_column]
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for iv in intervals:
             segment = sig.loc[iv["start"] : iv["end"]]
             events.append(
@@ -156,7 +156,7 @@ class SteadyStateDetectionEvents(Base):
         if not intervals:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for iv in intervals:
             seg_std = rolling_std.loc[iv["start"] : iv["end"]]
             events.append(
@@ -177,7 +177,7 @@ class SteadyStateDetectionEvents(Base):
         window: str = "5m",
         std_threshold: float = 1.0,
         min_duration: str = "10m",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Summary statistics of steady vs transient time.
 
         Returns:

--- a/src/ts_shape/events/engineering/steady_state_detection.py
+++ b/src/ts_shape/events/engineering/steady_state_detection.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/threshold_monitoring.py
+++ b/src/ts_shape/events/engineering/threshold_monitoring.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/threshold_monitoring.py
+++ b/src/ts_shape/events/engineering/threshold_monitoring.py
@@ -43,7 +43,7 @@ class ThresholdMonitoringEvents(Base):
         self.signal[self.time_column] = pd.to_datetime(self.signal[self.time_column])
 
     def multi_level_threshold(
-        self, levels: Dict[str, float], direction: str = "above"
+        self, levels: dict[str, float], direction: str = "above"
     ) -> pd.DataFrame:
         """Detect intervals where signal exceeds configurable threshold levels.
 
@@ -70,7 +70,7 @@ class ThresholdMonitoringEvents(Base):
             levels.items(), key=lambda x: x[1], reverse=(direction == "above")
         )
 
-        all_events: List[Dict[str, Any]] = []
+        all_events: list[dict[str, Any]] = []
 
         for level_name, threshold in sorted_levels:
             if direction == "above":
@@ -134,7 +134,7 @@ class ThresholdMonitoringEvents(Base):
         values = sig[self.value_column].values
         times = sig[self.time_column].values
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         in_alarm = False
         alarm_start = None
         peak = -np.inf
@@ -206,7 +206,7 @@ class ThresholdMonitoringEvents(Base):
             sample_count=("above", "count"),
         )
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, row in resampled.iterrows():
             if row["sample_count"] == 0:
                 continue

--- a/src/ts_shape/events/engineering/warmup_analysis.py
+++ b/src/ts_shape/events/engineering/warmup_analysis.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/engineering/warmup_analysis.py
+++ b/src/ts_shape/events/engineering/warmup_analysis.py
@@ -46,7 +46,7 @@ class WarmUpCoolDownEvents(Base):
 
     def _detect_ramps(
         self, direction: str, min_change: float, min_duration: str = "1m"
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Detect monotonic ramp intervals (rising or falling).
 
         Uses a smoothed diff to identify sustained directional movement.
@@ -72,7 +72,7 @@ class WarmUpCoolDownEvents(Base):
             moving = diff < 0
 
         # Intervalize the boolean mask over the diff indices
-        intervals: List[Dict[str, Any]] = []
+        intervals: list[dict[str, Any]] = []
         in_ramp = False
         start_idx = 0
 
@@ -159,7 +159,7 @@ class WarmUpCoolDownEvents(Base):
         if not ramps:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for r in ramps:
             events.append(
                 {
@@ -207,7 +207,7 @@ class WarmUpCoolDownEvents(Base):
         if not ramps:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for r in ramps:
             events.append(
                 {
@@ -291,7 +291,7 @@ class WarmUpCoolDownEvents(Base):
         if not ramps:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for r in ramps:
             mask = sig[self.time_column] >= r["start"]
             segment = sig[mask].reset_index(drop=True)

--- a/src/ts_shape/events/maintenance/degradation_detection.py
+++ b/src/ts_shape/events/maintenance/degradation_detection.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/maintenance/degradation_detection.py
+++ b/src/ts_shape/events/maintenance/degradation_detection.py
@@ -117,7 +117,7 @@ class DegradationDetectionEvents(Base):
 
         # Group contiguous degrading intervals
         group_id = (degrading != degrading.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for gid, seg in sig.groupby(group_id):
             seg_deg = degrading.loc[seg.index]
             if not seg_deg.iloc[0]:
@@ -212,7 +212,7 @@ class DegradationDetectionEvents(Base):
 
         # Group contiguous exceeded intervals
         group_id = (exceeded != exceeded.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for gid, seg in sig.groupby(group_id):
             seg_exc = exceeded.loc[seg.index]
             if not seg_exc.iloc[0]:
@@ -270,7 +270,7 @@ class DegradationDetectionEvents(Base):
         values = sig[self.value_column].values
         times = sig[self.time_column].values
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         # CUSUM-based approach: track cumulative deviation from running mean
         running_mean = values[0]
@@ -384,7 +384,7 @@ class DegradationDetectionEvents(Base):
             baseline_mean_for_pct = baseline_mean
 
         # Compute rolling metrics
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for i in range(len(sig)):
             t_end = sig[self.time_column].iloc[i]
             t_start = t_end - window_td

--- a/src/ts_shape/events/maintenance/failure_prediction.py
+++ b/src/ts_shape/events/maintenance/failure_prediction.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/maintenance/failure_prediction.py
+++ b/src/ts_shape/events/maintenance/failure_prediction.py
@@ -76,7 +76,7 @@ class FailurePredictionEvents(Base):
             sig[self.time_column] - sig[self.time_column].iloc[0]
         ).dt.total_seconds()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for i in range(len(sig)):
             current_val = float(sig[self.value_column].iloc[i])
             t_now = sig[self.time_column].iloc[i]
@@ -194,7 +194,7 @@ class FailurePredictionEvents(Base):
         t_max = sig[self.time_column].iloc[-1]
         window_starts = pd.date_range(start=t_min, end=t_max, freq=window_td)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         prev_warning_count = 0
         prev_critical_count = 0
 
@@ -265,7 +265,7 @@ class FailurePredictionEvents(Base):
             sig[self.time_column] - sig[self.time_column].iloc[0]
         ).dt.total_seconds()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for i in range(len(sig)):
             current_val = float(sig[self.value_column].iloc[i])
             t_now = sig[self.time_column].iloc[i]

--- a/src/ts_shape/events/maintenance/vibration_analysis.py
+++ b/src/ts_shape/events/maintenance/vibration_analysis.py
@@ -2,7 +2,7 @@ import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
 from scipy.stats import kurtosis  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/maintenance/vibration_analysis.py
+++ b/src/ts_shape/events/maintenance/vibration_analysis.py
@@ -98,7 +98,7 @@ class VibrationAnalysisEvents(Base):
 
         # Group contiguous exceeded intervals
         group_id = (exceeded != exceeded.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for gid, seg in sig.groupby(group_id):
             seg_exc = exceeded.loc[seg.index]
             if not seg_exc.iloc[0]:
@@ -163,7 +163,7 @@ class VibrationAnalysisEvents(Base):
         t_max = sig[self.time_column].iloc[-1]
         window_starts = pd.date_range(start=t_min, end=t_max, freq=window_td)
 
-        amplitudes: List[Dict[str, Any]] = []
+        amplitudes: list[dict[str, Any]] = []
         for ws in window_starts:
             we = ws + window_td
             mask = (sig[self.time_column] >= ws) & (sig[self.time_column] < we)
@@ -181,7 +181,7 @@ class VibrationAnalysisEvents(Base):
         if baseline_amp == 0:
             baseline_amp = np.finfo(float).eps
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for a in amplitudes:
             growth_pct = (a["amplitude"] - baseline_amp) / baseline_amp
             rows.append(
@@ -236,7 +236,7 @@ class VibrationAnalysisEvents(Base):
         t_max = sig[self.time_column].iloc[-1]
         window_starts = pd.date_range(start=t_min, end=t_max, freq=window_td)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for ws in window_starts:
             we = ws + window_td
             mask = (sig[self.time_column] >= ws) & (sig[self.time_column] < we)

--- a/src/ts_shape/events/production/alarm_management.py
+++ b/src/ts_shape/events/production/alarm_management.py
@@ -6,7 +6,7 @@ and standing alarm identification from boolean alarm signals.
 
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/alarm_management.py
+++ b/src/ts_shape/events/production/alarm_management.py
@@ -85,7 +85,7 @@ class AlarmManagementEvents(Base):
         s["state"] = s[self.value_column].fillna(False).astype(bool)
         s["group"] = (s["state"] != s["state"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         groups = list(s.groupby("group"))
         for idx, (_, seg) in enumerate(groups):
             if not seg["state"].iloc[0]:
@@ -247,7 +247,7 @@ class AlarmManagementEvents(Base):
         flagged_times = flagged.index.to_series().reset_index(drop=True)
         transition_counts = flagged.values
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         start = flagged_times.iloc[0]
         max_count = int(transition_counts[0])
 

--- a/src/ts_shape/events/production/batch_tracking.py
+++ b/src/ts_shape/events/production/batch_tracking.py
@@ -6,7 +6,7 @@ compute duration statistics, per-batch yield, and batch transition matrices.
 
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/batch_tracking.py
+++ b/src/ts_shape/events/production/batch_tracking.py
@@ -94,7 +94,7 @@ class BatchTrackingEvents(Base):
         s["batch_id"] = s[self.value_column].fillna("")
         s["group"] = (s["batch_id"] != s["batch_id"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby("group"):
             batch_id = seg["batch_id"].iloc[0]
             if batch_id == "":
@@ -234,7 +234,7 @@ class BatchTrackingEvents(Base):
 
         counter_data[self.time_column] = pd.to_datetime(counter_data[self.time_column])
 
-        quantities: List[int] = []
+        quantities: list[int] = []
         for _, batch_row in batches.iterrows():
             mask = (counter_data[self.time_column] >= batch_row["start"]) & (
                 counter_data[self.time_column] <= batch_row["end"]

--- a/src/ts_shape/events/production/bottleneck_detection.py
+++ b/src/ts_shape/events/production/bottleneck_detection.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/bottleneck_detection.py
+++ b/src/ts_shape/events/production/bottleneck_detection.py
@@ -34,7 +34,7 @@ class BottleneckDetectionEvents(Base):
         self.value_column = value_column
 
     def station_utilization(
-        self, station_uuids: List[str], window: str = "1h"
+        self, station_uuids: list[str], window: str = "1h"
     ) -> pd.DataFrame:
         """Per-station uptime percentage per time window.
 
@@ -45,7 +45,7 @@ class BottleneckDetectionEvents(Base):
         Returns:
             DataFrame with columns: start, uuid, utilization_pct.
         """
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
 
         for uid in station_uuids:
             station = self.dataframe[self.dataframe["uuid"] == uid].copy()
@@ -73,7 +73,7 @@ class BottleneckDetectionEvents(Base):
         )
 
     def detect_bottleneck(
-        self, station_uuids: List[str], window: str = "1h"
+        self, station_uuids: list[str], window: str = "1h"
     ) -> pd.DataFrame:
         """Identify the bottleneck station per window.
 
@@ -112,7 +112,7 @@ class BottleneckDetectionEvents(Base):
         )
 
     def shifting_bottleneck(
-        self, station_uuids: List[str], window: str = "1h"
+        self, station_uuids: list[str], window: str = "1h"
     ) -> pd.DataFrame:
         """Track when the bottleneck identity changes between stations.
 
@@ -136,7 +136,7 @@ class BottleneckDetectionEvents(Base):
                 ]
             )
 
-        shifts: List[Dict[str, Any]] = []
+        shifts: list[dict[str, Any]] = []
         prev_uuid = bottlenecks.iloc[0]["bottleneck_uuid"]
         prev_util = bottlenecks.iloc[0]["utilization_pct"]
 
@@ -171,8 +171,8 @@ class BottleneckDetectionEvents(Base):
         )
 
     def throughput_constraint_summary(
-        self, station_uuids: List[str], window: str = "1h"
-    ) -> Dict[str, Any]:
+        self, station_uuids: list[str], window: str = "1h"
+    ) -> dict[str, Any]:
         """Summary statistics for bottleneck analysis.
 
         Args:

--- a/src/ts_shape/events/production/changeover.py
+++ b/src/ts_shape/events/production/changeover.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/changeover.py
+++ b/src/ts_shape/events/production/changeover.py
@@ -71,10 +71,10 @@ class ChangeoverEvents(Base):
         product_uuid: str,
         *,
         value_column: str = "value_string",
-        start_time: Optional[pd.Timestamp] = None,
+        start_time: pd.Timestamp | None = None,
         until: str = "fixed_window",
-        config: Optional[Dict[str, Any]] = None,
-        fallback: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
+        fallback: dict[str, Any] | None = None,
     ) -> pd.DataFrame:
         """Compute changeover windows per product change with enhanced configurability.
 
@@ -116,7 +116,7 @@ class ChangeoverEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, r in changes.iterrows():
             t0 = pd.to_datetime(r["systime"])
             if until == "fixed_window":
@@ -168,13 +168,13 @@ class ChangeoverEvents(Base):
         return pd.DataFrame(rows)
 
     def _compute_stable_band_end(
-        self, t0: pd.Timestamp, config: Dict[str, Any]
-    ) -> Optional[pd.Timestamp]:
+        self, t0: pd.Timestamp, config: dict[str, Any]
+    ) -> pd.Timestamp | None:
         """Compute end time for stable_band method with configurable reference methods."""
         metric_defs = config.get("metrics", [])
         reference_method = config.get("reference_method", "expanding_median")
 
-        metric_ends: List[pd.Timestamp] = []
+        metric_ends: list[pd.Timestamp] = []
 
         for mdef in metric_defs:
             uid = mdef["uuid"]
@@ -203,7 +203,7 @@ class ChangeoverEvents(Base):
 
             # Find first stable period
             gid = (inside.ne(inside.shift())).cumsum()
-            end_found: Optional[pd.Timestamp] = None
+            end_found: pd.Timestamp | None = None
 
             for _, seg in s.groupby(gid):
                 seg_inside = inside.loc[seg.index]
@@ -227,8 +227,8 @@ class ChangeoverEvents(Base):
         self,
         series: pd.Series,
         method: str,
-        config: Dict[str, Any],
-        mdef: Dict[str, Any],
+        config: dict[str, Any],
+        mdef: dict[str, Any],
     ) -> pd.Series:
         """Calculate reference values using various methods."""
         if method == "expanding_median":

--- a/src/ts_shape/events/production/continuous_process_alignment.py
+++ b/src/ts_shape/events/production/continuous_process_alignment.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from ts_shape.utils.base import Base
 
-_SPEED_FACTORS: Dict[str, float] = {
+_SPEED_FACTORS: dict[str, float] = {
     "m/min": 1.0 / 60.0,
     "m/s": 1.0,
     "mm/s": 1.0 / 1000.0,
@@ -71,10 +71,10 @@ class ContinuousProcessAlignmentEvents(Base):
         self,
         dataframe: pd.DataFrame,
         speed_uuid: str,
-        line_config: List[Dict],
+        line_config: list[dict],
         *,
-        ref_uuid: Optional[str] = None,
-        cut_uuid: Optional[str] = None,
+        ref_uuid: str | None = None,
+        cut_uuid: str | None = None,
         time_column: str = "systime",
         uuid_column: str = "uuid",
         value_column: str = "value_double",
@@ -99,14 +99,14 @@ class ContinuousProcessAlignmentEvents(Base):
         self._speed_factor: float = _SPEED_FACTORS[speed_unit]
 
         # Build flat lookup: uuid -> (component_name, offset_m)
-        self._uuid_meta: Dict[str, tuple] = {}
+        self._uuid_meta: dict[str, tuple] = {}
         for component in line_config:
             name = component["name"]
             offset = float(component["offset"])
             for uid in component.get("uuids", []):
                 self._uuid_meta[uid] = (name, offset)
 
-        self._all_station_uuids: List[str] = list(self._uuid_meta.keys())
+        self._all_station_uuids: list[str] = list(self._uuid_meta.keys())
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -159,9 +159,9 @@ class ContinuousProcessAlignmentEvents(Base):
 
     def align_to_reference(
         self,
-        station_uuids: Optional[List[str]] = None,
+        station_uuids: list[str] | None = None,
         *,
-        value_column: Optional[str] = None,
+        value_column: str | None = None,
     ) -> pd.DataFrame:
         """Shift each station reading backward by its transport lag to produce
         a common ``material_ref_time``.
@@ -189,7 +189,7 @@ class ContinuousProcessAlignmentEvents(Base):
 
         speed_df = self._get_speed_df()
 
-        parts: List[pd.DataFrame] = []
+        parts: list[pd.DataFrame] = []
         for uid in uuids:
             if uid not in self._uuid_meta:
                 continue
@@ -228,8 +228,8 @@ class ContinuousProcessAlignmentEvents(Base):
         self,
         aligned_df: pd.DataFrame,
         *,
-        cut_length_uuid: Optional[str] = None,
-        part_counter_uuid: Optional[str] = None,
+        cut_length_uuid: str | None = None,
+        part_counter_uuid: str | None = None,
         cut_value_column: str = "value_double",
     ) -> pd.DataFrame:
         """Add ``piece_id``, ``piece_length_m``, and ``piece_cut_ref_time`` to
@@ -270,7 +270,7 @@ class ContinuousProcessAlignmentEvents(Base):
 
         # ---- detect cut events ----
         # Each entry: (systime, piece_length_m or NaN, n_pieces)
-        cut_events: List[tuple] = []
+        cut_events: list[tuple] = []
 
         if part_counter_uuid is not None:
             counter_df = (
@@ -356,7 +356,7 @@ class ContinuousProcessAlignmentEvents(Base):
             return result
 
         # ---- expand cut_events to per-piece rows, align to material_ref_time ----
-        piece_rows: List[Dict] = []
+        piece_rows: list[dict] = []
         piece_id = 1
         for ts, length_m, n_pieces in cut_events:
             # Determine material_ref_time of this cut event
@@ -448,7 +448,7 @@ class ContinuousProcessAlignmentEvents(Base):
 
     def lag_profile(
         self,
-        station_uuids: Optional[List[str]] = None,
+        station_uuids: list[str] | None = None,
         *,
         window: str = "1min",
     ) -> pd.DataFrame:
@@ -479,7 +479,7 @@ class ContinuousProcessAlignmentEvents(Base):
             * self._speed_factor
         ).clip(lower=self.min_speed)
 
-        parts: List[pd.DataFrame] = []
+        parts: list[pd.DataFrame] = []
         for uid in uuids:
             if uid not in self._uuid_meta:
                 continue
@@ -500,7 +500,7 @@ class ContinuousProcessAlignmentEvents(Base):
 
     def alignment_quality(
         self,
-        station_uuids: Optional[List[str]] = None,
+        station_uuids: list[str] | None = None,
         *,
         window: str = "1h",
     ) -> pd.DataFrame:
@@ -523,7 +523,7 @@ class ContinuousProcessAlignmentEvents(Base):
             .rename("speed_sample_count")
         )
 
-        station_counts: Dict[str, pd.Series] = {}
+        station_counts: dict[str, pd.Series] = {}
         for uid in uuids:
             if uid not in self._uuid_meta:
                 continue

--- a/src/ts_shape/events/production/continuous_process_alignment.py
+++ b/src/ts_shape/events/production/continuous_process_alignment.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd

--- a/src/ts_shape/events/production/downtime_tracking.py
+++ b/src/ts_shape/events/production/downtime_tracking.py
@@ -9,7 +9,6 @@ Essential module for daily downtime analysis:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/downtime_tracking.py
+++ b/src/ts_shape/events/production/downtime_tracking.py
@@ -55,7 +55,7 @@ class DowntimeTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         """Initialize downtime tracker.
 

--- a/src/ts_shape/events/production/duty_cycle.py
+++ b/src/ts_shape/events/production/duty_cycle.py
@@ -56,7 +56,7 @@ class DutyCycleEvents(Base):
         s["state"] = s[self.value_column].fillna(False).astype(bool)
         state_change = (s["state"] != s["state"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby(state_change):
             state = bool(seg["state"].iloc[0])
             start = seg[self.time_column].iloc[0]
@@ -92,7 +92,7 @@ class DutyCycleEvents(Base):
         window_td = pd.to_timedelta(window)
         resampled = s["state"].resample(window).mean()
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, pct in resampled.items():
             if pd.isna(pct):
                 continue
@@ -177,7 +177,7 @@ class DutyCycleEvents(Base):
         intervals = self.on_off_intervals()
         window_td = pd.to_timedelta(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for _, row in excessive.iterrows():
             w_start = row["start"]
             w_end = w_start + window_td

--- a/src/ts_shape/events/production/duty_cycle.py
+++ b/src/ts_shape/events/production/duty_cycle.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/flow_constraints.py
+++ b/src/ts_shape/events/production/flow_constraints.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Dict, Any, List, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/flow_constraints.py
+++ b/src/ts_shape/events/production/flow_constraints.py
@@ -38,10 +38,10 @@ class FlowConstraintEvents(Base):
     def blocked_events(
         self,
         *,
-        roles: Dict[str, str],
+        roles: dict[str, str],
         tolerance: str = "200ms",
-        tolerance_before: Optional[str] = None,
-        tolerance_after: Optional[str] = None,
+        tolerance_before: str | None = None,
+        tolerance_after: str | None = None,
         min_duration: str = "0s",
     ) -> pd.DataFrame:
         """Blocked: upstream_run=True while downstream_run=False.
@@ -121,7 +121,7 @@ class FlowConstraintEvents(Base):
         cond = merged["state_up"] & (~merged["state_dn"].fillna(False))
         gid = (cond.ne(cond.shift())).cumsum()
         min_td = pd.to_timedelta(min_duration)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in merged.groupby(gid):
             m = cond.loc[seg.index]
             if not m.any():
@@ -153,10 +153,10 @@ class FlowConstraintEvents(Base):
     def starved_events(
         self,
         *,
-        roles: Dict[str, str],
+        roles: dict[str, str],
         tolerance: str = "200ms",
-        tolerance_before: Optional[str] = None,
-        tolerance_after: Optional[str] = None,
+        tolerance_before: str | None = None,
+        tolerance_after: str | None = None,
         min_duration: str = "0s",
     ) -> pd.DataFrame:
         """Starved: downstream_run=True while upstream_run=False.
@@ -236,7 +236,7 @@ class FlowConstraintEvents(Base):
         cond = merged["state_dn"] & (~merged["state_up"].fillna(False))
         gid = (cond.ne(cond.shift())).cumsum()
         min_td = pd.to_timedelta(min_duration)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in merged.groupby(gid):
             m = cond.loc[seg.index]
             if not m.any():
@@ -294,14 +294,14 @@ class FlowConstraintEvents(Base):
     def flow_constraint_analytics(
         self,
         *,
-        roles: Dict[str, str],
+        roles: dict[str, str],
         tolerance: str = "200ms",
-        tolerance_before: Optional[str] = None,
-        tolerance_after: Optional[str] = None,
+        tolerance_before: str | None = None,
+        tolerance_after: str | None = None,
         min_duration: str = "0s",
         minor_threshold: str = "5s",
         moderate_threshold: str = "30s",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate comprehensive analytics for flow constraints (blockages and starvations).
 
         Args:
@@ -352,7 +352,7 @@ class FlowConstraintEvents(Base):
         )
 
         # Calculate summary statistics
-        summary: Dict[str, Any] = {}
+        summary: dict[str, Any] = {}
 
         # Blocked events statistics
         if not blocked_df.empty:

--- a/src/ts_shape/events/production/flow_metrics.py
+++ b/src/ts_shape/events/production/flow_metrics.py
@@ -13,7 +13,6 @@ Entry and exit are boolean signals; each rising edge is one unit.
 """
 
 import logging
-from typing import Optional, Union
 
 import pandas as pd  # type: ignore
 
@@ -26,7 +25,7 @@ from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
 
-_Number = Union[int, float, str]
+_Number = int | float | str
 
 
 def _to_seconds(value: _Number | None) -> float | None:

--- a/src/ts_shape/events/production/flow_metrics.py
+++ b/src/ts_shape/events/production/flow_metrics.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 _Number = Union[int, float, str]
 
 
-def _to_seconds(value: Optional[_Number]) -> Optional[float]:
+def _to_seconds(value: _Number | None) -> float | None:
     """Coerce a duration (seconds number or pandas offset string) to seconds."""
     if value is None:
         return None
@@ -220,7 +220,7 @@ class FlowMetricsEvents(Base):
     def flow_summary(
         self,
         *,
-        value_add_seconds: Optional[_Number] = None,
+        value_add_seconds: _Number | None = None,
         window: str = "1h",
     ) -> pd.DataFrame:
         """Combined flow metrics with a Little's Law consistency check.

--- a/src/ts_shape/events/production/line_balancing.py
+++ b/src/ts_shape/events/production/line_balancing.py
@@ -14,7 +14,7 @@ time between consecutive rising edges is that station's cycle time.
 
 import logging
 import math
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
@@ -24,7 +24,7 @@ from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
 
-_Number = Union[int, float, str]
+_Number = int | float | str
 
 
 def _to_seconds(value: _Number | None) -> float | None:

--- a/src/ts_shape/events/production/line_balancing.py
+++ b/src/ts_shape/events/production/line_balancing.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 _Number = Union[int, float, str]
 
 
-def _to_seconds(value: Optional[_Number]) -> Optional[float]:
+def _to_seconds(value: _Number | None) -> float | None:
     """Coerce a duration (seconds number or pandas offset string) to seconds."""
     if value is None:
         return None
@@ -57,7 +57,7 @@ class LineBalancingEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        station_uuids: Dict[str, str],
+        station_uuids: dict[str, str],
         *,
         event_uuid: str = "prod:line_balance",
         value_column: str = "value_bool",
@@ -106,7 +106,7 @@ class LineBalancingEvents(Base):
         Columns: ``uuid``, ``station_name``, ``completion``, ``cycle_time``.
         The cycle time is the gap to the previous completion at that station.
         """
-        rows: List[pd.DataFrame] = []
+        rows: list[pd.DataFrame] = []
         for uuid, name in self.station_uuids.items():
             times = self._rising_edge_times(uuid)
             if len(times) < 2:
@@ -130,10 +130,10 @@ class LineBalancingEvents(Base):
 
     def _resolve_takt(
         self,
-        takt_time: Optional[_Number],
-        demand: Optional[float],
-        available_time: Optional[_Number],
-    ) -> Optional[float]:
+        takt_time: _Number | None,
+        demand: float | None,
+        available_time: _Number | None,
+    ) -> float | None:
         """Resolve takt time (seconds) from an explicit value or demand/time."""
         if takt_time is not None:
             return _to_seconds(takt_time)
@@ -192,9 +192,9 @@ class LineBalancingEvents(Base):
     def balance_metrics(
         self,
         *,
-        takt_time: Optional[_Number] = None,
-        demand: Optional[float] = None,
-        available_time: Optional[_Number] = None,
+        takt_time: _Number | None = None,
+        demand: float | None = None,
+        available_time: _Number | None = None,
         window: str = "1h",
     ) -> pd.DataFrame:
         """Line-level balance metrics per time window.
@@ -234,7 +234,7 @@ class LineBalancingEvents(Base):
         cycles["start"] = cycles["completion"].dt.floor(window)
         means = cycles.groupby(["start", "uuid"])["cycle_time"].mean().reset_index()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for start, grp in means.groupby("start", sort=True):
             times = grp["cycle_time"].to_numpy(dtype=float)
             n = len(times)
@@ -267,9 +267,9 @@ class LineBalancingEvents(Base):
     def yamazumi(
         self,
         *,
-        takt_time: Optional[_Number] = None,
-        demand: Optional[float] = None,
-        available_time: Optional[_Number] = None,
+        takt_time: _Number | None = None,
+        demand: float | None = None,
+        available_time: _Number | None = None,
     ) -> pd.DataFrame:
         """Yamazumi (station-loading) table over the whole dataset.
 
@@ -300,7 +300,7 @@ class LineBalancingEvents(Base):
         means = cycles.groupby("uuid")["cycle_time"].mean()
         bottleneck_uuid = means.idxmax()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for uuid, name in self.station_uuids.items():
             if uuid not in means.index:
                 continue

--- a/src/ts_shape/events/production/line_throughput.py
+++ b/src/ts_shape/events/production/line_throughput.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np
-from typing import Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/line_throughput.py
+++ b/src/ts_shape/events/production/line_throughput.py
@@ -135,7 +135,7 @@ class LineThroughputEvents(Base):
         *,
         value_column: str = "value_integer",
         window: str = "1h",
-        target_rate: Optional[float] = None,
+        target_rate: float | None = None,
         availability_threshold: float = 0.95,
     ) -> pd.DataFrame:
         """Calculate Overall Equipment Effectiveness (OEE) metrics.
@@ -275,7 +275,7 @@ class LineThroughputEvents(Base):
         cycle_uuid: str,
         *,
         value_column: str = "value_bool",
-        expected_cycle_time: Optional[float] = None,
+        expected_cycle_time: float | None = None,
         tolerance_pct: float = 0.1,
     ) -> pd.DataFrame:
         """Enhanced cycle detection with quality validation.

--- a/src/ts_shape/events/production/long_downtime_events.py
+++ b/src/ts_shape/events/production/long_downtime_events.py
@@ -29,7 +29,7 @@ class LongDowntimeEvents(Base):
         event_uuid: str = "prod:long_downtime",
         value_column: str = "value_bool",
         time_column: str = "systime",
-        value_range: Optional[Tuple[Optional[float], Optional[float]]] = None,
+        value_range: tuple[float | None, float | None] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.state_uuid = state_uuid
@@ -93,7 +93,7 @@ class LongDowntimeEvents(Base):
         state_change = (s["state"] != s["state"].shift()).cumsum()
         min_td = pd.to_timedelta(min_gap)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby(state_change):
             if bool(seg["state"].iloc[0]):
                 continue  # running segment — skip
@@ -180,7 +180,7 @@ class LongDowntimeEvents(Base):
         )
         prod["systime"] = pd.to_datetime(prod["systime"])
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for i in range(len(gaps) - 1):
             start = gaps.iloc[i]["end"]
             end = gaps.iloc[i + 1]["start"]

--- a/src/ts_shape/events/production/long_downtime_events.py
+++ b/src/ts_shape/events/production/long_downtime_events.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional, Tuple
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/machine_state.py
+++ b/src/ts_shape/events/production/machine_state.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional, Tuple
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/machine_state.py
+++ b/src/ts_shape/events/production/machine_state.py
@@ -27,7 +27,7 @@ class MachineStateEvents(Base):
         event_uuid: str = "prod:run_idle",
         value_column: str = "value_bool",
         time_column: str = "systime",
-        value_range: Optional[Tuple[Optional[float], Optional[float]]] = None,
+        value_range: tuple[float | None, float | None] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.run_state_uuid = run_state_uuid
@@ -49,7 +49,7 @@ class MachineStateEvents(Base):
             .sort_values(self.time_column)
         )
         self.series[self.time_column] = pd.to_datetime(self.series[self.time_column])
-        self._state_groups: Optional[pd.Series] = None
+        self._state_groups: pd.Series | None = None
         self._compute_state_groups()
 
     def _as_state(self, col: pd.Series) -> pd.Series:
@@ -89,7 +89,7 @@ class MachineStateEvents(Base):
         s["state"] = self._as_state(s[self.value_column])
         state_change = (s["state"] != s["state"].shift()).cumsum()
         min_td = pd.to_timedelta(min_duration)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby(state_change):
             state = bool(seg["state"].iloc[0])
             start = seg[self.time_column].iloc[0]
@@ -192,7 +192,7 @@ class MachineStateEvents(Base):
             )
 
         threshold_td = pd.to_timedelta(threshold)
-        rapid_events: List[Dict[str, Any]] = []
+        rapid_events: list[dict[str, Any]] = []
 
         for i in range(len(transitions) - min_count + 1):
             start = transitions.iloc[i]["systime"]
@@ -228,7 +228,7 @@ class MachineStateEvents(Base):
         gaps = time_diffs[time_diffs > max_gap_td]
         return len(gaps)
 
-    def state_quality_metrics(self) -> Dict[str, Any]:
+    def state_quality_metrics(self) -> dict[str, Any]:
         """Return quality metrics for the state data.
 
         Returns dictionary with:

--- a/src/ts_shape/events/production/micro_stop_detection.py
+++ b/src/ts_shape/events/production/micro_stop_detection.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/micro_stop_detection.py
+++ b/src/ts_shape/events/production/micro_stop_detection.py
@@ -52,7 +52,7 @@ class MicroStopEvents(Base):
         s["state"] = s[self.value_column].fillna(False).astype(bool)
         state_change = (s["state"] != s["state"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby(state_change):
             state = bool(seg["state"].iloc[0])
             start = seg[self.time_column].iloc[0]
@@ -91,7 +91,7 @@ class MicroStopEvents(Base):
         max_td = pd.to_timedelta(max_duration)
         min_td = pd.to_timedelta(min_duration)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i, row in intervals.iterrows():
             if row["state"] != "idle":
                 continue

--- a/src/ts_shape/events/production/multi_process_traceability.py
+++ b/src/ts_shape/events/production/multi_process_traceability.py
@@ -20,7 +20,7 @@ being processed.  Handover signals between cells confirm the transfer.
 
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/multi_process_traceability.py
+++ b/src/ts_shape/events/production/multi_process_traceability.py
@@ -58,9 +58,9 @@ class MultiProcessTraceabilityEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        processes: List[Dict[str, str]],
+        processes: list[dict[str, str]],
         *,
-        handovers: Optional[List[Dict[str, str]]] = None,
+        handovers: list[dict[str, str]] | None = None,
         event_uuid: str = "prod:multi_process_trace",
         id_value_column: str = "value_string",
         handover_value_column: str = "value_integer",
@@ -92,13 +92,13 @@ class MultiProcessTraceabilityEvents(Base):
         self.time_column = time_column
 
         # Build station lookup: station_name -> list of id_uuids (parallel cells)
-        self._station_uuids: Dict[str, List[str]] = {}
+        self._station_uuids: dict[str, list[str]] = {}
         for proc in self.processes:
             station = proc["station"]
             self._station_uuids.setdefault(station, []).append(proc["id_uuid"])
 
         # Pre-filter process data per uuid
-        self._process_data: Dict[str, pd.DataFrame] = {}
+        self._process_data: dict[str, pd.DataFrame] = {}
         for proc in self.processes:
             uid = proc["id_uuid"]
             sdf = (
@@ -110,7 +110,7 @@ class MultiProcessTraceabilityEvents(Base):
             self._process_data[uid] = sdf
 
         # Pre-filter handover data per uuid
-        self._handover_data: Dict[str, pd.DataFrame] = {}
+        self._handover_data: dict[str, pd.DataFrame] = {}
         for ho in self.handovers:
             uid = ho["uuid"]
             hdf = (
@@ -156,7 +156,7 @@ class MultiProcessTraceabilityEvents(Base):
             gap = pd.Series(False, index=s.index)
         s["group"] = (value_change | gap).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby("group"):
             item_id = seg["item_id"].iloc[0]
             if item_id == "":
@@ -202,7 +202,7 @@ class MultiProcessTraceabilityEvents(Base):
               station for the same item.
             - uuid: Event UUID.
         """
-        all_intervals: List[pd.DataFrame] = []
+        all_intervals: list[pd.DataFrame] = []
         for proc in self.processes:
             intervals = self._detect_intervals(proc["id_uuid"], proc["station"])
             if not intervals.empty:
@@ -286,7 +286,7 @@ class MultiProcessTraceabilityEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for item_id, grp in timeline.groupby("item_id"):
             grp = grp.sort_values("start")
             first_seen = grp["start"].iloc[0]
@@ -341,7 +341,7 @@ class MultiProcessTraceabilityEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for item_id, grp in timeline.groupby("item_id"):
             if len(grp) < 2:
                 continue
@@ -418,7 +418,7 @@ class MultiProcessTraceabilityEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for ho in self.handovers:
             ho_uuid = ho["uuid"]
             from_station = ho["from_station"]

--- a/src/ts_shape/events/production/oee_calculator.py
+++ b/src/ts_shape/events/production/oee_calculator.py
@@ -10,7 +10,6 @@ Industry-standard metric for manufacturing productivity:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional
 
 from ts_shape.utils.base import Base
 from ts_shape.events._output import (

--- a/src/ts_shape/events/production/oee_calculator.py
+++ b/src/ts_shape/events/production/oee_calculator.py
@@ -91,7 +91,7 @@ class OEECalculator(Base):
     def calculate_availability(
         self,
         run_state_uuid: str,
-        planned_time_hours: Optional[float] = None,
+        planned_time_hours: float | None = None,
         *,
         value_column: str = "value_bool",
     ) -> pd.DataFrame:
@@ -170,7 +170,7 @@ class OEECalculator(Base):
         self,
         counter_uuid: str,
         ideal_cycle_time: float,
-        run_state_uuid: Optional[str] = None,
+        run_state_uuid: str | None = None,
         *,
         value_column: str = "value_integer",
         run_value_column: str = "value_bool",
@@ -336,10 +336,10 @@ class OEECalculator(Base):
         run_state_uuid: str,
         counter_uuid: str,
         ideal_cycle_time: float,
-        total_uuid: Optional[str] = None,
-        reject_uuid: Optional[str] = None,
+        total_uuid: str | None = None,
+        reject_uuid: str | None = None,
         *,
-        planned_time_hours: Optional[float] = None,
+        planned_time_hours: float | None = None,
     ) -> pd.DataFrame:
         """Calculate daily OEE = Availability * Performance * Quality.
 

--- a/src/ts_shape/events/production/operator_performance.py
+++ b/src/ts_shape/events/production/operator_performance.py
@@ -56,7 +56,7 @@ class OperatorPerformanceTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column

--- a/src/ts_shape/events/production/operator_performance.py
+++ b/src/ts_shape/events/production/operator_performance.py
@@ -9,7 +9,6 @@ Compare production output and quality across operators:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/order_traceability.py
+++ b/src/ts_shape/events/production/order_traceability.py
@@ -53,7 +53,7 @@ class ValueTraceabilityEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        station_uuids: Dict[str, str],
+        station_uuids: dict[str, str],
         *,
         event_uuid: str = "prod:value_trace",
         value_column: str = "value_string",
@@ -76,7 +76,7 @@ class ValueTraceabilityEvents(Base):
         self.time_column = time_column
 
         # Pre-filter and parse per-station data
-        self._station_data: Dict[str, pd.DataFrame] = {}
+        self._station_data: dict[str, pd.DataFrame] = {}
         for uuid, name in self.station_uuids.items():
             sdf = (
                 self.dataframe[self.dataframe["uuid"] == uuid]
@@ -111,7 +111,7 @@ class ValueTraceabilityEvents(Base):
         s["group"] = (s["identifier"] != s["identifier"].shift()).cumsum()
 
         station_name = self.station_uuids[uuid]
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in s.groupby("group"):
             identifier = seg["identifier"].iloc[0]
             if identifier == "":
@@ -151,7 +151,7 @@ class ValueTraceabilityEvents(Base):
             - station_sequence: Order of visit (1-based) per identifier.
             - uuid: Event UUID.
         """
-        all_intervals: List[pd.DataFrame] = []
+        all_intervals: list[pd.DataFrame] = []
         for uuid in self.station_uuids:
             intervals = self._detect_intervals(uuid)
             if not intervals.empty:
@@ -217,7 +217,7 @@ class ValueTraceabilityEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for identifier, grp in timeline.groupby("identifier"):
             grp = grp.sort_values("start")
             first_seen = grp["start"].iloc[0]

--- a/src/ts_shape/events/production/order_traceability.py
+++ b/src/ts_shape/events/production/order_traceability.py
@@ -12,7 +12,7 @@ identifier to its own UUID.  This module joins those signals to answer
 
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/part_tracking.py
+++ b/src/ts_shape/events/production/part_tracking.py
@@ -8,7 +8,6 @@ Simple, practical module for daily production reporting:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/part_tracking.py
+++ b/src/ts_shape/events/production/part_tracking.py
@@ -235,8 +235,8 @@ class PartProductionTracking(Base):
         part_id_uuid: str,
         counter_uuid: str,
         *,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
         value_column_part: str = "value_string",
         value_column_counter: str = "value_integer",
     ) -> pd.DataFrame:

--- a/src/ts_shape/events/production/performance_loss.py
+++ b/src/ts_shape/events/production/performance_loss.py
@@ -8,7 +8,6 @@ Track when machine runs slower than ideal/target speed:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/performance_loss.py
+++ b/src/ts_shape/events/production/performance_loss.py
@@ -57,7 +57,7 @@ class PerformanceLossTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column

--- a/src/ts_shape/events/production/period_summary.py
+++ b/src/ts_shape/events/production/period_summary.py
@@ -183,8 +183,8 @@ class PeriodSummary(Base):
     def weekly_summary(
         self,
         counter_uuid: str,
-        ok_counter_uuid: Optional[str] = None,
-        nok_counter_uuid: Optional[str] = None,
+        ok_counter_uuid: str | None = None,
+        nok_counter_uuid: str | None = None,
         *,
         value_column: str = "value_integer",
     ) -> pd.DataFrame:
@@ -283,8 +283,8 @@ class PeriodSummary(Base):
     def monthly_summary(
         self,
         counter_uuid: str,
-        ok_counter_uuid: Optional[str] = None,
-        nok_counter_uuid: Optional[str] = None,
+        ok_counter_uuid: str | None = None,
+        nok_counter_uuid: str | None = None,
         *,
         value_column: str = "value_integer",
     ) -> pd.DataFrame:
@@ -414,7 +414,7 @@ class PeriodSummary(Base):
         p1_data = daily[(daily["date"] >= p1_start) & (daily["date"] <= p1_end)]
         p2_data = daily[(daily["date"] >= p2_start) & (daily["date"] <= p2_end)]
 
-        def _metrics(data: pd.DataFrame) -> Dict[str, float]:
+        def _metrics(data: pd.DataFrame) -> dict[str, float]:
             if data.empty:
                 return {
                     "total_production": 0,

--- a/src/ts_shape/events/production/period_summary.py
+++ b/src/ts_shape/events/production/period_summary.py
@@ -12,7 +12,6 @@ Two modes of operation:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/quality_tracking.py
+++ b/src/ts_shape/events/production/quality_tracking.py
@@ -61,7 +61,7 @@ class QualityTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         """Initialize quality tracker.
 

--- a/src/ts_shape/events/production/quality_tracking.py
+++ b/src/ts_shape/events/production/quality_tracking.py
@@ -9,7 +9,6 @@ Essential module for daily quality analysis:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/rework_tracking.py
+++ b/src/ts_shape/events/production/rework_tracking.py
@@ -56,7 +56,7 @@ class ReworkTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column
@@ -297,7 +297,7 @@ class ReworkTracking(Base):
         self,
         rework_uuid: str,
         part_id_uuid: str,
-        rework_costs: Dict[str, float],
+        rework_costs: dict[str, float],
         *,
         value_column_rework: str = "value_integer",
         value_column_part: str = "value_string",

--- a/src/ts_shape/events/production/rework_tracking.py
+++ b/src/ts_shape/events/production/rework_tracking.py
@@ -10,7 +10,6 @@ Track rework events and their impact:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/routing_traceability.py
+++ b/src/ts_shape/events/production/routing_traceability.py
@@ -26,7 +26,7 @@ This module correlates both signals to reconstruct the full routing path.
 
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Dict, Any, Optional, Union
+from typing import Any
 
 from ts_shape.utils.base import Base
 
@@ -80,8 +80,8 @@ class RoutingTraceabilityEvents(Base):
         id_uuid: str,
         routing_uuid: str,
         *,
-        state_map: dict[Union[int, float, str], str] | None = None,
-        station_map: dict[Union[int, float, str], str] | None = None,
+        state_map: dict[int | float | str, str] | None = None,
+        station_map: dict[int | float | str, str] | None = None,
         event_uuid: str = "prod:routing_trace",
         id_value_column: str = "value_string",
         routing_value_column: str = "value_integer",
@@ -109,9 +109,7 @@ class RoutingTraceabilityEvents(Base):
         self.id_uuid = id_uuid
         self.routing_uuid = routing_uuid
         # state_map takes priority; fall back to station_map for backwards compat
-        self.state_map: dict[Union[int, float, str], str] = (
-            state_map or station_map or {}
-        )
+        self.state_map: dict[int | float | str, str] = state_map or station_map or {}
         self.event_uuid = event_uuid
         self.id_value_column = id_value_column
         self.routing_value_column = routing_value_column

--- a/src/ts_shape/events/production/routing_traceability.py
+++ b/src/ts_shape/events/production/routing_traceability.py
@@ -80,8 +80,8 @@ class RoutingTraceabilityEvents(Base):
         id_uuid: str,
         routing_uuid: str,
         *,
-        state_map: Optional[Dict[Union[int, float, str], str]] = None,
-        station_map: Optional[Dict[Union[int, float, str], str]] = None,
+        state_map: dict[Union[int, float, str], str] | None = None,
+        station_map: dict[Union[int, float, str], str] | None = None,
         event_uuid: str = "prod:routing_trace",
         id_value_column: str = "value_string",
         routing_value_column: str = "value_integer",
@@ -109,7 +109,7 @@ class RoutingTraceabilityEvents(Base):
         self.id_uuid = id_uuid
         self.routing_uuid = routing_uuid
         # state_map takes priority; fall back to station_map for backwards compat
-        self.state_map: Dict[Union[int, float, str], str] = (
+        self.state_map: dict[Union[int, float, str], str] = (
             state_map or station_map or {}
         )
         self.event_uuid = event_uuid
@@ -243,7 +243,7 @@ class RoutingTraceabilityEvents(Base):
         merged["combo"] = merged["item_id"] + "|" + merged["routing_value"].astype(str)
         merged["group"] = (merged["combo"] != merged["combo"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in merged.groupby("group"):
             item_id = seg["item_id"].iloc[0]
             routing_val = seg["routing_value"].iloc[0]
@@ -304,7 +304,7 @@ class RoutingTraceabilityEvents(Base):
                 ]
             )
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for item_id, grp in timeline.groupby("item_id"):
             grp = grp.sort_values("start")
             first_seen = grp["start"].iloc[0]

--- a/src/ts_shape/events/production/runtime_accounting.py
+++ b/src/ts_shape/events/production/runtime_accounting.py
@@ -91,7 +91,7 @@ class RuntimeAccountingEvents(Base):
     def _run_intervals(self, samples: pd.DataFrame) -> pd.DataFrame:
         """Contiguous run segments. Columns: ``start``, ``duration_seconds``."""
         change = (samples["state"] != samples["state"].shift()).cumsum()
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, grp in samples.groupby(change):
             if not bool(grp["state"].iloc[0]):
                 continue
@@ -173,7 +173,7 @@ class RuntimeAccountingEvents(Base):
 
         samples = samples.copy()
         samples["win"] = samples[self.time_column].dt.floor(window)
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for win, grp in samples.groupby("win", sort=True):
             run_s = float(grp.loc[grp["state"], "dur"].sum())
             covered = float(grp["dur"].sum())

--- a/src/ts_shape/events/production/runtime_accounting.py
+++ b/src/ts_shape/events/production/runtime_accounting.py
@@ -14,7 +14,7 @@ counts): here the focus is *absolute* run time and an hour-meter reading.
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 import pandas as pd  # type: ignore
 

--- a/src/ts_shape/events/production/scrap_tracking.py
+++ b/src/ts_shape/events/production/scrap_tracking.py
@@ -60,7 +60,7 @@ class ScrapTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column
@@ -212,7 +212,7 @@ class ScrapTracking(Base):
         self,
         scrap_uuid: str,
         part_id_uuid: str,
-        material_costs: Dict[str, float],
+        material_costs: dict[str, float],
         *,
         value_column_scrap: str = "value_double",
         value_column_part: str = "value_string",

--- a/src/ts_shape/events/production/scrap_tracking.py
+++ b/src/ts_shape/events/production/scrap_tracking.py
@@ -8,7 +8,6 @@ Track material waste and scrap (different from NOK parts):
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/setup_time_tracking.py
+++ b/src/ts_shape/events/production/setup_time_tracking.py
@@ -52,7 +52,7 @@ class SetupTimeTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column

--- a/src/ts_shape/events/production/setup_time_tracking.py
+++ b/src/ts_shape/events/production/setup_time_tracking.py
@@ -9,7 +9,6 @@ Track setup durations to support Single-Minute Exchange of Die improvement:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/shift_handover.py
+++ b/src/ts_shape/events/production/shift_handover.py
@@ -76,7 +76,7 @@ class ShiftHandoverReport(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column
@@ -173,11 +173,11 @@ class ShiftHandoverReport(Base):
     @staticmethod
     def from_shift_data(
         production_df: pd.DataFrame,
-        quality_df: Optional[pd.DataFrame] = None,
-        downtime_df: Optional[pd.DataFrame] = None,
+        quality_df: pd.DataFrame | None = None,
+        downtime_df: pd.DataFrame | None = None,
         *,
-        targets: Optional[Dict[str, float]] = None,
-        report_date: Optional[str] = None,
+        targets: dict[str, float] | None = None,
+        report_date: str | None = None,
     ) -> pd.DataFrame:
         """Build a handover report from pre-computed shift-level DataFrames.
 
@@ -299,13 +299,13 @@ class ShiftHandoverReport(Base):
         nok_counter_uuid: str,
         state_uuid: str,
         *,
-        targets: Optional[Dict[str, float]] = None,
+        targets: dict[str, float] | None = None,
         quality_target_pct: float = 98.0,
         availability_target_pct: float = 90.0,
         running_value: str = "Running",
         value_column_counter: str = "value_integer",
         value_column_state: str = "value_string",
-        report_date: Optional[str] = None,
+        report_date: str | None = None,
     ) -> pd.DataFrame:
         """Generate a shift handover report from raw timeseries signals.
 
@@ -409,19 +409,19 @@ class ShiftHandoverReport(Base):
 
     def highlight_issues(
         self,
-        counter_uuid: Optional[str] = None,
-        ok_counter_uuid: Optional[str] = None,
-        nok_counter_uuid: Optional[str] = None,
-        state_uuid: Optional[str] = None,
+        counter_uuid: str | None = None,
+        ok_counter_uuid: str | None = None,
+        nok_counter_uuid: str | None = None,
+        state_uuid: str | None = None,
         *,
-        report_df: Optional[pd.DataFrame] = None,
-        thresholds: Optional[Dict[str, float]] = None,
-        targets: Optional[Dict[str, float]] = None,
+        report_df: pd.DataFrame | None = None,
+        thresholds: dict[str, float] | None = None,
+        targets: dict[str, float] | None = None,
         running_value: str = "Running",
         value_column_counter: str = "value_integer",
         value_column_state: str = "value_string",
-        report_date: Optional[str] = None,
-    ) -> List[Dict[str, str]]:
+        report_date: str | None = None,
+    ) -> list[dict[str, str]]:
         """Identify issues that need attention.
 
         Can be called in two ways:

--- a/src/ts_shape/events/production/shift_handover.py
+++ b/src/ts_shape/events/production/shift_handover.py
@@ -13,7 +13,6 @@ Two modes of operation:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict, List
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/shift_reporting.py
+++ b/src/ts_shape/events/production/shift_reporting.py
@@ -54,7 +54,7 @@ class ShiftReporting(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, Tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         """Initialize shift reporter.
 
@@ -110,11 +110,11 @@ class ShiftReporting(Base):
     def shift_production(
         self,
         counter_uuid: str,
-        part_id_uuid: Optional[str] = None,
+        part_id_uuid: str | None = None,
         *,
         value_column_counter: str = "value_integer",
         value_column_part: str = "value_string",
-        date: Optional[str] = None,
+        date: str | None = None,
     ) -> pd.DataFrame:
         """Production quantity per shift.
 
@@ -298,10 +298,10 @@ class ShiftReporting(Base):
     def shift_targets(
         self,
         counter_uuid: str,
-        targets: Dict[str, float],
+        targets: dict[str, float],
         *,
         value_column_counter: str = "value_integer",
-        date: Optional[str] = None,
+        date: str | None = None,
     ) -> pd.DataFrame:
         """Compare actual production to shift targets.
 
@@ -364,7 +364,7 @@ class ShiftReporting(Base):
         *,
         value_column_counter: str = "value_integer",
         days: int = 30,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> dict[str, pd.DataFrame]:
         """Identify best and worst performing shifts.
 
         Args:

--- a/src/ts_shape/events/production/shift_reporting.py
+++ b/src/ts_shape/events/production/shift_reporting.py
@@ -8,7 +8,6 @@ Simple module for shift summaries:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict, Tuple
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/production/target_tracking.py
+++ b/src/ts_shape/events/production/target_tracking.py
@@ -52,7 +52,7 @@ class TargetTracking(Base):
         dataframe: pd.DataFrame,
         *,
         time_column: str = "systime",
-        shift_definitions: Optional[Dict[str, tuple[str, str]]] = None,
+        shift_definitions: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column
@@ -78,7 +78,7 @@ class TargetTracking(Base):
     def compare_to_target(
         self,
         metric_uuid: str,
-        targets: Dict[str, float],
+        targets: dict[str, float],
         *,
         value_column: str = "value_integer",
     ) -> pd.DataFrame:
@@ -217,7 +217,7 @@ class TargetTracking(Base):
         daily_target: float,
         *,
         value_column: str = "value_integer",
-    ) -> Dict[str, Union[float, int]]:
+    ) -> dict[str, Union[float, int]]:
         """How often are targets met?
 
         Args:

--- a/src/ts_shape/events/production/target_tracking.py
+++ b/src/ts_shape/events/production/target_tracking.py
@@ -8,7 +8,6 @@ Generic module for comparing any metric to targets:
 
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, Dict, Union
 
 from ts_shape.utils.base import Base
 
@@ -217,7 +216,7 @@ class TargetTracking(Base):
         daily_target: float,
         *,
         value_column: str = "value_integer",
-    ) -> dict[str, Union[float, int]]:
+    ) -> dict[str, float | int]:
         """How often are targets met?
 
         Args:

--- a/src/ts_shape/events/quality/anomaly_classification.py
+++ b/src/ts_shape/events/quality/anomaly_classification.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/anomaly_classification.py
+++ b/src/ts_shape/events/quality/anomaly_classification.py
@@ -72,7 +72,7 @@ class AnomalyClassificationEvents(Base):
         is_same = np.concatenate([[True], diffs <= tolerance])
         groups = (is_same != np.roll(is_same, 1)).cumsum()
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for gid in np.unique(groups):
             mask = groups == gid
             if not is_same[mask][0]:
@@ -121,7 +121,7 @@ class AnomalyClassificationEvents(Base):
         sig = sig.set_index(self.time_column)
         window_td = pd.to_timedelta(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         start_time = sig.index[0]
         end_time = sig.index[-1]
         current = start_time
@@ -175,7 +175,7 @@ class AnomalyClassificationEvents(Base):
         sig = sig.set_index(self.time_column)
         window_td = pd.to_timedelta(window)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         start_time = sig.index[0]
         end_time = sig.index[-1]
         current = start_time
@@ -236,7 +236,7 @@ class AnomalyClassificationEvents(Base):
         if global_std == 0 or np.isnan(global_std):
             global_std = 1e-10
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         start_time = sig.index[0]
         end_time = sig.index[-1]
         current = start_time

--- a/src/ts_shape/events/quality/capability_trending.py
+++ b/src/ts_shape/events/quality/capability_trending.py
@@ -31,10 +31,10 @@ class CapabilityTrendingEvents(Base):
         dataframe: pd.DataFrame,
         signal_uuid: str,
         *,
-        upper_spec: Optional[float] = None,
-        lower_spec: Optional[float] = None,
-        upper_spec_uuid: Optional[str] = None,
-        lower_spec_uuid: Optional[str] = None,
+        upper_spec: float | None = None,
+        lower_spec: float | None = None,
+        upper_spec_uuid: str | None = None,
+        lower_spec_uuid: str | None = None,
         value_column: str = "value_double",
         event_uuid: str = "quality:capability_trend",
         time_column: str = "systime",
@@ -47,12 +47,12 @@ class CapabilityTrendingEvents(Base):
 
         # Resolve spec limits
         if upper_spec is not None:
-            self.upper_spec_fixed: Optional[float] = float(upper_spec)
+            self.upper_spec_fixed: float | None = float(upper_spec)
         else:
             self.upper_spec_fixed = None
 
         if lower_spec is not None:
-            self.lower_spec_fixed: Optional[float] = float(lower_spec)
+            self.lower_spec_fixed: float | None = float(lower_spec)
         else:
             self.lower_spec_fixed = None
 
@@ -118,7 +118,7 @@ class CapabilityTrendingEvents(Base):
         if overall_std == 0 or pd.isna(overall_std):
             overall_std = np.nan
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
             n = len(vals)
@@ -189,7 +189,7 @@ class CapabilityTrendingEvents(Base):
             return pd.DataFrame(columns=cols)
 
         cpk_vals = cap["cpk"].values
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for i in range(len(cap)):
             cpk = cpk_vals[i]
@@ -262,7 +262,7 @@ class CapabilityTrendingEvents(Base):
         y = cpk_vals[valid_mask]
         slope, intercept, _, _, _ = stats.linregress(x, y)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i in range(len(cap)):
             cpk = cpk_vals[i]
             if np.isnan(cpk):
@@ -310,7 +310,7 @@ class CapabilityTrendingEvents(Base):
         sig = self.signal[[self.time_column, self.value_column]].copy()
         sig = sig.set_index(self.time_column)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
             n = len(vals)

--- a/src/ts_shape/events/quality/capability_trending.py
+++ b/src/ts_shape/events/quality/capability_trending.py
@@ -2,7 +2,7 @@ import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
 from scipy import stats  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/data_gap_analysis.py
+++ b/src/ts_shape/events/quality/data_gap_analysis.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/data_gap_analysis.py
+++ b/src/ts_shape/events/quality/data_gap_analysis.py
@@ -75,7 +75,7 @@ class DataGapAnalysisEvents(Base):
         times = self.signal[self.time_column].values
         diffs = np.diff(times)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i, d in enumerate(diffs):
             gap = pd.Timedelta(d)
             if gap >= threshold:
@@ -197,7 +197,7 @@ class DataGapAnalysisEvents(Base):
 
         counts = sig[self.value_column].resample(freq).count()
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, count in counts.items():
             end = ts + window_td
             # Find gaps overlapping this window
@@ -266,7 +266,7 @@ class DataGapAnalysisEvents(Base):
         signal_std = float(np.nanstd(values))
         safe_threshold = 2.0 * signal_std if signal_std > 0 else float("inf")
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i, d in enumerate(diffs):
             gap = pd.Timedelta(d)
             if gap < min_td or gap > max_td:

--- a/src/ts_shape/events/quality/gauge_repeatability.py
+++ b/src/ts_shape/events/quality/gauge_repeatability.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/gauge_repeatability.py
+++ b/src/ts_shape/events/quality/gauge_repeatability.py
@@ -43,7 +43,7 @@ class GaugeRepeatabilityEvents(Base):
         *,
         part_column: str = "value_string",
         value_column: str = "value_double",
-        operator_column: Optional[str] = None,
+        operator_column: str | None = None,
         event_uuid: str = "quality:gauge_rr",
         time_column: str = "systime",
     ) -> None:
@@ -62,7 +62,7 @@ class GaugeRepeatabilityEvents(Base):
             .sort_values(self.time_column)
         )
 
-    def repeatability(self, n_trials: Optional[int] = None) -> pd.DataFrame:
+    def repeatability(self, n_trials: int | None = None) -> pd.DataFrame:
         """Equipment Variation (EV) — within-part variation.
 
         Groups measurements by part, computes range-based or pooled
@@ -79,7 +79,7 @@ class GaugeRepeatabilityEvents(Base):
         if self.signal.empty or self.part_column not in self.signal.columns:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         grouped = self.signal.groupby(self.part_column)
 
         ranges = []
@@ -127,7 +127,7 @@ class GaugeRepeatabilityEvents(Base):
         if self.signal.empty or self.operator_column not in self.signal.columns:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         # Per-operator mean across all parts
         op_means = []
@@ -167,7 +167,7 @@ class GaugeRepeatabilityEvents(Base):
             pd.DataFrame(events, columns=cols) if events else pd.DataFrame(columns=cols)
         )
 
-    def gauge_rr_summary(self, tolerance_range: Optional[float] = None) -> pd.DataFrame:
+    def gauge_rr_summary(self, tolerance_range: float | None = None) -> pd.DataFrame:
         """Full Gauge R&R summary table.
 
         Computes EV, AV, GRR, PV, TV, %GRR, %PV, and number of
@@ -239,7 +239,7 @@ class GaugeRepeatabilityEvents(Base):
 
         return pd.DataFrame([result])
 
-    def measurement_bias(self, reference_values: Dict[str, float]) -> pd.DataFrame:
+    def measurement_bias(self, reference_values: dict[str, float]) -> pd.DataFrame:
         """Compare average measurements to known reference values.
 
         Args:
@@ -254,7 +254,7 @@ class GaugeRepeatabilityEvents(Base):
         if self.signal.empty or self.part_column not in self.signal.columns:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for part, group in self.signal.groupby(self.part_column):
             if part not in reference_values:
                 continue

--- a/src/ts_shape/events/quality/multi_sensor_validation.py
+++ b/src/ts_shape/events/quality/multi_sensor_validation.py
@@ -25,7 +25,7 @@ class MultiSensorValidationEvents(Base):
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        sensor_uuids: List[str],
+        sensor_uuids: list[str],
         *,
         value_column: str = "value_double",
         event_uuid: str = "quality:multi_sensor",
@@ -84,7 +84,7 @@ class MultiSensorValidationEvents(Base):
         if self._pivot.empty:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in self._pivot.resample(window):
             group = group.dropna(how="all")
             if group.empty or len(group) < 1:
@@ -128,7 +128,7 @@ class MultiSensorValidationEvents(Base):
             return pd.DataFrame(columns=cols)
 
         pairs = list(combinations(self.sensor_uuids, 2))
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for ts, group in self._pivot.resample(window):
             group = group.dropna(how="all")
@@ -172,7 +172,7 @@ class MultiSensorValidationEvents(Base):
         if self._pivot.empty:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in self._pivot.resample(window):
             group = group.dropna(how="all")
             if group.empty:
@@ -221,7 +221,7 @@ class MultiSensorValidationEvents(Base):
         if self._pivot.empty:
             return pd.DataFrame(columns=cols)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in self._pivot.resample(window):
             group = group.dropna(how="all")
             if group.empty:

--- a/src/ts_shape/events/quality/multi_sensor_validation.py
+++ b/src/ts_shape/events/quality/multi_sensor_validation.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 from itertools import combinations
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/outlier_detection.py
+++ b/src/ts_shape/events/quality/outlier_detection.py
@@ -230,7 +230,7 @@ class OutlierDetectionEvents(Base):
         self,
         contamination: float = 0.1,
         include_singles: bool = True,
-        random_state: Optional[int] = 42,
+        random_state: int | None = 42,
     ) -> pd.DataFrame:
         """
         Detects outliers using sklearn's IsolationForest algorithm.

--- a/src/ts_shape/events/quality/outlier_detection.py
+++ b/src/ts_shape/events/quality/outlier_detection.py
@@ -2,7 +2,6 @@ import logging
 import pandas as pd  # type: ignore
 import numpy as np
 from scipy.stats import zscore
-from typing import Optional
 from ts_shape.utils.base import Base
 from ts_shape.events._output import empty_event_df, finalize_point_df
 

--- a/src/ts_shape/events/quality/sensor_drift.py
+++ b/src/ts_shape/events/quality/sensor_drift.py
@@ -30,8 +30,8 @@ class SensorDriftEvents(Base):
         dataframe: pd.DataFrame,
         signal_uuid: str,
         *,
-        reference_uuid: Optional[str] = None,
-        reference_value: Optional[float] = None,
+        reference_uuid: str | None = None,
+        reference_value: float | None = None,
         value_column: str = "value_double",
         event_uuid: str = "quality:sensor_drift",
         time_column: str = "systime",
@@ -63,7 +63,7 @@ class SensorDriftEvents(Base):
         else:
             self._reference_series = None
 
-    def _get_reference_for_window(self, start, end) -> Optional[float]:
+    def _get_reference_for_window(self, start, end) -> float | None:
         """Get reference value for a time window."""
         if self.reference_value is not None:
             return self.reference_value
@@ -77,7 +77,7 @@ class SensorDriftEvents(Base):
         return None
 
     def detect_zero_drift(
-        self, window: str = "8h", threshold: Optional[float] = None
+        self, window: str = "8h", threshold: float | None = None
     ) -> pd.DataFrame:
         """Track mean offset from baseline per window.
 
@@ -97,9 +97,9 @@ class SensorDriftEvents(Base):
         sig = self.signal[[self.time_column, self.value_column]].copy()
         sig = sig.set_index(self.time_column)
 
-        events: List[Dict[str, Any]] = []
-        prev_offset: Optional[float] = None
-        auto_threshold: Optional[float] = None
+        events: list[dict[str, Any]] = []
+        prev_offset: float | None = None
+        auto_threshold: float | None = None
 
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
@@ -196,8 +196,8 @@ class SensorDriftEvents(Base):
         sig = self.signal[[self.time_column, self.value_column]].copy()
         sig = sig.set_index(self.time_column)
 
-        events: List[Dict[str, Any]] = []
-        baseline_sensitivity: Optional[float] = None
+        events: list[dict[str, Any]] = []
+        baseline_sensitivity: float | None = None
 
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
@@ -249,7 +249,7 @@ class SensorDriftEvents(Base):
         sig = sig.set_index(self.time_column)
 
         # Compute per-window metric
-        window_values: List[tuple] = []
+        window_values: list[tuple] = []
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
             if len(vals) < 2:
@@ -280,7 +280,7 @@ class SensorDriftEvents(Base):
         else:
             direction = "decreasing"
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i, (ts, v) in enumerate(window_values):
             events.append(
                 {
@@ -297,7 +297,7 @@ class SensorDriftEvents(Base):
         )
 
     def calibration_health(
-        self, window: str = "8h", tolerance: Optional[float] = None
+        self, window: str = "8h", tolerance: float | None = None
     ) -> pd.DataFrame:
         """Composite calibration health score per window.
 
@@ -317,7 +317,7 @@ class SensorDriftEvents(Base):
         sig = self.signal[[self.time_column, self.value_column]].copy()
         sig = sig.set_index(self.time_column)
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in sig.resample(window):
             vals = group[self.value_column].dropna()
             if len(vals) < 2:

--- a/src/ts_shape/events/quality/sensor_drift.py
+++ b/src/ts_shape/events/quality/sensor_drift.py
@@ -2,7 +2,7 @@ import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
 from scipy import stats  # type: ignore
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/signal_quality.py
+++ b/src/ts_shape/events/quality/signal_quality.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/quality/signal_quality.py
+++ b/src/ts_shape/events/quality/signal_quality.py
@@ -65,7 +65,7 @@ class SignalQualityEvents(Base):
         expected_td = pd.to_timedelta(expected_freq)
         threshold = expected_td * tolerance_factor
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for i, d in enumerate(diffs):
             gap = pd.Timedelta(d)
             if gap > threshold:
@@ -115,7 +115,7 @@ class SignalQualityEvents(Base):
             sig["interval"].resample(window).agg(["mean", "std", "min", "max", "count"])
         )
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, row in resampled.iterrows():
             if row["count"] < 2 or pd.isna(row["mean"]):
                 continue
@@ -173,7 +173,7 @@ class SignalQualityEvents(Base):
             return pd.DataFrame(columns=cols)
 
         groups = (out_of_range != out_of_range.shift()).cumsum()
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
 
         for _, seg in sig.groupby(groups):
             seg_oor = out_of_range.loc[seg.index]
@@ -234,7 +234,7 @@ class SignalQualityEvents(Base):
 
         counts = sig[self.value_column].resample(window).count()
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, actual in counts.items():
             completeness = min(100.0, round(actual / expected_per_window * 100, 2))
             events.append(

--- a/src/ts_shape/events/quality/statistical_process_control.py
+++ b/src/ts_shape/events/quality/statistical_process_control.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np
-from typing import List, Optional, Tuple
 from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)

--- a/src/ts_shape/events/quality/statistical_process_control.py
+++ b/src/ts_shape/events/quality/statistical_process_control.py
@@ -263,7 +263,7 @@ class StatisticalProcessControlRuleBased(Base):
 
     def _calculate_rule_2_7_8_optimized(
         self, df: pd.DataFrame, limits: pd.DataFrame
-    ) -> Tuple[pd.Series, pd.Series, pd.Series]:
+    ) -> tuple[pd.Series, pd.Series, pd.Series]:
         """
         Optimized calculation for rules 2, 7, and 8 that share common computations.
         Reduces multiple passes through the data by computing related patterns together.
@@ -299,7 +299,7 @@ class StatisticalProcessControlRuleBased(Base):
         return rule_2, rule_7, rule_8
 
     def apply_rules_vectorized(
-        self, selected_rules: Optional[List[str]] = None
+        self, selected_rules: list[str] | None = None
     ) -> pd.DataFrame:
         """
         Applies SPC rules using vectorized operations with optimized multi-rule processing.
@@ -483,7 +483,7 @@ class StatisticalProcessControlRuleBased(Base):
             )
 
     def detect_cusum_shifts(
-        self, target: Optional[float] = None, k: float = 0.5, h: float = 5.0
+        self, target: float | None = None, k: float = 0.5, h: float = 5.0
     ) -> pd.DataFrame:
         """
         Detect process shifts using CUSUM (Cumulative Sum) control chart.
@@ -669,7 +669,7 @@ class StatisticalProcessControlRuleBased(Base):
         return result
 
     def process(
-        self, selected_rules: Optional[List[str]] = None, include_severity: bool = False
+        self, selected_rules: list[str] | None = None, include_severity: bool = False
     ) -> pd.DataFrame:
         """
         Applies the selected SPC rules and generates a DataFrame of events where any rules are violated.

--- a/src/ts_shape/events/quality/tolerance_deviation.py
+++ b/src/ts_shape/events/quality/tolerance_deviation.py
@@ -3,7 +3,7 @@ from ts_shape.utils.base import Base
 import pandas as pd  # type: ignore
 import numpy as np
 import operator
-from typing import Callable, Optional, Dict
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/events/quality/tolerance_deviation.py
+++ b/src/ts_shape/events/quality/tolerance_deviation.py
@@ -26,13 +26,13 @@ class ToleranceDeviationEvents(Base):
         dataframe: pd.DataFrame,
         tolerance_column: str,
         actual_column: str,
-        tolerance_uuid: Optional[str] = None,
+        tolerance_uuid: str | None = None,
         actual_uuid: str = None,
         event_uuid: str = None,
         compare_func: Callable[[pd.Series, pd.Series], pd.Series] = operator.ge,
         time_threshold: str = "5min",
-        upper_tolerance_uuid: Optional[str] = None,
-        lower_tolerance_uuid: Optional[str] = None,
+        upper_tolerance_uuid: str | None = None,
+        lower_tolerance_uuid: str | None = None,
         warning_threshold: float = 0.8,
         tolerance_lag: str = "0s",
     ) -> None:
@@ -72,15 +72,15 @@ class ToleranceDeviationEvents(Base):
                     "Either tolerance_uuid or both upper_tolerance_uuid and lower_tolerance_uuid must be provided"
                 )
             # Use single tolerance for both upper and lower (backward compatibility)
-            self.tolerance_uuid: Optional[str] = tolerance_uuid
-            self.upper_tolerance_uuid: Optional[str] = None
-            self.lower_tolerance_uuid: Optional[str] = None
+            self.tolerance_uuid: str | None = tolerance_uuid
+            self.upper_tolerance_uuid: str | None = None
+            self.lower_tolerance_uuid: str | None = None
             self.separate_tolerances: bool = False
         else:
             # Use separate upper and lower tolerances
-            self.tolerance_uuid: Optional[str] = None
-            self.upper_tolerance_uuid: Optional[str] = upper_tolerance_uuid
-            self.lower_tolerance_uuid: Optional[str] = lower_tolerance_uuid
+            self.tolerance_uuid: str | None = None
+            self.upper_tolerance_uuid: str | None = upper_tolerance_uuid
+            self.lower_tolerance_uuid: str | None = lower_tolerance_uuid
             self.separate_tolerances: bool = True
 
     def _apply_tolerance_lag(
@@ -419,8 +419,8 @@ class ToleranceDeviationEvents(Base):
         return events_df
 
     def compute_capability_indices(
-        self, target_value: Optional[float] = None
-    ) -> Dict[str, float]:
+        self, target_value: float | None = None
+    ) -> dict[str, float]:
         """
         Calculate process capability indices (Cp, Cpk, Pp, Ppk).
 

--- a/src/ts_shape/events/quality/value_distribution.py
+++ b/src/ts_shape/events/quality/value_distribution.py
@@ -1,7 +1,8 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any, Sequence
+from typing import Any
+from collections.abc import Sequence
 from scipy import stats as sp_stats  # type: ignore
 
 from ts_shape.utils.base import Base

--- a/src/ts_shape/events/quality/value_distribution.py
+++ b/src/ts_shape/events/quality/value_distribution.py
@@ -89,7 +89,7 @@ class ValueDistributionEvents(Base):
             global_std = 1.0
         sep_abs = min_separation * global_std
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         prev_mode = None
 
         for ts, group in sig.resample(window):
@@ -147,7 +147,7 @@ class ValueDistributionEvents(Base):
         density = kde(x_grid)
 
         # Find local maxima
-        peaks: List[int] = []
+        peaks: list[int] = []
         for i in range(1, len(density) - 1):
             if density[i] > density[i - 1] and density[i] > density[i + 1]:
                 peaks.append(i)
@@ -235,7 +235,7 @@ class ValueDistributionEvents(Base):
             .set_index(self.time_column)
         )
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in sig.resample(freq):
             vals = group[self.value_column].dropna()
             if len(vals) < min_samples:
@@ -296,13 +296,13 @@ class ValueDistributionEvents(Base):
             .set_index(self.time_column)
         )
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for ts, group in sig.resample(freq):
             vals = group[self.value_column].dropna()
             if len(vals) < 2:
                 continue
 
-            row: Dict[str, Any] = {
+            row: dict[str, Any] = {
                 "start": ts,
                 "n_samples": len(vals),
             }
@@ -323,7 +323,7 @@ class ValueDistributionEvents(Base):
     @staticmethod
     def _find_modes(
         values: np.ndarray, max_modes: int, min_separation: float
-    ) -> List[float]:
+    ) -> list[float]:
         """Find up to *max_modes* peaks in the value distribution via KDE."""
         if len(values) < 5:
             return []
@@ -337,7 +337,7 @@ class ValueDistributionEvents(Base):
         density = kde(x_grid)
 
         # Local maxima
-        peaks: List[int] = []
+        peaks: list[int] = []
         for i in range(1, len(density) - 1):
             if density[i] > density[i - 1] and density[i] > density[i + 1]:
                 peaks.append(i)
@@ -347,7 +347,7 @@ class ValueDistributionEvents(Base):
 
         # Sort by density height, keep modes separated by min_separation
         peaks.sort(key=lambda idx: density[idx], reverse=True)
-        modes: List[float] = []
+        modes: list[float] = []
         for p in peaks:
             val = float(x_grid[p])
             if all(abs(val - m) >= min_separation for m in modes):

--- a/src/ts_shape/events/supplychain/inventory_monitoring.py
+++ b/src/ts_shape/events/supplychain/inventory_monitoring.py
@@ -7,7 +7,7 @@ identifies reorder point breaches, and predicts stockouts.
 import logging
 import pandas as pd  # type: ignore
 import numpy as np
-from typing import List, Dict, Any
+from typing import Any
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/events/supplychain/inventory_monitoring.py
+++ b/src/ts_shape/events/supplychain/inventory_monitoring.py
@@ -100,7 +100,7 @@ class InventoryMonitoringEvents(Base):
         # Group contiguous below-threshold segments
         lv["group"] = (lv["below"] != lv["below"].shift()).cumsum()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         for _, seg in lv[lv["below"]].groupby("group"):
             start = seg[self.time_column].iloc[0]
             end = seg[self.time_column].iloc[-1]
@@ -215,7 +215,7 @@ class InventoryMonitoringEvents(Base):
         # Detect transitions into breach (was above, now below)
         lv["prev_value"] = lv[self.value_column].shift()
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
 
         # Reorder point breaches: crossing below reorder_level
         reorder_mask = (lv[self.value_column] < reorder_level) & (
@@ -294,7 +294,7 @@ class InventoryMonitoringEvents(Base):
         lv = self.levels[[self.time_column, self.value_column]].copy()
         window_td = pd.to_timedelta(consumption_rate_window)
 
-        rows: List[Dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
         times = lv[self.time_column].values
         values = lv[self.value_column].values
 

--- a/src/ts_shape/features/cross_signal.py
+++ b/src/ts_shape/features/cross_signal.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import List, Dict, Any
+from typing import Any
 
 from scipy import signal as scipy_signal  # type: ignore
 from scipy import stats as scipy_stats  # type: ignore

--- a/src/ts_shape/features/cross_signal.py
+++ b/src/ts_shape/features/cross_signal.py
@@ -69,7 +69,7 @@ class CrossSignalAnalytics:
         n = min(len(x), len(y))
         x, y = x[:n], y[:n]
 
-        results_by_lag: List[Dict[str, Any]] = []
+        results_by_lag: list[dict[str, Any]] = []
 
         for p in range(1, max_lag + 1):
             if n <= 2 * p + 1:

--- a/src/ts_shape/features/cycles/cycle_processor.py
+++ b/src/ts_shape/features/cycles/cycle_processor.py
@@ -61,7 +61,7 @@ class CycleDataProcessor(Base):
         )
         logger.debug(f"Built interval index with {len(intervals)} cycles.")
 
-    def split_by_cycle(self) -> Dict[str, pd.DataFrame]:
+    def split_by_cycle(self) -> dict[str, pd.DataFrame]:
         """
         Splits the values DataFrame by cycles defined in the cycles DataFrame.
         Uses optimized interval-based assignment.
@@ -140,8 +140,8 @@ class CycleDataProcessor(Base):
         return result
 
     def group_by_cycle_uuid(
-        self, data: Optional[pd.DataFrame] = None
-    ) -> List[pd.DataFrame]:
+        self, data: pd.DataFrame | None = None
+    ) -> list[pd.DataFrame]:
         """
         Group the DataFrame by the cycle_uuid column, resulting in a list of DataFrames, each containing data for one cycle.
 
@@ -165,8 +165,8 @@ class CycleDataProcessor(Base):
         return grouped_dataframes
 
     def split_dataframes_by_group(
-        self, dfs: List[pd.DataFrame], column: str
-    ) -> List[pd.DataFrame]:
+        self, dfs: list[pd.DataFrame], column: str
+    ) -> list[pd.DataFrame]:
         """
         Splits a list of DataFrames by groups based on a specified column.
         This function performs a groupby operation on each DataFrame in the list and then flattens the result.
@@ -330,7 +330,7 @@ class CycleDataProcessor(Base):
         metric: str = "value_double",
         method: str = "low_variability",
         top_n: int = 5,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Identify the best performing cycles (golden cycles).
 

--- a/src/ts_shape/features/cycles/cycle_processor.py
+++ b/src/ts_shape/features/cycles/cycle_processor.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, List, Optional
 import pandas as pd  # type: ignore
 import numpy as np
 from ts_shape.utils.base import Base

--- a/src/ts_shape/features/cycles/cycles_extractor.py
+++ b/src/ts_shape/features/cycles/cycles_extractor.py
@@ -14,7 +14,7 @@ class CycleExtractor(Base):
         self,
         dataframe: pd.DataFrame,
         start_uuid: str,
-        end_uuid: Optional[str] = None,
+        end_uuid: str | None = None,
         value_change_threshold: float = 0.0,
     ):
         """Initializes the class with the data and the UUIDs for cycle start and end.
@@ -39,7 +39,7 @@ class CycleExtractor(Base):
         self.value_change_threshold = abs(value_change_threshold)
 
         # Statistics tracking
-        self._stats: Dict[str, Any] = {
+        self._stats: dict[str, Any] = {
             "total_cycles": 0,
             "complete_cycles": 0,
             "incomplete_cycles": 0,
@@ -455,7 +455,7 @@ class CycleExtractor(Base):
 
         return result_df
 
-    def suggest_method(self) -> Dict[str, Any]:
+    def suggest_method(self) -> dict[str, Any]:
         """Suggest the best cycle extraction method based on data characteristics.
 
         Analyzes the input DataFrame to recommend appropriate extraction method(s).
@@ -553,7 +553,7 @@ class CycleExtractor(Base):
         logger.info(f"Method suggestion: {suggestions['recommended_methods']}")
         return suggestions
 
-    def get_extraction_stats(self) -> Dict[str, Any]:
+    def get_extraction_stats(self) -> dict[str, Any]:
         """Get statistics about the last cycle extraction.
 
         Returns:

--- a/src/ts_shape/features/cycles/cycles_extractor.py
+++ b/src/ts_shape/features/cycles/cycles_extractor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict, Any
+from typing import Any
 import pandas as pd  # type: ignore
 import uuid
 from ts_shape.utils.base import Base

--- a/src/ts_shape/features/export.py
+++ b/src/ts_shape/features/export.py
@@ -28,7 +28,7 @@ class FeatureMatrixExporter:
         matrix = FeatureMatrixExporter.to_feature_matrix(df, uuid_col='uuid', value_cols=['value_double'])
     """
 
-    _DEFAULT_AGGS: Dict[str, Callable] = {
+    _DEFAULT_AGGS: dict[str, Callable] = {
         "mean": np.mean,
         "std": np.std,
         "min": np.min,
@@ -40,9 +40,9 @@ class FeatureMatrixExporter:
         cls,
         df: pd.DataFrame,
         uuid_col: str = "uuid",
-        value_cols: Optional[List[str]] = None,
-        agg_funcs: Optional[Dict[str, Union[str, Callable]]] = None,
-        group_col: Optional[str] = None,
+        value_cols: list[str] | None = None,
+        agg_funcs: dict[str, Union[str, Callable]] | None = None,
+        group_col: str | None = None,
     ) -> pd.DataFrame:
         """Pivot a long-format DataFrame into a wide feature matrix.
 
@@ -90,7 +90,7 @@ class FeatureMatrixExporter:
                 f"group_col '{group_col}' not found. Available columns: {list(df.columns)}"
             )
 
-        rows: Dict = {}
+        rows: dict = {}
         if group_col:
             iterator = (
                 ((rk, sig), grp) for (rk, sig), grp in df.groupby([group_col, uuid_col])

--- a/src/ts_shape/features/export.py
+++ b/src/ts_shape/features/export.py
@@ -5,7 +5,7 @@ suitable for machine-learning workflows.
 """
 
 import logging
-from typing import Dict, List, Optional, Callable, Union
+from collections.abc import Callable
 import pandas as pd  # type: ignore
 import numpy as np
 
@@ -41,7 +41,7 @@ class FeatureMatrixExporter:
         df: pd.DataFrame,
         uuid_col: str = "uuid",
         value_cols: list[str] | None = None,
-        agg_funcs: dict[str, Union[str, Callable]] | None = None,
+        agg_funcs: dict[str, str | Callable] | None = None,
         group_col: str | None = None,
     ) -> pd.DataFrame:
         """Pivot a long-format DataFrame into a wide feature matrix.

--- a/src/ts_shape/features/pattern_recognition.py
+++ b/src/ts_shape/features/pattern_recognition.py
@@ -74,7 +74,7 @@ class PatternRecognition(Base):
         series: np.ndarray,
         window_size: int,
         exclusion_zone: int,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Compute the Matrix Profile and Matrix Profile Index.
 
         Args:
@@ -114,7 +114,7 @@ class PatternRecognition(Base):
         value_column: str = "value_double",
         window_size: int = 50,
         top_k: int = 5,
-        exclusion_zone: Optional[int] = None,
+        exclusion_zone: int | None = None,
         time_column: str = "systime",
     ) -> pd.DataFrame:
         """Find the top-k recurring subsequence patterns (motifs).
@@ -174,7 +174,7 @@ class PatternRecognition(Base):
         value_column: str = "value_double",
         window_size: int = 50,
         top_k: int = 5,
-        exclusion_zone: Optional[int] = None,
+        exclusion_zone: int | None = None,
         time_column: str = "systime",
     ) -> pd.DataFrame:
         """Find the top-k anomalous subsequences (discords).
@@ -295,7 +295,7 @@ class PatternRecognition(Base):
         dataframe: pd.DataFrame,
         template: np.ndarray,
         value_column: str = "value_double",
-        threshold: Optional[float] = None,
+        threshold: float | None = None,
         normalize: bool = True,
         time_column: str = "systime",
     ) -> pd.DataFrame:

--- a/src/ts_shape/features/pattern_recognition.py
+++ b/src/ts_shape/features/pattern_recognition.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Optional, Tuple
 
 from scipy.fft import fft, ifft  # type: ignore
 

--- a/src/ts_shape/features/segment_analysis/profile_comparison.py
+++ b/src/ts_shape/features/segment_analysis/profile_comparison.py
@@ -30,8 +30,8 @@ class ProfileComparison(Base):
     def _get_metric_columns(
         cls,
         df: pd.DataFrame,
-        metric_columns: Optional[List[str]] = None,
-    ) -> List[str]:
+        metric_columns: list[str] | None = None,
+    ) -> list[str]:
         """Identify numeric metric columns from a profiles DataFrame."""
         non_metric = {
             "uuid",
@@ -58,7 +58,7 @@ class ProfileComparison(Base):
         cls,
         metric_profiles: pd.DataFrame,
         group_column: str = "uuid",
-        metric_columns: Optional[List[str]] = None,
+        metric_columns: list[str] | None = None,
         distance_metric: str = "euclidean",
         normalize: bool = True,
     ) -> pd.DataFrame:
@@ -109,7 +109,7 @@ class ProfileComparison(Base):
         cls,
         distance_matrix: pd.DataFrame,
         n_clusters: int = 3,
-        distance_threshold: Optional[float] = None,
+        distance_threshold: float | None = None,
         linkage_method: str = "average",
     ) -> pd.DataFrame:
         """Group items by metric similarity using hierarchical clustering.
@@ -212,7 +212,7 @@ class ProfileComparison(Base):
         metric_profiles: pd.DataFrame,
         uuid_column: str = "uuid",
         group_column: str = "segment_index",
-        metric_columns: Optional[List[str]] = None,
+        metric_columns: list[str] | None = None,
         normalize: bool = True,
     ) -> pd.DataFrame:
         """Track how each UUID's metrics change across consecutive segments.
@@ -264,7 +264,7 @@ class ProfileComparison(Base):
         metric_profiles: pd.DataFrame,
         uuid_column: str = "uuid",
         group_column: str = "segment_value",
-        metric_columns: Optional[List[str]] = None,
+        metric_columns: list[str] | None = None,
         normalize: bool = True,
         top_k: int = 10,
     ) -> pd.DataFrame:

--- a/src/ts_shape/features/segment_analysis/profile_comparison.py
+++ b/src/ts_shape/features/segment_analysis/profile_comparison.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Optional, List
 
 from scipy.spatial.distance import pdist, squareform  # type: ignore
 from scipy.cluster.hierarchy import linkage, fcluster  # type: ignore

--- a/src/ts_shape/features/segment_analysis/segment_extractor.py
+++ b/src/ts_shape/features/segment_analysis/segment_extractor.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional
 
 from ts_shape.utils.base import Base
 

--- a/src/ts_shape/features/segment_analysis/segment_extractor.py
+++ b/src/ts_shape/features/segment_analysis/segment_extractor.py
@@ -26,7 +26,7 @@ class SegmentExtractor(Base):
         uuid_column: str = "uuid",
         value_column: str = "value_string",
         time_column: str = "systime",
-        min_duration: Optional[str] = None,
+        min_duration: str | None = None,
     ) -> pd.DataFrame:
         """Detect value transitions and extract time ranges per segment.
 

--- a/src/ts_shape/features/segment_analysis/segment_processor.py
+++ b/src/ts_shape/features/segment_analysis/segment_processor.py
@@ -49,7 +49,7 @@ class SegmentProcessor(Base):
         time_ranges: pd.DataFrame,
         uuid_column: str = "uuid",
         time_column: str = "systime",
-        target_uuids: Optional[List[str]] = None,
+        target_uuids: list[str] | None = None,
     ) -> pd.DataFrame:
         """Filter process parameter data by extracted time ranges.
 
@@ -126,7 +126,7 @@ class SegmentProcessor(Base):
         uuid_column: str = "uuid",
         value_column: str = "value_double",
         group_column: str = "segment_value",
-        metrics: Optional[List[str]] = None,
+        metrics: list[str] | None = None,
     ) -> pd.DataFrame:
         """Compute statistical metrics per UUID per segment.
 

--- a/src/ts_shape/features/segment_analysis/segment_processor.py
+++ b/src/ts_shape/features/segment_analysis/segment_processor.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, List
 
 from ts_shape.utils.base import Base
 from ts_shape.features.stats.numeric_stats import NumericStatistics

--- a/src/ts_shape/features/segment_analysis/time_windowed_features.py
+++ b/src/ts_shape/features/segment_analysis/time_windowed_features.py
@@ -28,8 +28,8 @@ class TimeWindowedFeatureTable(Base):
         time_column: str = "systime",
         uuid_column: str = "uuid",
         value_column: str = "value_double",
-        segment_column: Optional[str] = "segment_value",
-        metrics: Optional[List[str]] = None,
+        segment_column: str | None = "segment_value",
+        metrics: list[str] | None = None,
     ) -> pd.DataFrame:
         """Compute statistical metrics per UUID per time window (long format).
 
@@ -122,8 +122,8 @@ class TimeWindowedFeatureTable(Base):
         time_column: str = "systime",
         uuid_column: str = "uuid",
         value_column: str = "value_double",
-        segment_column: Optional[str] = "segment_value",
-        metrics: Optional[List[str]] = None,
+        segment_column: str | None = "segment_value",
+        metrics: list[str] | None = None,
         column_separator: str = "__",
     ) -> pd.DataFrame:
         """Compute a wide-format feature table with one row per time window.

--- a/src/ts_shape/features/segment_analysis/time_windowed_features.py
+++ b/src/ts_shape/features/segment_analysis/time_windowed_features.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, List
 
 from ts_shape.utils.base import Base
 from ts_shape.features.stats.numeric_stats import NumericStatistics

--- a/src/ts_shape/features/stats/boolean_stats.py
+++ b/src/ts_shape/features/stats/boolean_stats.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Dict, Union
 from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
@@ -73,7 +72,7 @@ class BooleanStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> dict[str, Union[int, float, bool]]:
+    ) -> dict[str, int | float | bool]:
         """Returns a summary of boolean statistics for the specified column as a dictionary."""
         return {
             "true_count": cls.count_true(dataframe, column_name),

--- a/src/ts_shape/features/stats/boolean_stats.py
+++ b/src/ts_shape/features/stats/boolean_stats.py
@@ -73,7 +73,7 @@ class BooleanStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> Dict[str, Union[int, float, bool]]:
+    ) -> dict[str, Union[int, float, bool]]:
         """Returns a summary of boolean statistics for the specified column as a dictionary."""
         return {
             "true_count": cls.count_true(dataframe, column_name),

--- a/src/ts_shape/features/stats/feature_table.py
+++ b/src/ts_shape/features/stats/feature_table.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, Union
 import pandas as pd  # type: ignore
 from pandas.api.types import is_numeric_dtype, is_bool_dtype, is_object_dtype
 
@@ -34,7 +33,7 @@ class DescriptiveFeatures:
         """
         self.data = dataframe
 
-    def overall_stats(self, group: pd.DataFrame) -> dict[str, Union[int, float]]:
+    def overall_stats(self, group: pd.DataFrame) -> dict[str, int | float]:
         """Compute and return overall statistics for the DataFrame group.
 
         - **total_rows**: Total number of rows in the group.
@@ -57,7 +56,7 @@ class DescriptiveFeatures:
 
     def compute_per_group(
         self, group: pd.DataFrame
-    ) -> dict[str, dict[str, Union[int, float, str, bool]]]:
+    ) -> dict[str, dict[str, int | float | str | bool]]:
         """Compute and return statistics for each column in the DataFrame group.
 
         Returns:
@@ -87,9 +86,7 @@ class DescriptiveFeatures:
 
     def compute(
         self, output_format: str = "dict"
-    ) -> Union[
-        pd.DataFrame, dict[str, dict[str, dict[str, Union[int, float, str, bool]]]]
-    ]:
+    ) -> pd.DataFrame | dict[str, dict[str, dict[str, int | float | str | bool]]]:
         """Compute and return descriptive statistics for each UUID in the DataFrame.
 
         Args:

--- a/src/ts_shape/features/stats/feature_table.py
+++ b/src/ts_shape/features/stats/feature_table.py
@@ -34,7 +34,7 @@ class DescriptiveFeatures:
         """
         self.data = dataframe
 
-    def overall_stats(self, group: pd.DataFrame) -> Dict[str, Union[int, float]]:
+    def overall_stats(self, group: pd.DataFrame) -> dict[str, Union[int, float]]:
         """Compute and return overall statistics for the DataFrame group.
 
         - **total_rows**: Total number of rows in the group.
@@ -57,7 +57,7 @@ class DescriptiveFeatures:
 
     def compute_per_group(
         self, group: pd.DataFrame
-    ) -> Dict[str, Dict[str, Union[int, float, str, bool]]]:
+    ) -> dict[str, dict[str, Union[int, float, str, bool]]]:
         """Compute and return statistics for each column in the DataFrame group.
 
         Returns:
@@ -88,7 +88,7 @@ class DescriptiveFeatures:
     def compute(
         self, output_format: str = "dict"
     ) -> Union[
-        pd.DataFrame, Dict[str, Dict[str, Dict[str, Union[int, float, str, bool]]]]
+        pd.DataFrame, dict[str, dict[str, dict[str, Union[int, float, str, bool]]]]
     ]:
         """Compute and return descriptive statistics for each UUID in the DataFrame.
 

--- a/src/ts_shape/features/stats/numeric_stats.py
+++ b/src/ts_shape/features/stats/numeric_stats.py
@@ -1,7 +1,6 @@
 import logging
 import pandas as pd  # type: ignore
 from scipy import stats
-from typing import Dict, Union
 from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ class NumericStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> dict[str, Union[float, int]]:
+    ) -> dict[str, float | int]:
         """Returns a dictionary with comprehensive numeric statistics for the specified column."""
         _series = dataframe[column_name]
         return {

--- a/src/ts_shape/features/stats/numeric_stats.py
+++ b/src/ts_shape/features/stats/numeric_stats.py
@@ -109,7 +109,7 @@ class NumericStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> Dict[str, Union[float, int]]:
+    ) -> dict[str, Union[float, int]]:
         """Returns a dictionary with comprehensive numeric statistics for the specified column."""
         _series = dataframe[column_name]
         return {

--- a/src/ts_shape/features/stats/string_stats.py
+++ b/src/ts_shape/features/stats/string_stats.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Dict, Union
 from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)
@@ -143,7 +142,7 @@ class StringStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> dict[str, Union[int, str, float]]:
+    ) -> dict[str, int | str | float]:
         """Returns a dictionary with comprehensive string statistics for the specified column."""
         most_frequent = cls.most_frequent(dataframe, column_name)
         value_counts = dataframe[column_name].value_counts()

--- a/src/ts_shape/features/stats/string_stats.py
+++ b/src/ts_shape/features/stats/string_stats.py
@@ -143,7 +143,7 @@ class StringStatistics(Base):
     @classmethod
     def summary_as_dict(
         cls, dataframe: pd.DataFrame, column_name: str
-    ) -> Dict[str, Union[int, str, float]]:
+    ) -> dict[str, Union[int, str, float]]:
         """Returns a dictionary with comprehensive string statistics for the specified column."""
         most_frequent = cls.most_frequent(dataframe, column_name)
         value_counts = dataframe[column_name].value_counts()

--- a/src/ts_shape/loader/combine/integrator.py
+++ b/src/ts_shape/loader/combine/integrator.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import List, Union, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +15,8 @@ class DataIntegratorHybrid:
     @classmethod
     def combine_data(
         cls,
-        timeseries_sources: list[Union[pd.DataFrame, object]] | None = None,
-        metadata_sources: list[Union[pd.DataFrame, object]] | None = None,
+        timeseries_sources: list[pd.DataFrame | object] | None = None,
+        metadata_sources: list[pd.DataFrame | object] | None = None,
         uuids: list[str] | None = None,
         join_key: str = "uuid",
         merge_how: str = "left",
@@ -72,7 +71,7 @@ class DataIntegratorHybrid:
 
     @classmethod
     def _combine_timeseries(
-        cls, sources: list[Union[pd.DataFrame, object]] | None, join_key: str
+        cls, sources: list[pd.DataFrame | object] | None, join_key: str
     ) -> pd.DataFrame:
         """
         Combine timeseries data from multiple sources.
@@ -100,7 +99,7 @@ class DataIntegratorHybrid:
 
     @classmethod
     def _combine_metadata(
-        cls, sources: list[Union[pd.DataFrame, object]] | None, join_key: str
+        cls, sources: list[pd.DataFrame | object] | None, join_key: str
     ) -> pd.DataFrame:
         """
         Combine metadata from multiple sources.

--- a/src/ts_shape/loader/combine/integrator.py
+++ b/src/ts_shape/loader/combine/integrator.py
@@ -16,9 +16,9 @@ class DataIntegratorHybrid:
     @classmethod
     def combine_data(
         cls,
-        timeseries_sources: Optional[List[Union[pd.DataFrame, object]]] = None,
-        metadata_sources: Optional[List[Union[pd.DataFrame, object]]] = None,
-        uuids: Optional[List[str]] = None,
+        timeseries_sources: list[Union[pd.DataFrame, object]] | None = None,
+        metadata_sources: list[Union[pd.DataFrame, object]] | None = None,
+        uuids: list[str] | None = None,
         join_key: str = "uuid",
         merge_how: str = "left",
     ) -> pd.DataFrame:
@@ -72,7 +72,7 @@ class DataIntegratorHybrid:
 
     @classmethod
     def _combine_timeseries(
-        cls, sources: Optional[List[Union[pd.DataFrame, object]]], join_key: str
+        cls, sources: list[Union[pd.DataFrame, object]] | None, join_key: str
     ) -> pd.DataFrame:
         """
         Combine timeseries data from multiple sources.
@@ -100,7 +100,7 @@ class DataIntegratorHybrid:
 
     @classmethod
     def _combine_metadata(
-        cls, sources: Optional[List[Union[pd.DataFrame, object]]], join_key: str
+        cls, sources: list[Union[pd.DataFrame, object]] | None, join_key: str
     ) -> pd.DataFrame:
         """
         Combine metadata from multiple sources.

--- a/src/ts_shape/loader/context/context_enricher.py
+++ b/src/ts_shape/loader/context/context_enricher.py
@@ -1,6 +1,5 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Optional, List
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/loader/context/context_enricher.py
+++ b/src/ts_shape/loader/context/context_enricher.py
@@ -52,7 +52,7 @@ class ContextEnricher:
         metadata: pd.DataFrame,
         *,
         metadata_uuid_col: str = "uuid",
-        columns: Optional[List[str]] = None,
+        columns: list[str] | None = None,
     ) -> pd.DataFrame:
         """Join metadata columns onto timeseries by UUID.
 

--- a/src/ts_shape/loader/metadata/metadata_api_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_api_loader.py
@@ -30,11 +30,11 @@ class DatapointAPI:
 
     def __init__(
         self,
-        device_names: List[str],
+        device_names: list[str],
         base_url: str,
         api_token: str,
         output_path: str = "data",
-        required_uuid_list: Optional[List[str]] = None,
+        required_uuid_list: list[str] | None = None,
         filter_enabled: bool = True,
         timeout: int = 30,
     ):
@@ -53,10 +53,10 @@ class DatapointAPI:
         self.api_token = api_token
         self.output_path = output_path
         self.timeout = timeout
-        self.required_uuid_list: List[str] = required_uuid_list or []
+        self.required_uuid_list: list[str] = required_uuid_list or []
         self.filter_enabled = filter_enabled
-        self.device_metadata: Dict[str, pd.DataFrame] = {}
-        self.device_uuids: Dict[str, List[str]] = {}
+        self.device_metadata: dict[str, pd.DataFrame] = {}
+        self.device_uuids: dict[str, list[str]] = {}
         self._headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_token}",
@@ -74,8 +74,8 @@ class DatapointAPI:
         return response.json()
 
     def _filter_by_query(
-        self, records: List[Dict], query: str, fields: List[str]
-    ) -> List[Dict]:
+        self, records: list[dict], query: str, fields: list[str]
+    ) -> list[dict]:
         q = query.lower()
         return [
             r for r in records if any(q in str(r.get(f, "")).lower() for f in fields)
@@ -85,15 +85,15 @@ class DatapointAPI:
     # Core GET methods — one per API level
     # ------------------------------------------------------------------
 
-    def get_datatrons(self) -> List[Dict]:
+    def get_datatrons(self) -> list[dict]:
         """GET /api/datatrons — return all datatrons."""
         return self._get(self._DATATRONS_PATH)
 
-    def get_devices(self, datatron_id) -> List[Dict]:
+    def get_devices(self, datatron_id) -> list[dict]:
         """GET /api/datatrons/{datatron_id}/devices — return all devices for a datatron."""
         return self._get(self._DEVICES_PATH.format(datatron_id=datatron_id))
 
-    def get_datapoints(self, datatron_id, device_id) -> List[Dict]:
+    def get_datapoints(self, datatron_id, device_id) -> list[dict]:
         """GET /api/datatrons/{datatron_id}/devices/{device_id}/data_points."""
         return self._get(
             self._DATAPOINTS_PATH.format(datatron_id=datatron_id, device_id=device_id)
@@ -104,22 +104,22 @@ class DatapointAPI:
     # ------------------------------------------------------------------
 
     def search_datatrons(
-        self, query: str, fields: Optional[List[str]] = None
-    ) -> List[Dict]:
+        self, query: str, fields: list[str] | None = None
+    ) -> list[dict]:
         """Filter datatrons whose fields contain *query* (case-insensitive)."""
         fields = fields or ["name", "serialNumber", "deviceUUID", "model"]
         return self._filter_by_query(self.get_datatrons(), query, fields)
 
     def search_devices(
-        self, datatron_id, query: str, fields: Optional[List[str]] = None
-    ) -> List[Dict]:
+        self, datatron_id, query: str, fields: list[str] | None = None
+    ) -> list[dict]:
         """Filter devices for a datatron whose fields contain *query*."""
         fields = fields or ["name", "serialNumber", "deviceUUID"]
         return self._filter_by_query(self.get_devices(datatron_id), query, fields)
 
     def search_datapoints(
-        self, datatron_id, device_id, query: str, fields: Optional[List[str]] = None
-    ) -> List[Dict]:
+        self, datatron_id, device_id, query: str, fields: list[str] | None = None
+    ) -> list[dict]:
         """Filter datapoints for a device whose fields contain *query*."""
         fields = fields or ["label", "uuid", "unit"]
         return self._filter_by_query(
@@ -130,9 +130,7 @@ class DatapointAPI:
     # Cross-hierarchy find methods — no parent ID needed
     # ------------------------------------------------------------------
 
-    def find_devices(
-        self, query: str, fields: Optional[List[str]] = None
-    ) -> List[Dict]:
+    def find_devices(self, query: str, fields: list[str] | None = None) -> list[dict]:
         """Search all devices across all datatrons.
 
         Each result dict includes an extra ``datatron_id`` key.
@@ -145,8 +143,8 @@ class DatapointAPI:
         return results
 
     def find_datapoints(
-        self, query: str, fields: Optional[List[str]] = None
-    ) -> List[Dict]:
+        self, query: str, fields: list[str] | None = None
+    ) -> list[dict]:
         """Search all datapoints across all datatrons and devices.
 
         Each result dict includes extra ``datatron_id`` and ``device_id`` keys.
@@ -200,7 +198,7 @@ class DatapointAPI:
                 self.device_uuids[device_name] = metadata_df["uuid"].tolist()
                 self._export_json(metadata_df.to_dict(orient="records"), device_name)
 
-    def _export_json(self, data_points: List[Dict], device_name: str) -> None:
+    def _export_json(self, data_points: list[dict], device_name: str) -> None:
         """Write data points to a JSON file for the specified device."""
         file_name = (
             f"{self.output_path}/{device_name.replace(' ', '_')}_data_points.json"
@@ -212,18 +210,18 @@ class DatapointAPI:
     # Public accessors
     # ------------------------------------------------------------------
 
-    def get_all_uuids(self) -> Dict[str, List[str]]:
+    def get_all_uuids(self) -> dict[str, list[str]]:
         """Return ``{device_name: [uuid, ...]}`` — ready for the Azure parquet loader."""
         return self.device_uuids
 
-    def get_all_metadata(self) -> Dict[str, List[Dict]]:
+    def get_all_metadata(self) -> dict[str, list[dict]]:
         """Return ``{device_name: [record, ...]}`` with uuid/label/config columns."""
         return {
             device: metadata.to_dict(orient="records")
             for device, metadata in self.device_metadata.items()
         }
 
-    def display_dataframe(self, device_name: Optional[str] = None) -> None:
+    def display_dataframe(self, device_name: str | None = None) -> None:
         """Log the metadata DataFrame for one device or all devices."""
         if device_name:
             if device_name in self.device_metadata:

--- a/src/ts_shape/loader/metadata/metadata_api_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_api_loader.py
@@ -2,7 +2,6 @@ import logging
 import requests
 import pandas as pd  # type: ignore
 import json
-from typing import List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/loader/metadata/metadata_db_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_db_loader.py
@@ -14,12 +14,12 @@ class DatapointDB:
 
     def __init__(
         self,
-        device_names: List[str],
+        device_names: list[str],
         db_user: str,
         db_pass: str,
         db_host: str,
         output_path: str = "data",
-        required_uuid_list: List[str] = None,
+        required_uuid_list: list[str] = None,
         filter_enabled: bool = True,
     ):
         """
@@ -40,10 +40,10 @@ class DatapointDB:
         self.output_path = output_path
         self.required_uuid_list = required_uuid_list or []
         self.filter_enabled = filter_enabled
-        self.device_metadata: Dict[str, pd.DataFrame] = (
+        self.device_metadata: dict[str, pd.DataFrame] = (
             {}
         )  # Store metadata for each device
-        self.device_uuids: Dict[str, List[str]] = {}  # Store UUIDs for each device
+        self.device_uuids: dict[str, list[str]] = {}  # Store UUIDs for each device
         self._db_access()
 
     def _db_access(self) -> None:
@@ -83,7 +83,7 @@ class DatapointDB:
                 # Export to JSON file
                 self._export_json(metadata_df.to_dict(orient="records"), device_name)
 
-    def _export_json(self, data_points: List[Dict[str, str]], device_name: str) -> None:
+    def _export_json(self, data_points: list[dict[str, str]], device_name: str) -> None:
         """Export data points to a JSON file for the specified device."""
         file_name = (
             f"{self.output_path}/{device_name.replace(' ', '_')}_data_points.json"
@@ -91,11 +91,11 @@ class DatapointDB:
         with open(file_name, "w") as f:
             json.dump(data_points, f, indent=2)
 
-    def get_all_uuids(self) -> Dict[str, List[str]]:
+    def get_all_uuids(self) -> dict[str, list[str]]:
         """Return a dictionary of UUIDs for each device."""
         return self.device_uuids
 
-    def get_all_metadata(self) -> Dict[str, List[Dict[str, str]]]:
+    def get_all_metadata(self) -> dict[str, list[dict[str, str]]]:
         """Return a dictionary of metadata for each device."""
         return {
             device: metadata.to_dict(orient="records")

--- a/src/ts_shape/loader/metadata/metadata_db_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_db_loader.py
@@ -2,7 +2,6 @@ import logging
 import pandas as pd  # type: ignore
 import json
 from sqlalchemy import create_engine, text
-from typing import List, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/loader/metadata/metadata_json_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_json_loader.py
@@ -1,6 +1,7 @@
 import logging
 import json
-from typing import Dict, Any, List, Optional, Iterable
+from typing import Any
+from collections.abc import Iterable
 import pandas as pd
 
 logger = logging.getLogger(__name__)

--- a/src/ts_shape/loader/metadata/metadata_json_loader.py
+++ b/src/ts_shape/loader/metadata/metadata_json_loader.py
@@ -44,7 +44,7 @@ class MetadataJsonLoader:
         Returns:
             MetadataJsonLoader instance.
         """
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
         return cls(data, strict=strict)
 
@@ -113,7 +113,7 @@ class MetadataJsonLoader:
 
         return df.set_index("uuid")
 
-    def _normalize_to_records(self, data: Any) -> List[Dict[str, Any]]:
+    def _normalize_to_records(self, data: Any) -> list[dict[str, Any]]:
         """
         Normalize supported input shapes into a list of record dicts with
         keys: 'uuid', 'label', and 'config'.
@@ -144,7 +144,7 @@ class MetadataJsonLoader:
                         raise ValueError(f"Column lengths differ: {lengths}")
                     # Fallback to shortest length
                 n = min(lengths.values()) if lengths else 0
-                out: List[Dict[str, Any]] = []
+                out: list[dict[str, Any]] = []
                 for i in range(n):
                     out.append(
                         self._normalize_record(
@@ -193,7 +193,7 @@ class MetadataJsonLoader:
         return []
 
     @staticmethod
-    def _normalize_record(rec: Dict[str, Any]) -> Dict[str, Any]:
+    def _normalize_record(rec: dict[str, Any]) -> dict[str, Any]:
         """
         Ensure a single record has the shape {uuid, label, config},
         coercing 'config' to a dictionary where possible.
@@ -253,7 +253,7 @@ class MetadataJsonLoader:
         return self.df.head(n)
 
     # ------- Lookups -------
-    def get_by_uuid(self, uuid: str) -> Optional[Dict[str, Any]]:
+    def get_by_uuid(self, uuid: str) -> dict[str, Any] | None:
         """
         Retrieve a row by UUID as a dictionary.
 
@@ -267,7 +267,7 @@ class MetadataJsonLoader:
             return None
         return self.df.loc[uuid].to_dict()
 
-    def get_by_label(self, label: str) -> Optional[Dict[str, Any]]:
+    def get_by_label(self, label: str) -> dict[str, Any] | None:
         """
         Retrieve the first row matching a label as a dictionary.
 
@@ -321,7 +321,7 @@ class MetadataJsonLoader:
         return self.df[self.df["label"].isin(labels_set)]
 
     # ------- Introspection -------
-    def list_uuids(self) -> List[str]:
+    def list_uuids(self) -> list[str]:
         """
         Return a list of UUIDs present in the metadata index.
 
@@ -330,7 +330,7 @@ class MetadataJsonLoader:
         """
         return list(self.df.index.astype(str))
 
-    def list_labels(self) -> List[str]:
+    def list_labels(self) -> list[str]:
         """
         Return all non-null labels.
 

--- a/src/ts_shape/loader/timeseries/azure_blob_energy_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_energy_loader.py
@@ -73,15 +73,15 @@ class AzureBlobEnergyLoader:
 
     def __init__(
         self,
-        container_name: Optional[str] = None,
+        container_name: str | None = None,
         *,
-        connection_string: Optional[str] = None,
-        account_url: Optional[str] = None,
-        credential: Optional[object] = None,
-        sas_url: Optional[str] = None,
+        connection_string: str | None = None,
+        account_url: str | None = None,
+        credential: object | None = None,
+        sas_url: str | None = None,
         prefix: str = "",
         max_workers: int = 8,
-        thousands: Optional[str] = None,
+        thousands: str | None = None,
         decimal: str = ".",
     ) -> None:
         """
@@ -160,11 +160,11 @@ class AzureBlobEnergyLoader:
         account_name: str,
         container_name: str,
         *,
-        credential: Optional[object] = None,
+        credential: object | None = None,
         endpoint_suffix: str = "blob.core.windows.net",
         prefix: str = "",
         max_workers: int = 8,
-        thousands: Optional[str] = None,
+        thousands: str | None = None,
         decimal: str = ".",
     ) -> "AzureBlobEnergyLoader":
         """
@@ -227,7 +227,7 @@ class AzureBlobEnergyLoader:
         self,
         start: Union[str, "pd.Timestamp"],
         end: Union[str, "pd.Timestamp"],
-        series_ids: Optional[List[str]] = None,
+        series_ids: list[str] | None = None,
     ) -> pd.DataFrame:
         """
         Load all CSV files in ``csv/YYYY/MM/DD/`` for each date in [start, end].
@@ -246,9 +246,9 @@ class AzureBlobEnergyLoader:
 
     def load_by_series_ids(
         self,
-        series_ids: List[str],
-        start: Optional[Union[str, "pd.Timestamp"]] = None,
-        end: Optional[Union[str, "pd.Timestamp"]] = None,
+        series_ids: list[str],
+        start: Union[str, "pd.Timestamp"] | None = None,
+        end: Union[str, "pd.Timestamp"] | None = None,
     ) -> pd.DataFrame:
         """
         Load specific series by ID.
@@ -284,8 +284,8 @@ class AzureBlobEnergyLoader:
         self,
         start: Union[str, "pd.Timestamp"],
         end: Union[str, "pd.Timestamp"],
-        series_ids: Optional[List[str]] = None,
-    ) -> Iterator[Tuple[str, pd.DataFrame]]:
+        series_ids: list[str] | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
         """
         Stream CSV files one at a time as (series_id, DataFrame) tuples.
 
@@ -306,7 +306,7 @@ class AzureBlobEnergyLoader:
             if df is not None and not df.empty:
                 yield self._series_id_from_blob_name(blob_name), df
 
-    def list_series(self) -> List[str]:
+    def list_series(self) -> list[str]:
         """
         List all series IDs present in the blob store by scanning ``csv/``.
 
@@ -335,7 +335,7 @@ class AzureBlobEnergyLoader:
         self,
         start: Union[str, "pd.Timestamp"],
         end: Union[str, "pd.Timestamp"],
-    ) -> List[str]:
+    ) -> list[str]:
         """Return list of day-level blob prefixes: csv/YYYY/MM/DD/"""
         dates = pd.date_range(
             start=pd.to_datetime(start).normalize(),
@@ -353,11 +353,11 @@ class AzureBlobEnergyLoader:
         self,
         start: Union[str, "pd.Timestamp"],
         end: Union[str, "pd.Timestamp"],
-        ids_set: Optional[set],
-    ) -> List[str]:
+        ids_set: set | None,
+    ) -> list[str]:
         """List CSV blob names across the date range, optionally filtered by ids_set."""
         day_prefixes = self._build_date_paths(start, end)
-        blob_names: List[str] = []
+        blob_names: list[str] = []
         for pfx in day_prefixes:
             for blob in self.container_client.list_blobs(name_starts_with=pfx):
                 name: str = blob.name
@@ -376,7 +376,7 @@ class AzureBlobEnergyLoader:
         """Extract series_id from blob path: csv/2026/01/13/sensor_001.csv → sensor_001"""
         return PurePosixPath(blob_name).stem
 
-    def _download_csv(self, blob_name: str) -> Optional[pd.DataFrame]:
+    def _download_csv(self, blob_name: str) -> pd.DataFrame | None:
         """Download a single CSV blob and normalize to standard schema. Returns None on error."""
         try:
             downloader = self.container_client.download_blob(blob_name)
@@ -410,12 +410,12 @@ class AzureBlobEnergyLoader:
         out["is_delta"] = True
         return out.sort_values("systime").reset_index(drop=True)
 
-    def _download_and_concat(self, blob_names: List[str]) -> pd.DataFrame:
+    def _download_and_concat(self, blob_names: list[str]) -> pd.DataFrame:
         """Download a list of CSV blobs concurrently and concatenate results."""
         if not blob_names:
             return pd.DataFrame(columns=_EMPTY_SCHEMA)
 
-        frames: List[pd.DataFrame] = []
+        frames: list[pd.DataFrame] = []
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = {
                 executor.submit(self._download_csv, name): name for name in blob_names

--- a/src/ts_shape/loader/timeseries/azure_blob_energy_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_energy_loader.py
@@ -1,7 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
 from pathlib import PurePosixPath
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Union
+from collections.abc import Iterator
 import logging
 
 import pandas as pd  # type: ignore

--- a/src/ts_shape/loader/timeseries/azure_blob_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_loader.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
-from typing import Iterable, List, Optional, Set, Dict, Any, Callable, Iterator, Tuple
+from typing import Any
+from collections.abc import Iterable, Callable, Iterator
 import logging
 import warnings
 

--- a/src/ts_shape/loader/timeseries/azure_blob_loader.py
+++ b/src/ts_shape/loader/timeseries/azure_blob_loader.py
@@ -23,12 +23,12 @@ class AzureBlobParquetLoader:
 
     def __init__(
         self,
-        container_name: Optional[str] = None,
+        container_name: str | None = None,
         *,
-        connection_string: Optional[str] = None,
-        account_url: Optional[str] = None,
-        credential: Optional[object] = None,
-        sas_url: Optional[str] = None,
+        connection_string: str | None = None,
+        account_url: str | None = None,
+        credential: object | None = None,
+        sas_url: str | None = None,
         prefix: str = "",
         max_workers: int = 8,
         hour_pattern: str = "{Y}/{m}/{d}/{H}/",
@@ -139,7 +139,7 @@ class AzureBlobParquetLoader:
         account_name: str,
         container_name: str,
         *,
-        credential: Optional[object] = None,
+        credential: object | None = None,
         endpoint_suffix: str = "blob.core.windows.net",
         prefix: str = "",
         max_workers: int = 8,
@@ -168,7 +168,7 @@ class AzureBlobParquetLoader:
             max_workers=max_workers,
         )
 
-    def _iter_matching_blob_names(self, uuids: Set[str]) -> Iterable[str]:
+    def _iter_matching_blob_names(self, uuids: set[str]) -> Iterable[str]:
         """
         Iterate over blob names that end with .parquet and contain any of the given UUIDs.
 
@@ -190,9 +190,9 @@ class AzureBlobParquetLoader:
     def _download_parquet(
         self,
         blob_name: str,
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
-    ) -> Optional[pd.DataFrame]:
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame | None:
         """
         Download a parquet blob and return a DataFrame. Returns None if not found.
 
@@ -210,10 +210,10 @@ class AzureBlobParquetLoader:
 
     def _download_many(
         self,
-        blob_names: List[str],
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
-    ) -> Tuple[List[pd.DataFrame], int, int]:
+        blob_names: list[str],
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> tuple[list[pd.DataFrame], int, int]:
         """
         Download a set of parquet blobs concurrently.
 
@@ -228,7 +228,7 @@ class AzureBlobParquetLoader:
             downloaded or parsed (missing, unauthorized, or corrupt), and
             ``n_empty`` counts blobs that parsed successfully but had no rows.
         """
-        frames: List[pd.DataFrame] = []
+        frames: list[pd.DataFrame] = []
         n_failed = 0
         n_empty = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
@@ -247,7 +247,7 @@ class AzureBlobParquetLoader:
         return frames, n_failed, n_empty
 
     def _warn_empty(
-        self, method: str, detail: str, filters: Optional[list] = None
+        self, method: str, detail: str, filters: list | None = None
     ) -> None:
         """
         Emit a ``LoaderConfigWarning`` explaining why a load returned no data.
@@ -260,7 +260,7 @@ class AzureBlobParquetLoader:
             stacklevel=3,
         )
 
-    def _time_search_detail(self, slots: List[pd.Timestamp]) -> str:
+    def _time_search_detail(self, slots: list[pd.Timestamp]) -> str:
         """Describe the prefix/pattern/hour-range probed by a time-range load."""
         prefix_repr = repr(self.prefix or "")
         pattern_repr = repr(self.hour_pattern)
@@ -305,8 +305,8 @@ class AzureBlobParquetLoader:
 
     def load_all_files(
         self,
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
+        columns: list[str] | None = None,
+        filters: list | None = None,
     ) -> pd.DataFrame:
         """
         Load all parquet blobs in the container (optionally under `prefix`).
@@ -352,8 +352,8 @@ class AzureBlobParquetLoader:
         self,
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
+        columns: list[str] | None = None,
+        filters: list | None = None,
     ) -> pd.DataFrame:
         """
         Load all parquet blobs under hourly folders within [start, end].
@@ -368,7 +368,7 @@ class AzureBlobParquetLoader:
         """
         slots = list(self._hourly_slots(start_timestamp, end_timestamp))
         hour_prefixes = [self._hour_prefix(ts) for ts in slots]
-        blob_names: List[str] = []
+        blob_names: list[str] = []
         for pfx in hour_prefixes:
             blob_iter = self.container_client.list_blobs(name_starts_with=pfx)
             blob_names.extend([b.name for b in blob_iter if str(b.name).endswith(".parquet")])  # type: ignore[attr-defined]
@@ -399,9 +399,9 @@ class AzureBlobParquetLoader:
         self,
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
-    ) -> Iterator[Tuple[str, pd.DataFrame]]:
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
         """
         Stream parquet DataFrames under hourly folders within [start, end].
 
@@ -426,7 +426,7 @@ class AzureBlobParquetLoader:
         names_iter = _names_iter()
         yielded = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures: Dict[Any, str] = {}
+            futures: dict[Any, str] = {}
             # initial fill
             try:
                 while len(futures) < self.max_workers:
@@ -472,9 +472,9 @@ class AzureBlobParquetLoader:
         self,
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
-        uuid_list: List[str],
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
+        uuid_list: list[str],
+        columns: list[str] | None = None,
+        filters: list | None = None,
     ) -> pd.DataFrame:
         """
         Load parquet blobs for given UUIDs within [start, end] hours.
@@ -503,8 +503,8 @@ class AzureBlobParquetLoader:
 
         raw = [_clean_uuid(u) for u in uuid_list]
         # Include lowercase variants to be tolerant of case differences in filenames
-        variants_ordered: List[str] = []
-        seen: Set[str] = set()
+        variants_ordered: list[str] = []
+        seen: set[str] = set()
         for u in raw:
             for v in (u, u.lower()):
                 if v and v not in seen:
@@ -516,7 +516,7 @@ class AzureBlobParquetLoader:
 
         # 1) Authoritative path: list each hour prefix, match by basename.
         basenames = {f"{u}.parquet" for u in variants_ordered}
-        listed_names: List[str] = []
+        listed_names: list[str] = []
         listing_failed = False
         try:
             for pfx in hour_prefixes:
@@ -579,10 +579,10 @@ class AzureBlobParquetLoader:
         self,
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
-        uuid_list: List[str],
-        columns: Optional[List[str]] = None,
-        filters: Optional[list] = None,
-    ) -> Iterator[Tuple[str, pd.DataFrame]]:
+        uuid_list: list[str],
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
         """
         Stream parquet DataFrames for given UUIDs within [start, end] hours.
 
@@ -602,8 +602,8 @@ class AzureBlobParquetLoader:
             return str(u).strip().strip("{}").strip()
 
         raw = [_clean_uuid(u) for u in uuid_list]
-        variants_ordered: List[str] = []
-        seen: Set[str] = set()
+        variants_ordered: list[str] = []
+        seen: set[str] = set()
         for u in raw:
             for v in (u, u.lower()):
                 if v and v not in seen:
@@ -614,7 +614,7 @@ class AzureBlobParquetLoader:
         hour_prefixes = [self._hour_prefix(ts) for ts in slots]
         basenames = {f"{u}.parquet" for u in variants_ordered}
 
-        listed_names: List[str] = []
+        listed_names: list[str] = []
         listing_failed = False
         try:
             for pfx in hour_prefixes:
@@ -648,7 +648,7 @@ class AzureBlobParquetLoader:
         names_iter = iter(all_blob_names)
         yielded = 0
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures: Dict[Any, str] = {}
+            futures: dict[Any, str] = {}
             try:
                 while len(futures) < self.max_workers:
                     n = next(names_iter)
@@ -689,8 +689,8 @@ class AzureBlobParquetLoader:
             )
 
     def list_structure(
-        self, parquet_only: bool = True, limit: Optional[int] = None
-    ) -> Dict[str, List[str]]:
+        self, parquet_only: bool = True, limit: int | None = None
+    ) -> dict[str, list[str]]:
         """
         List folder prefixes (hours) and blob names under the configured `prefix`.
 
@@ -703,8 +703,8 @@ class AzureBlobParquetLoader:
             - folders: Sorted unique hour-level prefixes like 'parquet/YYYY/MM/DD/HH/'
             - files: Sorted blob names (full paths) matching the filter
         """
-        folders: Set[str] = set()
-        files: List[str] = []
+        folders: set[str] = set()
+        files: list[str] = []
         collected = 0
 
         blob_iter = self.container_client.list_blobs(
@@ -738,17 +738,17 @@ class AzureBlobFlexibleFileLoader:
     """
 
     # Parser registry: maps lowercase extensions (with dot) -> callable(content, name) -> Any
-    _parsers: Dict[str, Callable[[bytes, str], Any]] = {}
+    _parsers: dict[str, Callable[[bytes, str], Any]] = {}
     _parsers_initialized: bool = False
 
     def __init__(
         self,
-        container_name: Optional[str] = None,
+        container_name: str | None = None,
         *,
-        connection_string: Optional[str] = None,
-        account_url: Optional[str] = None,
-        credential: Optional[object] = None,
-        sas_url: Optional[str] = None,
+        connection_string: str | None = None,
+        account_url: str | None = None,
+        credential: object | None = None,
+        sas_url: str | None = None,
         prefix: str = "",
         max_workers: int = 8,
         hour_pattern: str = "{Y}/{m}/{d}/{H}/",
@@ -849,7 +849,7 @@ class AzureBlobFlexibleFileLoader:
         return f"{base}{sub}"
 
     # ---- Core operations ----
-    def _download_bytes(self, blob_name: str) -> Optional[bytes]:
+    def _download_bytes(self, blob_name: str) -> bytes | None:
         try:
             downloader = self.container_client.download_blob(blob_name)
             return downloader.readall()
@@ -857,10 +857,10 @@ class AzureBlobFlexibleFileLoader:
             return None
 
     @staticmethod
-    def _normalize_exts(exts: Optional[Iterable[str]]) -> Optional[Set[str]]:
+    def _normalize_exts(exts: Iterable[str] | None) -> set[str] | None:
         if exts is None:
             return None
-        norm: Set[str] = set()
+        norm: set[str] = set()
         for e in exts:
             s = str(e).strip().lower()
             if not s:
@@ -886,7 +886,7 @@ class AzureBlobFlexibleFileLoader:
         cls._parsers.pop(ext, None)
 
     @classmethod
-    def available_parsers(cls) -> Set[str]:
+    def available_parsers(cls) -> set[str]:
         return set(cls._parsers.keys())
 
     @classmethod
@@ -957,9 +957,9 @@ class AzureBlobFlexibleFileLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         *,
-        extensions: Optional[Iterable[str]] = None,
-        limit: Optional[int] = None,
-    ) -> List[str]:
+        extensions: Iterable[str] | None = None,
+        limit: int | None = None,
+    ) -> list[str]:
         """
         List blob names under each hourly prefix within [start, end].
 
@@ -968,7 +968,7 @@ class AzureBlobFlexibleFileLoader:
             limit: Optional cap on number of files collected.
         """
         allowed_exts = self._normalize_exts(extensions)
-        names: List[str] = []
+        names: list[str] = []
         collected = 0
         for pfx in (
             self._hour_prefix(ts)
@@ -992,7 +992,7 @@ class AzureBlobFlexibleFileLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         *,
-        extensions: Optional[Iterable[str]] = None,
+        extensions: Iterable[str] | None = None,
     ) -> Iterator[str]:
         """
         Yield blob names under each hourly prefix within [start, end].
@@ -1016,9 +1016,9 @@ class AzureBlobFlexibleFileLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         *,
-        extensions: Optional[Iterable[str]] = None,
+        extensions: Iterable[str] | None = None,
         parse: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Download files that match extensions within [start, end] hour prefixes.
         Returns a dict mapping blob_name -> parsed object (if parse=True and a parser exists),
@@ -1029,7 +1029,7 @@ class AzureBlobFlexibleFileLoader:
         )
         if not blob_names:
             return {}
-        results: Dict[str, Any] = {}
+        results: dict[str, Any] = {}
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_to_name = {
                 executor.submit(self._download_bytes, n): n for n in blob_names
@@ -1048,9 +1048,9 @@ class AzureBlobFlexibleFileLoader:
         start_timestamp: str | pd.Timestamp,
         end_timestamp: str | pd.Timestamp,
         *,
-        extensions: Optional[Iterable[str]] = None,
+        extensions: Iterable[str] | None = None,
         parse: bool = False,
-    ) -> Iterator[Tuple[str, Any]]:
+    ) -> Iterator[tuple[str, Any]]:
         """
         Stream matching files as (blob_name, bytes-or-parsed) within [start, end].
         Maintains up to `max_workers` concurrent downloads while yielding incrementally.
@@ -1060,7 +1060,7 @@ class AzureBlobFlexibleFileLoader:
         )
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_name: Dict[Any, str] = {}
+            future_to_name: dict[Any, str] = {}
             # initial fill
             try:
                 while len(future_to_name) < self.max_workers:
@@ -1097,9 +1097,9 @@ class AzureBlobFlexibleFileLoader:
         end_timestamp: str | pd.Timestamp,
         basenames: Iterable[str],
         *,
-        extensions: Optional[Iterable[str]] = None,
+        extensions: Iterable[str] | None = None,
         parse: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Download files whose basename (final path segment) is in `basenames`,
         optionally filtered by extensions, within [start, end] hour prefixes.
@@ -1107,7 +1107,7 @@ class AzureBlobFlexibleFileLoader:
         """
         base_set = {str(b).strip() for b in basenames if str(b).strip()}
         allowed_exts = self._normalize_exts(extensions)
-        candidates: List[str] = []
+        candidates: list[str] = []
         for pfx in (
             self._hour_prefix(ts)
             for ts in self._hourly_slots(start_timestamp, end_timestamp)
@@ -1127,7 +1127,7 @@ class AzureBlobFlexibleFileLoader:
         if not candidates:
             return {}
 
-        results: Dict[str, Any] = {}
+        results: dict[str, Any] = {}
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_to_name = {
                 executor.submit(self._download_bytes, n): n for n in candidates
@@ -1147,9 +1147,9 @@ class AzureBlobFlexibleFileLoader:
         end_timestamp: str | pd.Timestamp,
         basenames: Iterable[str],
         *,
-        extensions: Optional[Iterable[str]] = None,
+        extensions: Iterable[str] | None = None,
         parse: bool = False,
-    ) -> Iterator[Tuple[str, Any]]:
+    ) -> Iterator[tuple[str, Any]]:
         """
         Stream files whose basename is in `basenames` within [start, end].
         Yields (blob_name, bytes-or-parsed) incrementally with bounded concurrency.
@@ -1176,7 +1176,7 @@ class AzureBlobFlexibleFileLoader:
 
         names_iter = _names_iter()
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            future_to_name: Dict[Any, str] = {}
+            future_to_name: dict[Any, str] = {}
             # initial fill
             try:
                 while len(future_to_name) < self.max_workers:

--- a/src/ts_shape/loader/timeseries/energy_api_loader.py
+++ b/src/ts_shape/loader/timeseries/energy_api_loader.py
@@ -10,7 +10,7 @@ Classes:
 import logging
 import pandas as pd  # type: ignore
 import requests
-from typing import Optional, Dict, Any, List
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/loader/timeseries/energy_api_loader.py
+++ b/src/ts_shape/loader/timeseries/energy_api_loader.py
@@ -42,7 +42,7 @@ class EnergyAPILoader:
         self,
         base_url: str,
         *,
-        headers: Optional[Dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialise the loader.
@@ -64,11 +64,11 @@ class EnergyAPILoader:
         self,
         endpoint: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         time_key: str = "timestamp",
         value_key: str = "value",
         uuid_value: str = "energy:default",
-        data_root: Optional[str] = None,
+        data_root: str | None = None,
     ) -> pd.DataFrame:
         """Fetch energy data from a REST endpoint and return a DataFrame.
 
@@ -97,13 +97,13 @@ class EnergyAPILoader:
     def fetch_multiple_meters(
         self,
         endpoint: str,
-        meter_ids: List[str],
+        meter_ids: list[str],
         *,
         meter_param: str = "meter_id",
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         time_key: str = "timestamp",
         value_key: str = "value",
-        data_root: Optional[str] = None,
+        data_root: str | None = None,
     ) -> pd.DataFrame:
         """Fetch data for several meters and combine into one DataFrame.
 
@@ -122,7 +122,7 @@ class EnergyAPILoader:
         Returns:
             Combined DataFrame sorted by systime.
         """
-        frames: List[pd.DataFrame] = []
+        frames: list[pd.DataFrame] = []
         base_params = dict(params) if params else {}
 
         for mid in meter_ids:
@@ -152,7 +152,7 @@ class EnergyAPILoader:
         self,
         endpoint: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
     ) -> Any:
         """Execute GET request and return parsed JSON."""
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
@@ -169,7 +169,7 @@ class EnergyAPILoader:
         time_key: str,
         value_key: str,
         uuid_value: str,
-        data_root: Optional[str],
+        data_root: str | None,
     ) -> pd.DataFrame:
         """Convert raw JSON into a standard ts_shape DataFrame."""
         if data_root is not None and isinstance(raw, dict):

--- a/src/ts_shape/loader/timeseries/s3proxy_parquet_loader.py
+++ b/src/ts_shape/loader/timeseries/s3proxy_parquet_loader.py
@@ -18,8 +18,8 @@ class S3ProxyDataAccess:
         self,
         start_timestamp: str,
         end_timestamp: str,
-        uuids: List[str],
-        s3_config: Dict[str, str],
+        uuids: list[str],
+        s3_config: dict[str, str],
     ):
         """
         Initialize the S3ProxyDataAccess object.

--- a/src/ts_shape/loader/timeseries/s3proxy_parquet_loader.py
+++ b/src/ts_shape/loader/timeseries/s3proxy_parquet_loader.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 import pandas as pd  # type: ignore
 import s3fs
-from typing import List, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/loader/timeseries/timescale_loader.py
+++ b/src/ts_shape/loader/timeseries/timescale_loader.py
@@ -12,8 +12,8 @@ class TimescaleDBDataAccess:
         self,
         start_timestamp: str,
         end_timestamp: str,
-        uuids: List[str],
-        db_config: Dict[str, str],
+        uuids: list[str],
+        db_config: dict[str, str],
     ):
         self.start_timestamp = start_timestamp
         self.end_timestamp = end_timestamp

--- a/src/ts_shape/loader/timeseries/timescale_loader.py
+++ b/src/ts_shape/loader/timeseries/timescale_loader.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 import pandas as pd  # type: ignore
 from sqlalchemy import create_engine, text
-from typing import List, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/ts_shape/pipeline.py
+++ b/src/ts_shape/pipeline.py
@@ -70,7 +70,8 @@ from __future__ import annotations
 import inspect
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
+from collections.abc import Callable
 
 import pandas as pd  # type: ignore
 

--- a/src/ts_shape/pipeline.py
+++ b/src/ts_shape/pipeline.py
@@ -102,7 +102,7 @@ def _param_names(func: Any) -> set[str]:
     return names
 
 
-def _first_param_name(func: Any) -> Optional[str]:
+def _first_param_name(func: Any) -> str | None:
     """Return the first non-``self`` / ``cls`` parameter name of ``func``."""
     try:
         sig = inspect.signature(func)
@@ -124,7 +124,7 @@ def _subst(value: Any, working_df: pd.DataFrame, input_df: pd.DataFrame) -> Any:
     return value
 
 
-def _validate_sentinels(kwargs: Dict[str, Any]) -> None:
+def _validate_sentinels(kwargs: dict[str, Any]) -> None:
     """Reject unknown ``$``-prefixed sentinel strings at registration time."""
     for key, value in kwargs.items():
         if isinstance(value, str) and value.startswith("$") and value not in _SENTINELS:
@@ -135,8 +135,8 @@ def _validate_sentinels(kwargs: Dict[str, Any]) -> None:
 
 
 def _split_kwargs(
-    target: type, method: str, kwargs: Dict[str, Any]
-) -> Tuple[set[str], set[str]]:
+    target: type, method: str, kwargs: dict[str, Any]
+) -> tuple[set[str], set[str]]:
     """Route kwarg names between ``target.__init__`` and ``target.method``.
 
     Returns ``(init_keys, method_keys)``. A kwarg may match both. Raises
@@ -146,7 +146,7 @@ def _split_kwargs(
     method_params = _param_names(getattr(target, method))
     init_keys: set[str] = set()
     method_keys: set[str] = set()
-    unknown: List[str] = []
+    unknown: list[str] = []
     for key in kwargs:
         in_init = key in init_params
         in_method = key in method_params
@@ -166,8 +166,8 @@ def _split_kwargs(
 
 
 def _resolve(
-    target: Any, method: Optional[str], kwargs: Dict[str, Any]
-) -> Tuple[_Executor, Optional[str]]:
+    target: Any, method: str | None, kwargs: dict[str, Any]
+) -> tuple[_Executor, str | None]:
     """Build a ``(working_df, input_df) -> df`` executor for one step.
 
     Returns ``(executor, detector_id)``; ``detector_id`` is the
@@ -236,7 +236,7 @@ def _resolve(
 
 
 def _resolve_source(
-    target: Any, method: Optional[str], kwargs: Dict[str, Any]
+    target: Any, method: str | None, kwargs: dict[str, Any]
 ) -> Callable[[], pd.DataFrame]:
     """Build a ``() -> DataFrame`` executor for a source (loader) step.
 
@@ -296,14 +296,14 @@ def _resolve_source(
     return _load_instance
 
 
-def _default_name(target: Any, method: Optional[str]) -> str:
+def _default_name(target: Any, method: str | None) -> str:
     """Pick a readable step name when the caller did not supply one."""
     if method is not None:
         return method
     return getattr(target, "__name__", "step")
 
 
-def _format_kwargs(kwargs: Dict[str, Any]) -> str:
+def _format_kwargs(kwargs: dict[str, Any]) -> str:
     """Render kwargs for :meth:`Pipeline.describe`."""
     return ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
 
@@ -314,8 +314,8 @@ class _Step:
     name: str
     # source executors take no args; transform/detect take (working, input).
     executor: Callable[..., pd.DataFrame]
-    detector_id: Optional[str]
-    kwargs: Dict[str, Any]
+    detector_id: str | None
+    kwargs: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -330,8 +330,8 @@ class PipelineResult:
 
     name: str
     data: pd.DataFrame
-    events: Dict[str, pd.DataFrame]
-    _detector_ids: Dict[str, Optional[str]] = field(default_factory=dict)
+    events: dict[str, pd.DataFrame]
+    _detector_ids: dict[str, str | None] = field(default_factory=dict)
 
     def to_event_log(self, *, concat: bool = True) -> Any:
         """Normalize detector outputs into an OCEL event log.
@@ -351,7 +351,7 @@ class PipelineResult:
         from ts_shape.eventlog import concat as _concat
         from ts_shape.eventlog import to_event_log as _to_event_log
 
-        logs: Dict[str, Any] = {}
+        logs: dict[str, Any] = {}
         for step_name, events_df in self.events.items():
             detector_id = self._detector_ids.get(step_name)
             if detector_id is None:
@@ -394,16 +394,16 @@ class Pipeline:
             name: A label for the pipeline, surfaced in ``repr`` and results.
         """
         self.name = name
-        self._steps: List[_Step] = []
+        self._steps: list[_Step] = []
 
     def source(
         self,
         target: Any,
-        method: Optional[str] = None,
+        method: str | None = None,
         *,
-        name: Optional[str] = None,
+        name: str | None = None,
         **kwargs: Any,
-    ) -> "Pipeline":
+    ) -> Pipeline:
         """Add a source step -- a loader that produces the pipeline's first frame.
 
         A source step must be the **first** step, and a pipeline may have at
@@ -447,11 +447,11 @@ class Pipeline:
     def transform(
         self,
         target: Any,
-        method: Optional[str] = None,
+        method: str | None = None,
         *,
-        name: Optional[str] = None,
+        name: str | None = None,
         **kwargs: Any,
-    ) -> "Pipeline":
+    ) -> Pipeline:
         """Add a transform step -- its output replaces the working DataFrame.
 
         Args:
@@ -481,11 +481,11 @@ class Pipeline:
     def detect(
         self,
         target: Any,
-        method: Optional[str] = None,
+        method: str | None = None,
         *,
-        name: Optional[str] = None,
+        name: str | None = None,
         **kwargs: Any,
-    ) -> "Pipeline":
+    ) -> Pipeline:
         """Add a detector step -- its output is stored, the signal is unchanged.
 
         Args:
@@ -514,7 +514,7 @@ class Pipeline:
         return self
 
     @property
-    def steps(self) -> List[Tuple[str, str]]:
+    def steps(self) -> list[tuple[str, str]]:
         """The ordered ``(kind, name)`` pairs of the configured steps."""
         return [(s.kind, s.name) for s in self._steps]
 
@@ -529,15 +529,15 @@ class Pipeline:
             lines.append(f"  {index}. [{step.kind:<9s}] {step.name}{suffix}")
         return "\n".join(lines)
 
-    def _execute(self, dataframe: Optional[pd.DataFrame], *, capture: bool) -> Tuple[
+    def _execute(self, dataframe: pd.DataFrame | None, *, capture: bool) -> tuple[
         pd.DataFrame,
-        Dict[str, pd.DataFrame],
-        Dict[str, Optional[str]],
-        Dict[str, pd.DataFrame],
+        dict[str, pd.DataFrame],
+        dict[str, str | None],
+        dict[str, pd.DataFrame],
     ]:
-        events: Dict[str, pd.DataFrame] = {}
-        detector_ids: Dict[str, Optional[str]] = {}
-        intermediates: Dict[str, pd.DataFrame] = {}
+        events: dict[str, pd.DataFrame] = {}
+        detector_ids: dict[str, str | None] = {}
+        intermediates: dict[str, pd.DataFrame] = {}
         has_source = bool(self._steps) and self._steps[0].kind == "source"
 
         if has_source:
@@ -605,7 +605,7 @@ class Pipeline:
 
         return working, events, detector_ids, intermediates
 
-    def run(self, dataframe: Optional[pd.DataFrame] = None) -> PipelineResult:
+    def run(self, dataframe: pd.DataFrame | None = None) -> PipelineResult:
         """Execute every step.
 
         Args:
@@ -632,8 +632,8 @@ class Pipeline:
         )
 
     def run_steps(
-        self, dataframe: Optional[pd.DataFrame] = None
-    ) -> Dict[str, pd.DataFrame]:
+        self, dataframe: pd.DataFrame | None = None
+    ) -> dict[str, pd.DataFrame]:
         """Execute every step and return *all* intermediate DataFrames.
 
         Useful for debugging which step changes the data unexpectedly.

--- a/src/ts_shape/transform/calculator/unit_conversion.py
+++ b/src/ts_shape/transform/calculator/unit_conversion.py
@@ -12,7 +12,6 @@ pint is an optional dependency; install it with::
 """
 
 import logging
-from typing import Optional, Tuple
 
 import pandas as pd  # type: ignore
 

--- a/src/ts_shape/transform/calculator/unit_conversion.py
+++ b/src/ts_shape/transform/calculator/unit_conversion.py
@@ -101,7 +101,7 @@ class UnitConverter(Base):
             ) from exc
 
     @classmethod
-    def conversion_factor(cls, from_unit: str, to_unit: str) -> Tuple[float, float]:
+    def conversion_factor(cls, from_unit: str, to_unit: str) -> tuple[float, float]:
         """Return the ``(scale, offset)`` mapping ``from_unit`` -> ``to_unit``.
 
         The conversion is ``target = value * scale + offset``. ``offset`` is
@@ -132,7 +132,7 @@ class UnitConverter(Base):
         to_unit: str,
         *,
         column_name: str = "value_double",
-        target_column: Optional[str] = None,
+        target_column: str | None = None,
     ) -> pd.DataFrame:
         """Convert a numeric DataFrame column to different units.
 

--- a/src/ts_shape/transform/functions/lambda_func.py
+++ b/src/ts_shape/transform/functions/lambda_func.py
@@ -1,6 +1,7 @@
 import logging
 import pandas as pd  # type: ignore
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 from ts_shape.utils.base import Base
 
 logger = logging.getLogger(__name__)

--- a/src/ts_shape/transform/harmonization.py
+++ b/src/ts_shape/transform/harmonization.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-from typing import Optional, List
 
 from ts_shape.errors import DataQualityWarning
 from ts_shape.utils.base import Base

--- a/src/ts_shape/transform/harmonization.py
+++ b/src/ts_shape/transform/harmonization.py
@@ -67,7 +67,7 @@ class DataHarmonizer(Base):
         self,
         freq: str,
         method: str = "linear",
-        fill_limit: Optional[int] = None,
+        fill_limit: int | None = None,
     ) -> pd.DataFrame:
         """Resample to a uniform time grid with interpolation.
 
@@ -121,8 +121,8 @@ class DataHarmonizer(Base):
     def fill_gaps(
         self,
         strategy: str = "interpolate",
-        max_gap: Optional[str] = None,
-        fill_value: Optional[float] = None,
+        max_gap: str | None = None,
+        fill_value: float | None = None,
     ) -> pd.DataFrame:
         """Fill gaps in the wide-format data using the specified strategy.
 
@@ -208,8 +208,8 @@ class DataHarmonizer(Base):
 
     def merge_multi_signals(
         self,
-        uuids: Optional[List[str]] = None,
-        freq: Optional[str] = None,
+        uuids: list[str] | None = None,
+        freq: str | None = None,
         method: str = "linear",
     ) -> pd.DataFrame:
         """End-to-end harmonization: pivot, filter, resample, interpolate.

--- a/tests/eventlog/test_adapter_coverage.py
+++ b/tests/eventlog/test_adapter_coverage.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import pkgutil
-from typing import Iterator
+from collections.abc import Iterator
 
 import pandas as pd
 

--- a/tests/test_azure_blob_energy_loader.py
+++ b/tests/test_azure_blob_energy_loader.py
@@ -10,19 +10,19 @@ from ts_shape.loader.timeseries.azure_blob_energy_loader import AzureBlobEnergyL
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
 _CSV_BYTES = (
-    "time,value\n"
-    "2026-01-13T00:00:00Z,107.603588867188\n"
-    "2026-01-13T00:15:00Z,184.093249511719\n"
-    "2026-01-13T00:30:00Z,288.517919921875\n"
-).encode()
+    b"time,value\n"
+    b"2026-01-13T00:00:00Z,107.603588867188\n"
+    b"2026-01-13T00:15:00Z,184.093249511719\n"
+    b"2026-01-13T00:30:00Z,288.517919921875\n"
+)
 
 _META_BYTES = (
-    "id\tlabel_lvl1\tlabel_lvl2\tlabel_lvl3\tlabel_lvl4\tdescription\tunit"
-    "\thierarchy_lvl1\thierarchy_lvl2\thierarchy_lvl3"
-    "\thierarchy_lvl4\thierarchy_lvl5\thierarchy_lvl6\n"
-    "sensor_001\tBuilding A\tFloor 1\tLine 1\t\tMain meter\tkWh"
-    "\tSite\tBuilding\tFloor\tLine\t\t\n"
-).encode()
+    b"id\tlabel_lvl1\tlabel_lvl2\tlabel_lvl3\tlabel_lvl4\tdescription\tunit"
+    b"\thierarchy_lvl1\thierarchy_lvl2\thierarchy_lvl3"
+    b"\thierarchy_lvl4\thierarchy_lvl5\thierarchy_lvl6\n"
+    b"sensor_001\tBuilding A\tFloor 1\tLine 1\t\tMain meter\tkWh"
+    b"\tSite\tBuilding\tFloor\tLine\t\t\n"
+)
 
 
 def _make_container_client(blob_bytes: bytes = _CSV_BYTES, list_names: list = None):


### PR DESCRIPTION
Adds an advisory layer that surfaces deprecation signal from every angle
without blocking builds:

- pytest filterwarnings = "default::(Pending)?DeprecationWarning" so
  warnings from pandas/numpy/sqlalchemy/etc. show up in test output
- New CI "scan" job (continue-on-error) runs pytest with
  -W error::DeprecationWarning, ruff --select UP, mypy with
  enable_error_code=[deprecated], pip-audit, and pip list --outdated;
  uploads all findings as the deprecation-scan artefact
- PYTHONDEVMODE=1 on the main test job to expose extension warnings
- mypy config under [tool.mypy] so it can be invoked with no args
- scripts/scan_deprecations.sh as a local reproducer
- Renovate maximised: vulnerability auto-merge, transitiveRemediation,
  rangeStrategy=bump, openssf-scorecard preset, deprecation-watch label
  on stable releases, prConcurrentLimit raised to 10

Baseline: 900 tests pass with zero DeprecationWarnings today.