### PR TITLE
feat(events): add development pack for product & process R&D workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Key Features
 
 - **Unified DataFrame workflow** -- Load timeseries + metadata, join on `uuid`, process.
-- **Modular packs** -- Quality, Production, Engineering, Maintenance, Supply Chain events.
+- **Modular packs** -- Quality, Production, Engineering, Maintenance, Supply Chain, Energy, Correlation, and Development (product & process R&D) events.
 - **Performance-aware** -- Vectorised ops, chunked DB reads, concurrent I/O.
 - **Zero ML dependencies** -- Core uses only pandas, numpy, scipy.
 - **Multi-source loaders** -- Parquet, S3, Azure Blob, TimescaleDB, REST APIs.
@@ -52,7 +52,7 @@ import ts_shape
 # Generate a sample dataset (or load your own via pandas / a ts-shape loader)
 df = ts_shape.make_timeseries(["sensor:temp"], n_points=2000, n_outliers=6)
 
-# Discover what is available -- 60+ detectors across 7 packs
+# Discover what is available -- 70+ detectors across 8 packs
 ts_shape.list_detectors("events.quality")
 
 # Detect outliers
@@ -255,6 +255,45 @@ rul = fp.remaining_useful_life(degradation_rate=0.01, failure_threshold=120.0)
 # Vibration analysis (RMS, crest factor, kurtosis)
 vib = VibrationAnalysisEvents(df, signal_uuid="sensor:vibration")
 indicators = vib.bearing_health_indicators(window="5m")
+```
+
+### Development Events (Product & Process R&D)
+Designed for the activities that happen before commercial production: DOE runs,
+design-space qualification, golden-batch comparison, recipe-phase adherence, and
+outcome-driven critical-parameter ranking.
+
+```python
+from ts_shape.events.development import (
+    DesignOfExperimentsEvents,
+    DesignSpaceEvents,
+    GoldenBatchDeviationEvents,
+    RecipePhaseAdherenceEvents,
+    CriticalParameterRankingEvents,
+)
+
+# Recover DOE run structure from a continuous trace
+doe = DesignOfExperimentsEvents(df, factor_uuids=["factor:F1", "factor:F2"])
+runs = doe.detect_runs(min_duration="5min", stability_tol=0.01)
+effects = doe.compute_effects(response_uuid="response:Y", statistic="settled")
+
+# Multivariate qualified operating window
+ds = DesignSpaceEvents(qualification_df, cpp_uuids=["cpp:temp", "cpp:ph"]).fit_box()
+excursions = ds.detect_excursions(operation_df)
+
+# Golden-batch trajectory comparison (pointwise / area / DTW)
+gb = GoldenBatchDeviationEvents(reference_df, signal_uuid="reactor:temp")
+deviation = gb.compare(new_batch_df, mode="dtw")
+
+# Recipe-phase pass/fail vs. a declarative spec
+spec = {"hold": {"hold_value": (78.0, 82.0)}, "heat_up": {"ramp_rate_max": 0.5}}
+rp = RecipePhaseAdherenceEvents(df, phase_uuid="phase:reactor",
+                                value_uuid="temp:reactor", spec=spec)
+phases = rp.evaluate()
+
+# Rank candidate CPPs by their statistical link to a quality outcome
+cpp = CriticalParameterRankingEvents(df)
+drivers = cpp.top_drivers(per_run_df, candidate_columns=["x1", "x2", "x3"],
+                          outcome_column="yield", method="spearman")
 ```
 
 ### Supply Chain Events

--- a/docs/research/manufacturing-operations-research.md
+++ b/docs/research/manufacturing-operations-research.md
@@ -547,7 +547,63 @@ The ten proposed modules (§4) would close these gaps with minimal external depe
 
 ---
 
-## 7. Key Statistics Reference
+## 7. Product & Process Development R&D Methods (`events.development` pack)
+
+The methods proposed in §4 close operational gaps. A separate concern -- and a distinct user persona -- is **product and process development**: the work of formulation scientists, process development engineers, and validation teams that happens **before** (or alongside) commercial production. The same `events.*` architecture supports these workflows with a focused pack named `development`.
+
+### 7.1 Why a Separate Pack
+
+Operations detectors answer "is my running line in spec?" R&D detectors answer different questions:
+
+- "Which of these factor settings actually drives the outcome?" (DOE)
+- "What is the qualified multivariate operating window?" (design space)
+- "Does this batch trajectory match the golden reference?" (golden batch)
+- "Did every recipe phase meet its acceptance criteria?" (recipe adherence)
+- "Which input parameters are statistically linked to yield?" (CPP ranking)
+
+These questions appear in process development for pharma (ICH Q8 design space, IQ/OQ/PQ validation), biotech (golden-batch concept for upstream/downstream), specialty chemicals (campaign DOE for new product introduction), food & beverage (recipe validation), and semiconductors (FOUP-level characterisation runs). The market is smaller than mainline operations but the unit value per detector is higher: a single DOE-effect estimation can save weeks of pilot-plant time.
+
+### 7.2 Implemented Detectors
+
+| Detector | Purpose | Output shape | Methods |
+|---|---|---|---|
+| `DesignOfExperimentsEvents` | Recover DOE run structure from continuous data; estimate per-factor main effects. | interval / static | `detect_runs`, `compute_effects` |
+| `DesignSpaceEvents` | Fit a multivariate qualified operating window (box or convex hull) from R&D data; flag commercial-operation excursions and near-boundary samples. | interval / point | `fit_box`, `fit_hull`, `detect_excursions`, `boundary_proximity` |
+| `GoldenBatchDeviationEvents` | Quantify deviation of a new batch trajectory from a reference (golden) batch using pointwise, area-between-curves, or DTW distance. | summary | `compare`, `phase_breakdown` |
+| `RecipePhaseAdherenceEvents` | Evaluate batch recipe phases against a declarative spec (duration / hold value / ramp rate / peak / trough). | interval | `evaluate` |
+| `CriticalParameterRankingEvents` | Rank candidate input parameters by their statistical association with a quality outcome (Pearson / Spearman / one-way ANOVA). | static | `rank`, `top_drivers` |
+
+### 7.3 Design Choices
+
+- **Zero-ML, scipy-only** -- consistent with the wider ts-shape philosophy. DTW is a pure-numpy implementation with a Sakoe-Chiba band; ANOVA and correlation calls go through `scipy.stats`; the convex hull uses `scipy.spatial.ConvexHull`.
+- **No new schema** -- every method returns canonical `point`, `interval`, `summary`, or `static` shapes via the same `_output.py` helpers used by the other 7 packs.
+- **Compositional with existing detectors** -- `RecipePhaseAdherenceEvents` builds on the same phase-segmentation idea as `BatchTrackingEvents`; `DesignSpaceEvents` complements the univariate `ProcessWindowEvents`; `GoldenBatchDeviationEvents` complements the cross-segment clustering in `features.segment_analysis.ProfileComparison`.
+- **Not duplicated work** -- step-response characterisation (time constant, overshoot, rise time, settling time) already lives in `SetpointChangeEvents` and is intentionally not re-implemented in this pack.
+
+### 7.4 Gaps Closed
+
+| R&D gap | Coverage before | Coverage now |
+|---|---|---|
+| DOE run segmentation from continuous data | none | `DesignOfExperimentsEvents.detect_runs` |
+| Per-factor effect estimation | none | `DesignOfExperimentsEvents.compute_effects` |
+| Multivariate design-space monitoring | univariate only (`ProcessWindowEvents`) | `DesignSpaceEvents` (box + hull) |
+| Golden-batch trajectory comparison | clustering only (`ProfileComparison`) | `GoldenBatchDeviationEvents` |
+| Recipe-phase spec compliance | phase segmentation only (`BatchTrackingEvents`) | `RecipePhaseAdherenceEvents` |
+| Outcome-driven CPP identification | signal-vs-signal correlation only (`AnomalyCorrelationEvents`) | `CriticalParameterRankingEvents` |
+
+### 7.5 Future Extensions (not in scope)
+
+Methods deliberately left out of the initial pack but worth revisiting:
+
+- **Higher-order effect estimation** (two-way interactions, response surface fitting via least-squares).
+- **Bayesian online change-point detection** for run-segmentation when factor changes are not stepwise.
+- **Process validation IQ/OQ/PQ workflow** -- requires a richer notion of "validation campaign" beyond per-run aggregation.
+- **Multivariate SPC (Hotelling T²)** -- proposed in §4 under the operations roadmap; would also serve R&D characterisation studies.
+- **Accelerated life test / Weibull fitting** -- niche but high-value in reliability engineering R&D.
+
+---
+
+## 8. Key Statistics Reference
 
 | Metric | Value | Source |
 |---|---|---|

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -93,6 +93,12 @@ _LAZY: dict[str, str] = {
     "DegradationDetectionEvents": "ts_shape.events.maintenance.degradation_detection",
     "FailurePredictionEvents": "ts_shape.events.maintenance.failure_prediction",
     "VibrationAnalysisEvents": "ts_shape.events.maintenance.vibration_analysis",
+    # -- events.development (product & process R&D) ----------------------
+    "CriticalParameterRankingEvents": "ts_shape.events.development.critical_parameter_ranking",
+    "DesignOfExperimentsEvents": "ts_shape.events.development.design_of_experiments",
+    "DesignSpaceEvents": "ts_shape.events.development.design_space",
+    "GoldenBatchDeviationEvents": "ts_shape.events.development.golden_batch",
+    "RecipePhaseAdherenceEvents": "ts_shape.events.development.recipe_phase_adherence",
     # -- events.energy --------------------------------------------------
     "CarbonIntensityEvents": "ts_shape.events.energy.carbon_intensity",
     "EnergyConsumptionEvents": "ts_shape.events.energy.consumption_analysis",

--- a/src/ts_shape/eventlog/archetypes.py
+++ b/src/ts_shape/eventlog/archetypes.py
@@ -34,6 +34,16 @@ ARCHETYPE_BY_METHOD: dict[tuple[str, str], str] = {
     ("SignalCorrelationEvents", "correlation_breakdown"): "correlation",
     ("SignalCorrelationEvents", "lag_correlation"): "correlation",
     ("SignalCorrelationEvents", "rolling_correlation"): "correlation",
+    # ---- development (product & process R&D) -------------------------------
+    ("CriticalParameterRankingEvents", "rank"): "static",
+    ("CriticalParameterRankingEvents", "top_drivers"): "static",
+    ("DesignOfExperimentsEvents", "compute_effects"): "static",
+    ("DesignOfExperimentsEvents", "detect_runs"): "interval",
+    ("DesignSpaceEvents", "boundary_proximity"): "threshold",
+    ("DesignSpaceEvents", "detect_excursions"): "interval",
+    ("GoldenBatchDeviationEvents", "compare"): "aggregate",
+    ("GoldenBatchDeviationEvents", "phase_breakdown"): "aggregate",
+    ("RecipePhaseAdherenceEvents", "evaluate"): "interval",
     # ---- energy ------------------------------------------------------------
     ("CarbonIntensityEvents", "carbon_intensity_per_unit"): "aggregate",
     ("CarbonIntensityEvents", "emission_factor_audit"): "aggregate",

--- a/src/ts_shape/eventlog/lambda_rules/spec.py
+++ b/src/ts_shape/eventlog/lambda_rules/spec.py
@@ -27,6 +27,7 @@ _VALID_PACKS: frozenset[str] = frozenset(
         "supplychain",
         "energy",
         "correlation",
+        "development",
     }
 )
 _VALID_ARCHETYPES: frozenset[str] = frozenset(

--- a/src/ts_shape/eventlog/taxonomy.py
+++ b/src/ts_shape/eventlog/taxonomy.py
@@ -53,6 +53,7 @@ _M = "maintenance"
 _SC = "supplychain"
 _EN = "energy"
 _CO = "correlation"
+_DV = "development"
 
 P = "point"
 I = "interval"  # noqa: E741 — one-letter shape alias used in the REGISTRY literal below
@@ -137,6 +138,70 @@ REGISTRY: dict[tuple[str, str], LabelRule] = {
             "ts_shape:method": "rolling_correlation",
             "ts_shape:confidence": "correlation",
         },
+    ),
+    # ---- development (product & process R&D) -------------------------------
+    ("CriticalParameterRankingEvents", "rank"): _r(
+        "development.cpp.rank",
+        _DV,
+        ST,
+        objs=("signal",),
+        standard_attrs={"ts_shape:method": "method"},
+    ),
+    ("CriticalParameterRankingEvents", "top_drivers"): _r(
+        "development.cpp.top_drivers",
+        _DV,
+        ST,
+        objs=("signal",),
+        standard_attrs={"ts_shape:method": "method"},
+    ),
+    ("DesignOfExperimentsEvents", "compute_effects"): _r(
+        "development.doe.effects",
+        _DV,
+        ST,
+        objs=("signal",),
+        standard_attrs={"ts_shape:method": "doe_effects"},
+    ),
+    ("DesignOfExperimentsEvents", "detect_runs"): _r(
+        "development.doe.run",
+        _DV,
+        I,
+        standard_attrs={"ts_shape:lifecycle_state": "doe_run"},
+    ),
+    ("DesignSpaceEvents", "boundary_proximity"): _r(
+        "development.design_space.boundary_proximity",
+        _DV,
+        P,
+        standard_attrs={
+            "ts_shape:method": "boundary_proximity",
+            "ts_shape:direction": "closest_axis",
+        },
+    ),
+    ("DesignSpaceEvents", "detect_excursions"): _r(
+        "development.design_space.excursion",
+        _DV,
+        I,
+        standard_attrs={"ts_shape:lifecycle_state": "excursion_mode"},
+    ),
+    ("GoldenBatchDeviationEvents", "compare"): _r(
+        "development.golden_batch.compare",
+        _DV,
+        S,
+        objs=("batch",),
+        standard_attrs={"ts_shape:sample_count": None},
+    ),
+    ("GoldenBatchDeviationEvents", "phase_breakdown"): _r(
+        "development.golden_batch.phase_breakdown",
+        _DV,
+        S,
+        objs=("batch",),
+        standard_attrs={"ts_shape:sample_count": None},
+    ),
+    ("RecipePhaseAdherenceEvents", "evaluate"): _r(
+        "development.recipe_phase.evaluate",
+        _DV,
+        I,
+        objs=("asset", "batch"),
+        standard_attrs={"ts_shape:lifecycle_state": "phase"},
     ),
     # ---- energy ------------------------------------------------------------
     ("CarbonIntensityEvents", "carbon_intensity_per_unit"): _r(

--- a/src/ts_shape/events/development/__init__.py
+++ b/src/ts_shape/events/development/__init__.py
@@ -1,0 +1,52 @@
+"""Development Events
+
+Detectors for product and process development (R&D) workflows: design of
+experiments, design-space qualification, golden-batch comparison, recipe
+phase adherence, and outcome-driven critical parameter ranking.
+
+These detectors target activities that happen before (or alongside)
+commercial production -- the work of process development engineers,
+formulation scientists, and validation teams -- as opposed to the
+operations-focused detectors in the other event packs.
+
+Classes:
+- DesignOfExperimentsEvents: Segment continuous signals into DOE runs and
+  estimate main effects per factor.
+  - detect_runs: Identify stable factor-setting intervals as DOE runs.
+  - compute_effects: Aggregate run response and main effects per factor.
+
+- DesignSpaceEvents: Establish a multivariate qualified operating window
+  from R&D data and monitor commercial operation against it.
+  - fit_box: Per-axis bounds (quantile or min/max).
+  - fit_hull: scipy convex hull of the qualified region.
+  - detect_excursions: Intervals where operation leaves the design space.
+  - boundary_proximity: Per-sample distance to the design-space boundary.
+
+- GoldenBatchDeviationEvents: Quantify deviation of new batch trajectories
+  against a reference (golden) batch.
+  - compare: Pointwise, area-between-curves, or DTW deviation.
+  - phase_breakdown: Deviation broken down by recipe phase.
+
+- RecipePhaseAdherenceEvents: Evaluate batch recipe phases against a
+  declarative spec (duration, hold value, ramp rate, peak).
+  - evaluate: One event per phase with pass/fail and failed criteria.
+
+- CriticalParameterRankingEvents: Rank candidate input parameters by their
+  statistical association with a quality outcome.
+  - rank: Pearson / Spearman correlation or one-way ANOVA F-statistic.
+  - top_drivers: Filter and sort the ranking to the top-k significant.
+"""
+
+from .critical_parameter_ranking import CriticalParameterRankingEvents
+from .design_of_experiments import DesignOfExperimentsEvents
+from .design_space import DesignSpaceEvents
+from .golden_batch import GoldenBatchDeviationEvents
+from .recipe_phase_adherence import RecipePhaseAdherenceEvents
+
+__all__ = [
+    "CriticalParameterRankingEvents",
+    "DesignOfExperimentsEvents",
+    "DesignSpaceEvents",
+    "GoldenBatchDeviationEvents",
+    "RecipePhaseAdherenceEvents",
+]

--- a/src/ts_shape/events/development/critical_parameter_ranking.py
+++ b/src/ts_shape/events/development/critical_parameter_ranking.py
@@ -90,7 +90,14 @@ class CriticalParameterRankingEvents(Base):
         """
         from scipy import stats  # local import: keeps top-level import cheap
 
-        cols = ["parameter", "method", "statistic", "p_value", "abs_effect_size", "rank"]
+        cols = [
+            "parameter",
+            "method",
+            "statistic",
+            "p_value",
+            "abs_effect_size",
+            "rank",
+        ]
         if outcome_column not in per_run_df.columns:
             raise ValueError(
                 f"Outcome column {outcome_column!r} missing from per_run_df; "
@@ -133,7 +140,9 @@ class CriticalParameterRankingEvents(Base):
                     bins = pd.qcut(x_arr, q=anova_bins, labels=False, duplicates="drop")
                 except ValueError:
                     continue
-                groups = [y_arr[bins == b] for b in np.unique(bins) if (bins == b).any()]
+                groups = [
+                    y_arr[bins == b] for b in np.unique(bins) if (bins == b).any()
+                ]
                 groups = [g for g in groups if len(g) >= 2]
                 if len(groups) < 2:
                     continue

--- a/src/ts_shape/events/development/critical_parameter_ranking.py
+++ b/src/ts_shape/events/development/critical_parameter_ranking.py
@@ -1,0 +1,201 @@
+"""Outcome-driven ranking of candidate critical process parameters (CPPs).
+
+During process development the question is rarely "is this signal in
+spec?" -- it is "*which* of these signals drives the outcome we care
+about?" This detector ranks candidate input parameters by their
+statistical association with a per-run quality outcome (yield, pass/fail,
+KPI), so the process development engineer can shortlist a small set of
+true CPPs for tighter control.
+
+Three association measures are supported, all from ``scipy.stats``:
+
+* ``pearson``   -- linear correlation (best when both inputs and outcome
+  are continuous and approximately linear).
+* ``spearman``  -- rank correlation (robust to non-linear monotonic
+  relationships and outliers).
+* ``anova_f``   -- one-way ANOVA F-statistic between groups defined by
+  discrete levels of the parameter (the right test when factors were
+  swept at discrete levels in a DOE).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from ts_shape.utils.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+class CriticalParameterRankingEvents(Base):
+    """Rank input parameters by their statistical link to a quality outcome.
+
+    The detector operates on a *per-run* table where each row is a
+    completed run (batch, DOE point, shift), each candidate column is the
+    aggregated value of an input parameter during that run, and an
+    outcome column holds the quality / yield measurement of interest.
+
+    The constructor still accepts a long-form ``dataframe`` for symmetry
+    with the rest of ts-shape, but :meth:`rank` requires the wide-format
+    per-run table directly because aggregating "the right number" for
+    each parameter is a development-engineer judgment call (mean of the
+    hold phase? settled value? peak?) that varies by parameter.
+    """
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        *,
+        event_uuid: str = "dev:cpp_ranking",
+        time_column: str = "systime",
+    ) -> None:
+        super().__init__(dataframe, column_name=time_column)
+        self.event_uuid = event_uuid
+        self.time_column = time_column
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def rank(
+        self,
+        per_run_df: pd.DataFrame,
+        candidate_columns: list[str],
+        outcome_column: str,
+        *,
+        method: str = "spearman",
+        anova_bins: int = 3,
+    ) -> pd.DataFrame:
+        """Rank candidate parameters by statistical association with the outcome.
+
+        Args:
+            per_run_df: One row per run, one column per candidate
+                parameter, plus an outcome column.
+            candidate_columns: Columns to evaluate as candidate CPPs.
+            outcome_column: Outcome (response) column.
+            method: ``"pearson"``, ``"spearman"``, or ``"anova_f"``.
+            anova_bins: Only used for ``method="anova_f"``. Each candidate
+                column is quantile-binned into this many groups before the
+                one-way ANOVA is run.
+
+        Returns:
+            Summary DataFrame: ``parameter``, ``method``, ``statistic``,
+            ``p_value``, ``abs_effect_size``, ``rank``. Sorted by
+            ``abs_effect_size`` descending so the top driver is the first
+            row.
+        """
+        from scipy import stats  # local import: keeps top-level import cheap
+
+        cols = ["parameter", "method", "statistic", "p_value", "abs_effect_size", "rank"]
+        if outcome_column not in per_run_df.columns:
+            raise ValueError(
+                f"Outcome column {outcome_column!r} missing from per_run_df; "
+                f"available: {list(per_run_df.columns)}"
+            )
+        if not candidate_columns:
+            return pd.DataFrame(columns=cols)
+
+        y_full = pd.to_numeric(per_run_df[outcome_column], errors="coerce")
+        if y_full.dropna().empty:
+            return pd.DataFrame(columns=cols)
+
+        rows: list[dict[str, Any]] = []
+        for col in candidate_columns:
+            if col not in per_run_df.columns:
+                logger.debug("Skipping unknown candidate column %s", col)
+                continue
+            x = pd.to_numeric(per_run_df[col], errors="coerce")
+            xy = pd.concat([x, y_full], axis=1).dropna()
+            if len(xy) < 3:
+                continue
+            x_arr = xy.iloc[:, 0].to_numpy(dtype=float)
+            y_arr = xy.iloc[:, 1].to_numpy(dtype=float)
+
+            stat: float
+            pval: float
+            effect: float
+
+            if method == "pearson":
+                res = stats.pearsonr(x_arr, y_arr)
+                stat, pval = float(res.statistic), float(res.pvalue)
+                effect = abs(stat)
+            elif method == "spearman":
+                res = stats.spearmanr(x_arr, y_arr)
+                stat, pval = float(res.statistic), float(res.pvalue)
+                effect = abs(stat)
+            elif method == "anova_f":
+                # Quantile-bin the candidate into `anova_bins` groups.
+                try:
+                    bins = pd.qcut(x_arr, q=anova_bins, labels=False, duplicates="drop")
+                except ValueError:
+                    continue
+                groups = [y_arr[bins == b] for b in np.unique(bins) if (bins == b).any()]
+                groups = [g for g in groups if len(g) >= 2]
+                if len(groups) < 2:
+                    continue
+                res = stats.f_oneway(*groups)
+                stat, pval = float(res.statistic), float(res.pvalue)
+                # Effect size: eta-squared = SS_between / SS_total.
+                grand = float(np.mean(np.concatenate(groups)))
+                ss_between = sum(
+                    len(g) * (float(np.mean(g)) - grand) ** 2 for g in groups
+                )
+                ss_total = float(np.sum((y_arr - grand) ** 2))
+                effect = ss_between / ss_total if ss_total > 0 else 0.0
+            else:
+                raise ValueError(
+                    f"Unknown method {method!r}; "
+                    f"choose 'pearson', 'spearman', or 'anova_f'."
+                )
+
+            rows.append(
+                {
+                    "parameter": col,
+                    "method": method,
+                    "statistic": stat,
+                    "p_value": pval,
+                    "abs_effect_size": effect,
+                }
+            )
+
+        if not rows:
+            return pd.DataFrame(columns=cols)
+
+        out = (
+            pd.DataFrame(rows)
+            .sort_values("abs_effect_size", ascending=False)
+            .reset_index(drop=True)
+        )
+        out["rank"] = np.arange(1, len(out) + 1)
+        return out[cols]
+
+    def top_drivers(
+        self,
+        per_run_df: pd.DataFrame,
+        candidate_columns: list[str],
+        outcome_column: str,
+        *,
+        method: str = "spearman",
+        k: int = 5,
+        alpha: float = 0.05,
+        anova_bins: int = 3,
+    ) -> pd.DataFrame:
+        """Return the top-``k`` candidates with ``p_value <= alpha``.
+
+        Wraps :meth:`rank` and filters by significance. The result keeps
+        the same column schema as :meth:`rank`.
+        """
+        full = self.rank(
+            per_run_df,
+            candidate_columns,
+            outcome_column,
+            method=method,
+            anova_bins=anova_bins,
+        )
+        if full.empty:
+            return full
+        return full[full["p_value"] <= alpha].head(k).reset_index(drop=True)

--- a/src/ts_shape/events/development/design_of_experiments.py
+++ b/src/ts_shape/events/development/design_of_experiments.py
@@ -258,7 +258,7 @@ class DesignOfExperimentsEvents(Base):
             if statistic == "min":
                 return float(window.min())
             if statistic == "settled":
-                tail = window.iloc[max(0, int(len(window) * 2 / 3)):]
+                tail = window.iloc[max(0, int(len(window) * 2 / 3)) :]
                 return float(tail.mean()) if len(tail) else float(window.mean())
             raise ValueError(f"Unknown statistic: {statistic!r}")
 
@@ -286,9 +286,11 @@ class DesignOfExperimentsEvents(Base):
                         "level": level,
                         "n_runs": int(len(group)),
                         "response_mean": response_mean,
-                        "response_std": float(group["_response"].std(ddof=1))
-                        if len(group) > 1
-                        else 0.0,
+                        "response_std": (
+                            float(group["_response"].std(ddof=1))
+                            if len(group) > 1
+                            else 0.0
+                        ),
                         "main_effect": response_mean - grand_mean,
                     }
                 )

--- a/src/ts_shape/events/development/design_of_experiments.py
+++ b/src/ts_shape/events/development/design_of_experiments.py
@@ -1,0 +1,296 @@
+"""Design-of-Experiments (DOE) run segmentation and effect estimation.
+
+A DOE campaign sweeps one or more factor signals through discrete levels
+while a response signal is measured. This detector recovers the run
+structure from continuous process data: contiguous time intervals where
+every factor signal is stationary at a recognisable level. Each run is
+tagged with its factor-level combination, and a follow-up method
+aggregates the response per factor level to expose main effects.
+
+The detector is deliberately classical -- no regression model fit, no
+fractional factorial enumeration -- so it works on any factor pattern an
+experimenter actually ran on the line, including OFAT, full factorial,
+fractional, and Latin square designs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from ts_shape.utils.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+class DesignOfExperimentsEvents(Base):
+    """Segment continuous process data into DOE runs and estimate effects.
+
+    A *run* is a contiguous interval during which every factor signal sits
+    on a single discrete level (low rolling std relative to its tolerance)
+    long enough to be a deliberate experimental setting rather than a
+    transient. Tagging each run with its factor-level combination produces
+    an experimental dataset that downstream effect estimation can act on.
+    """
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        factor_uuids: list[str],
+        *,
+        event_uuid: str = "dev:doe_run",
+        value_column: str = "value_double",
+        time_column: str = "systime",
+    ) -> None:
+        super().__init__(dataframe, column_name=time_column)
+        if not factor_uuids:
+            raise ValueError("factor_uuids must contain at least one signal UUID")
+        self.factor_uuids = list(factor_uuids)
+        self.event_uuid = event_uuid
+        self.value_column = value_column
+        self.time_column = time_column
+        for uid in self.factor_uuids:
+            self._validate_uuid(self.dataframe, uid)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _wide_factor_frame(self) -> pd.DataFrame:
+        """Pivot the long-form factor signals to wide form aligned on time."""
+        if self.dataframe.empty:
+            return pd.DataFrame()
+        sel = self.dataframe[self.dataframe["uuid"].isin(self.factor_uuids)]
+        if sel.empty:
+            return pd.DataFrame()
+        wide = (
+            sel.pivot_table(
+                index=self.time_column,
+                columns="uuid",
+                values=self.value_column,
+                aggfunc="last",
+            )
+            .sort_index()
+            .ffill()
+            .dropna(how="any")
+        )
+        # Restrict to requested factors and preserve the caller's order.
+        present = [u for u in self.factor_uuids if u in wide.columns]
+        return wide[present] if present else pd.DataFrame()
+
+    @staticmethod
+    def _bin_level(values: np.ndarray, n_levels: int | None) -> np.ndarray:
+        """Bin observed factor values into discrete level labels.
+
+        When ``n_levels`` is given, the values are quantile-binned into
+        exactly that many levels. Otherwise distinct rounded values are
+        used as their own levels -- correct for a real DOE where the
+        operator drove the factor to a small number of explicit setpoints.
+        """
+        if n_levels is None:
+            return np.round(values, 6)
+        bins = pd.qcut(values, q=n_levels, labels=False, duplicates="drop")
+        return bins.astype(float)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def detect_runs(
+        self,
+        *,
+        min_duration: str = "5min",
+        stability_tol: float = 0.02,
+        n_levels: dict[str, int] | None = None,
+    ) -> pd.DataFrame:
+        """Identify DOE runs as stable intervals across all factor signals.
+
+        Args:
+            min_duration: Minimum run length to be reported (e.g. ``"5min"``).
+                Shorter stable intervals are treated as transients.
+            stability_tol: Maximum relative range
+                ``(max - min) / (|mean| + eps)`` permitted within a run for
+                each factor. Default 2%.
+            n_levels: Optional ``{factor_uuid: k}`` mapping. When given, the
+                factor values are quantile-binned into ``k`` levels;
+                otherwise the rounded observed value is used as the level.
+
+        Returns:
+            Interval-shape DataFrame with columns: ``start``, ``end``,
+            ``duration_seconds``, ``uuid``, ``run_id``, and one
+            ``factor__<uuid>_level`` column per factor.
+        """
+        n_levels = n_levels or {}
+        base_cols = ["start", "end", "duration_seconds", "uuid", "run_id"]
+        level_cols = [f"factor__{u}_level" for u in self.factor_uuids]
+        all_cols = base_cols + level_cols
+
+        wide = self._wide_factor_frame()
+        if wide.empty:
+            return pd.DataFrame(columns=all_cols)
+
+        min_td = pd.to_timedelta(min_duration)
+        # Per-row relative range across factors; rows with a single factor
+        # are stable by definition. We measure relative range against the
+        # *next* row to detect setpoint transitions -- a robust signal
+        # because real DOE runs change the factor by orders of magnitude
+        # more than stability_tol.
+        eps = np.finfo(float).eps
+        diff = wide.diff().abs()
+        ref = wide.abs().clip(lower=eps)
+        rel = (diff / ref).fillna(0.0)
+        is_transition = (rel > stability_tol).any(axis=1)
+        # Group label increments at every transition.
+        group_id = is_transition.cumsum()
+
+        events: list[dict[str, Any]] = []
+        for gid, idxs in wide.groupby(group_id).groups.items():
+            block = wide.loc[idxs]
+            if len(block) < 2:
+                continue
+            start_t = block.index[0]
+            end_t = block.index[-1]
+            if (end_t - start_t) < min_td:
+                continue
+            row: dict[str, Any] = {
+                "start": start_t,
+                "end": end_t,
+                "duration_seconds": (end_t - start_t).total_seconds(),
+                "uuid": self.event_uuid,
+                "run_id": int(gid),
+            }
+            for u in self.factor_uuids:
+                if u not in block.columns:
+                    row[f"factor__{u}_level"] = np.nan
+                    continue
+                mean_val = float(block[u].mean())
+                k = n_levels.get(u)
+                # When n_levels[u] is set we cannot bin a single run in
+                # isolation, so we just attach the mean and rely on the
+                # post-pass below to assign discrete bin labels.
+                row[f"factor__{u}_level"] = mean_val if k is None else mean_val
+            events.append(row)
+
+        if not events:
+            return pd.DataFrame(columns=all_cols)
+
+        out = pd.DataFrame(events, columns=all_cols)
+
+        # Post-pass: quantile-bin per factor when ``n_levels`` was given.
+        for u, k in n_levels.items():
+            col = f"factor__{u}_level"
+            if col in out.columns and out[col].notna().any():
+                out[col] = self._bin_level(out[col].to_numpy(dtype=float), k)
+
+        return out
+
+    def compute_effects(
+        self,
+        response_uuid: str,
+        *,
+        statistic: str = "mean",
+        min_duration: str = "5min",
+        stability_tol: float = 0.02,
+        n_levels: dict[str, int] | None = None,
+    ) -> pd.DataFrame:
+        """Aggregate the response signal per factor level (main effects).
+
+        Args:
+            response_uuid: UUID of the response (output) signal.
+            statistic: Aggregation applied to the response within each run.
+                One of ``"mean"`` (default), ``"median"``, ``"max"``,
+                ``"min"``, or ``"settled"`` -- the latter takes the mean of
+                the final third of the run, useful for response signals
+                that need to stabilise after a factor change.
+            min_duration: Forwarded to :meth:`detect_runs`.
+            stability_tol: Forwarded to :meth:`detect_runs`.
+            n_levels: Forwarded to :meth:`detect_runs`.
+
+        Returns:
+            Summary DataFrame with one row per (factor, level), columns:
+            ``factor``, ``level``, ``n_runs``, ``response_mean``,
+            ``response_std``, ``main_effect``.
+            ``main_effect`` is ``response_mean`` minus the grand mean
+            across all runs.
+        """
+        cols = [
+            "factor",
+            "level",
+            "n_runs",
+            "response_mean",
+            "response_std",
+            "main_effect",
+        ]
+        self._validate_uuid(self.dataframe, response_uuid)
+
+        runs = self.detect_runs(
+            min_duration=min_duration,
+            stability_tol=stability_tol,
+            n_levels=n_levels,
+        )
+        if runs.empty:
+            return pd.DataFrame(columns=cols)
+
+        # Extract the response timeseries once.
+        resp = (
+            self.dataframe[self.dataframe["uuid"] == response_uuid][
+                [self.time_column, self.value_column]
+            ]
+            .copy()
+            .sort_values(self.time_column)
+            .set_index(self.time_column)
+        )
+        if resp.empty:
+            return pd.DataFrame(columns=cols)
+
+        def _agg(window: pd.Series) -> float:
+            if window.empty:
+                return float("nan")
+            if statistic == "mean":
+                return float(window.mean())
+            if statistic == "median":
+                return float(window.median())
+            if statistic == "max":
+                return float(window.max())
+            if statistic == "min":
+                return float(window.min())
+            if statistic == "settled":
+                tail = window.iloc[max(0, int(len(window) * 2 / 3)):]
+                return float(tail.mean()) if len(tail) else float(window.mean())
+            raise ValueError(f"Unknown statistic: {statistic!r}")
+
+        run_response = []
+        for _, run in runs.iterrows():
+            mask = (resp.index >= run["start"]) & (resp.index <= run["end"])
+            window = resp.loc[mask, self.value_column]
+            run_response.append(_agg(window))
+        runs = runs.assign(_response=run_response).dropna(subset=["_response"])
+        if runs.empty:
+            return pd.DataFrame(columns=cols)
+
+        grand_mean = float(runs["_response"].mean())
+
+        rows: list[dict[str, Any]] = []
+        for u in self.factor_uuids:
+            col = f"factor__{u}_level"
+            if col not in runs.columns:
+                continue
+            for level, group in runs.groupby(col, dropna=True):
+                response_mean = float(group["_response"].mean())
+                rows.append(
+                    {
+                        "factor": u,
+                        "level": level,
+                        "n_runs": int(len(group)),
+                        "response_mean": response_mean,
+                        "response_std": float(group["_response"].std(ddof=1))
+                        if len(group) > 1
+                        else 0.0,
+                        "main_effect": response_mean - grand_mean,
+                    }
+                )
+
+        return pd.DataFrame(rows, columns=cols) if rows else pd.DataFrame(columns=cols)

--- a/src/ts_shape/events/development/design_space.py
+++ b/src/ts_shape/events/development/design_space.py
@@ -1,0 +1,273 @@
+"""Multivariate design-space qualification and monitoring.
+
+In process development the *design space* is the multidimensional region
+of input parameters that has been demonstrated -- through DOE or process
+characterisation runs -- to deliver acceptable output quality. ICH Q8
+formalises the concept for pharma; it is equally useful in any process
+industry where multiple critical process parameters (CPPs) interact.
+
+This detector fits a design space to qualification data and emits events
+when commercial-operation data exits the qualified region. Two fitting
+modes are supported: per-axis quantile boxes (cheap, conservative) and a
+scipy convex hull (tight, captures correlation between factors).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from ts_shape.utils.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+class DesignSpaceEvents(Base):
+    """Fit and monitor a multivariate qualified operating window.
+
+    Workflow::
+
+        ds = DesignSpaceEvents(qualification_df, cpp_uuids=[...])
+        ds.fit_box()                    # or ds.fit_hull()
+        excursions = ds.detect_excursions(operation_df)
+        near = ds.boundary_proximity(operation_df, warn_margin=0.1)
+    """
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        cpp_uuids: list[str],
+        *,
+        event_uuid: str = "dev:design_space",
+        value_column: str = "value_double",
+        time_column: str = "systime",
+    ) -> None:
+        super().__init__(dataframe, column_name=time_column)
+        if len(cpp_uuids) < 2:
+            raise ValueError(
+                "cpp_uuids must contain at least two signals; "
+                "use ProcessWindowEvents for the univariate case"
+            )
+        self.cpp_uuids = list(cpp_uuids)
+        self.event_uuid = event_uuid
+        self.value_column = value_column
+        self.time_column = time_column
+        for uid in self.cpp_uuids:
+            self._validate_uuid(self.dataframe, uid)
+
+        self._qualification = self._wide_frame(self.dataframe)
+        self._box: dict[str, tuple[float, float]] | None = None
+        self._hull = None  # scipy.spatial.ConvexHull when fitted
+        self._hull_points: np.ndarray | None = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _wide_frame(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty:
+            return pd.DataFrame(columns=self.cpp_uuids)
+        sel = df[df["uuid"].isin(self.cpp_uuids)]
+        if sel.empty:
+            return pd.DataFrame(columns=self.cpp_uuids)
+        wide = (
+            sel.pivot_table(
+                index=self.time_column,
+                columns="uuid",
+                values=self.value_column,
+                aggfunc="last",
+            )
+            .sort_index()
+            .ffill()
+            .dropna(how="any")
+        )
+        present = [u for u in self.cpp_uuids if u in wide.columns]
+        return wide[present] if present else pd.DataFrame(columns=self.cpp_uuids)
+
+    # ------------------------------------------------------------------
+    # Fitting
+    # ------------------------------------------------------------------
+
+    def fit_box(self, quantiles: tuple[float, float] = (0.05, 0.95)) -> DesignSpaceEvents:
+        """Fit per-axis bounds from the qualification data.
+
+        Args:
+            quantiles: ``(low, high)`` quantile pair used to set each
+                axis's bounds. ``(0.0, 1.0)`` reduces to absolute min/max.
+
+        Returns:
+            ``self`` to allow ``DesignSpaceEvents(...).fit_box()`` chaining.
+        """
+        if self._qualification.empty:
+            raise ValueError("No qualification data available to fit_box on.")
+        low_q, high_q = quantiles
+        self._box = {
+            col: (
+                float(self._qualification[col].quantile(low_q)),
+                float(self._qualification[col].quantile(high_q)),
+            )
+            for col in self._qualification.columns
+        }
+        self._hull = None
+        self._hull_points = None
+        return self
+
+    def fit_hull(self) -> DesignSpaceEvents:
+        """Fit a convex hull around the qualification data.
+
+        Requires :mod:`scipy.spatial.ConvexHull`. The hull captures
+        correlation between CPPs that a per-axis box cannot, at the cost
+        of needing ``len(cpps) + 1`` non-degenerate qualification points.
+
+        Returns:
+            ``self`` for chaining.
+        """
+        from scipy.spatial import ConvexHull  # local import: optional scipy path
+
+        if len(self._qualification) < len(self.cpp_uuids) + 1:
+            raise ValueError(
+                f"fit_hull needs at least {len(self.cpp_uuids) + 1} qualification "
+                f"points in {len(self.cpp_uuids)} dimensions; "
+                f"got {len(self._qualification)}."
+            )
+        pts = self._qualification.to_numpy(dtype=float)
+        self._hull = ConvexHull(pts)
+        self._hull_points = pts
+        self._box = None
+        return self
+
+    # ------------------------------------------------------------------
+    # Membership tests
+    # ------------------------------------------------------------------
+
+    def _inside_box(self, wide: pd.DataFrame) -> np.ndarray:
+        """Return a boolean mask of samples inside the per-axis box."""
+        assert self._box is not None
+        inside = np.ones(len(wide), dtype=bool)
+        for col, (lo, hi) in self._box.items():
+            if col not in wide.columns:
+                continue
+            v = wide[col].to_numpy(dtype=float)
+            inside &= (v >= lo) & (v <= hi)
+        return inside
+
+    def _inside_hull(self, wide: pd.DataFrame) -> np.ndarray:
+        """Return a boolean mask of points inside the convex hull."""
+        assert self._hull is not None and self._hull_points is not None
+        pts = wide.to_numpy(dtype=float)
+        eqs = self._hull.equations  # shape (n_facets, n_dim + 1)
+        # Each facet inequality is A·x + b ≤ 0. Hull interior: all true.
+        # Small positive tolerance keeps boundary points inside.
+        tol = 1e-9
+        return np.all(eqs[:, :-1] @ pts.T + eqs[:, -1:] <= tol, axis=0)
+
+    # ------------------------------------------------------------------
+    # Public detectors
+    # ------------------------------------------------------------------
+
+    def detect_excursions(self, operation_df: pd.DataFrame) -> pd.DataFrame:
+        """Find contiguous intervals where operation leaves the design space.
+
+        Args:
+            operation_df: Long-form signal DataFrame containing all CPP
+                signals; only the configured ``cpp_uuids`` are used.
+
+        Returns:
+            Interval-shape DataFrame with columns: ``start``, ``end``,
+            ``duration_seconds``, ``uuid``, ``excursion_mode``
+            (``"box"`` / ``"hull"``).
+        """
+        cols = ["start", "end", "duration_seconds", "uuid", "excursion_mode"]
+        if self._box is None and self._hull is None:
+            raise RuntimeError("Call fit_box() or fit_hull() before detect_excursions.")
+        wide = self._wide_frame(operation_df)
+        if wide.empty:
+            return pd.DataFrame(columns=cols)
+
+        if self._box is not None:
+            inside = self._inside_box(wide)
+            mode = "box"
+        else:
+            inside = self._inside_hull(wide)
+            mode = "hull"
+
+        outside = ~inside
+        if not outside.any():
+            return pd.DataFrame(columns=cols)
+
+        # Group contiguous outside runs.
+        group_id = (outside != np.roll(outside, 1)).cumsum()
+        events: list[dict[str, Any]] = []
+        for gid, grp in pd.DataFrame({"out": outside, "gid": group_id}).groupby("gid"):
+            if not grp["out"].iloc[0]:
+                continue
+            idxs = grp.index
+            start_t = wide.index[idxs[0]]
+            end_t = wide.index[idxs[-1]]
+            events.append(
+                {
+                    "start": start_t,
+                    "end": end_t,
+                    "duration_seconds": (end_t - start_t).total_seconds(),
+                    "uuid": self.event_uuid,
+                    "excursion_mode": mode,
+                }
+            )
+        return pd.DataFrame(events, columns=cols) if events else pd.DataFrame(columns=cols)
+
+    def boundary_proximity(
+        self,
+        operation_df: pd.DataFrame,
+        warn_margin: float = 0.1,
+    ) -> pd.DataFrame:
+        """Emit point events for samples within ``warn_margin`` of the boundary.
+
+        Only supported for the ``fit_box`` mode -- a convex hull's
+        boundary distance is more expensive to compute per facet and is
+        not in scope for this detector. Call :meth:`detect_excursions`
+        for hull-fitted spaces.
+
+        Args:
+            operation_df: Long-form signal DataFrame.
+            warn_margin: Normalised distance threshold (fraction of the
+                axis span). A sample is reported when its closest axis
+                margin is below this value while still inside the box.
+
+        Returns:
+            Point-shape DataFrame: ``systime``, ``uuid``,
+            ``signed_margin``, ``closest_axis``.
+        """
+        cols = ["systime", "uuid", "signed_margin", "closest_axis"]
+        if self._box is None:
+            raise RuntimeError(
+                "boundary_proximity requires fit_box(); hull mode is not supported."
+            )
+        wide = self._wide_frame(operation_df)
+        if wide.empty:
+            return pd.DataFrame(columns=cols)
+
+        # Per-axis margins, then identify the closest axis per sample.
+        n = len(wide)
+        per_axis = np.empty((n, len(self._box)), dtype=float)
+        axis_names = list(self._box.keys())
+        for i, col in enumerate(axis_names):
+            lo, hi = self._box[col]
+            v = wide[col].to_numpy(dtype=float)
+            span = max(hi - lo, np.finfo(float).eps)
+            per_axis[:, i] = np.minimum((v - lo) / span, (hi - v) / span)
+        closest_idx = np.argmin(per_axis, axis=1)
+        closest_margin = per_axis[np.arange(n), closest_idx]
+        # Inside the box (margin >= 0) AND within warn_margin of boundary.
+        flag = (closest_margin >= 0) & (closest_margin <= warn_margin)
+        if not flag.any():
+            return pd.DataFrame(columns=cols)
+        rows = {
+            "systime": wide.index[flag],
+            "uuid": self.event_uuid,
+            "signed_margin": closest_margin[flag],
+            "closest_axis": [axis_names[i] for i in closest_idx[flag]],
+        }
+        return pd.DataFrame(rows, columns=cols)

--- a/src/ts_shape/events/development/design_space.py
+++ b/src/ts_shape/events/development/design_space.py
@@ -91,7 +91,9 @@ class DesignSpaceEvents(Base):
     # Fitting
     # ------------------------------------------------------------------
 
-    def fit_box(self, quantiles: tuple[float, float] = (0.05, 0.95)) -> DesignSpaceEvents:
+    def fit_box(
+        self, quantiles: tuple[float, float] = (0.05, 0.95)
+    ) -> DesignSpaceEvents:
         """Fit per-axis bounds from the qualification data.
 
         Args:
@@ -216,7 +218,9 @@ class DesignSpaceEvents(Base):
                     "excursion_mode": mode,
                 }
             )
-        return pd.DataFrame(events, columns=cols) if events else pd.DataFrame(columns=cols)
+        return (
+            pd.DataFrame(events, columns=cols) if events else pd.DataFrame(columns=cols)
+        )
 
     def boundary_proximity(
         self,

--- a/src/ts_shape/events/development/golden_batch.py
+++ b/src/ts_shape/events/development/golden_batch.py
@@ -238,7 +238,9 @@ class GoldenBatchDeviationEvents(Base):
             return pd.DataFrame(columns=cols)
 
         # Determine phase intervals from the phase signal.
-        phase_col = "value_string" if "value_string" in phase_df.columns else self.value_column
+        phase_col = (
+            "value_string" if "value_string" in phase_df.columns else self.value_column
+        )
         ph = (
             phase_df[phase_df["uuid"] == phase_uuid][[self.time_column, phase_col]]
             .copy()
@@ -252,7 +254,11 @@ class GoldenBatchDeviationEvents(Base):
         ph["_change"] = (ph[phase_col] != ph[phase_col].shift()).cumsum()
         intervals = (
             ph.groupby("_change")
-            .agg(start=(self.time_column, "first"), end=(self.time_column, "last"), phase=(phase_col, "first"))
+            .agg(
+                start=(self.time_column, "first"),
+                end=(self.time_column, "last"),
+                phase=(phase_col, "first"),
+            )
             .reset_index(drop=True)
         )
 
@@ -278,7 +284,8 @@ class GoldenBatchDeviationEvents(Base):
             if len(window) < 2:
                 continue
             candidate = self._resample_to_grid(
-                window[self.time_column], window[self.value_column].to_numpy(dtype=float)
+                window[self.time_column],
+                window[self.value_column].to_numpy(dtype=float),
             )
             residual = candidate - self._ref_resampled
             grid = np.linspace(0.0, 1.0, self.n_resample)

--- a/src/ts_shape/events/development/golden_batch.py
+++ b/src/ts_shape/events/development/golden_batch.py
@@ -1,0 +1,295 @@
+"""Golden-batch deviation: compare new batch trajectories to a reference.
+
+In batch process development a *golden batch* is a canonical run whose
+trajectory delivered the target product. Comparing later batches to that
+trajectory -- per timestep, per phase, or as a whole-trajectory shape
+distance -- is a workhorse diagnostic in pharma, food, and specialty
+chemicals.
+
+This detector supports three comparison modes:
+
+* ``pointwise`` -- resample both batches to a common normalised batch
+  time and report the maximum signed residual.
+* ``area``      -- numerical integral of the absolute residual using the
+  trapezoid rule. Captures cumulative deviation.
+* ``dtw``       -- pure-numpy dynamic time warping distance with a Sakoe
+  -Chiba band. Captures trajectory *shape* even when batches run at
+  different paces. No external DTW library required.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from ts_shape.utils.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+class GoldenBatchDeviationEvents(Base):
+    """Quantify deviation of a new batch from a golden reference batch."""
+
+    def __init__(
+        self,
+        reference_df: pd.DataFrame,
+        signal_uuid: str,
+        *,
+        event_uuid: str = "dev:golden_batch_deviation",
+        value_column: str = "value_double",
+        time_column: str = "systime",
+        n_resample: int = 256,
+    ) -> None:
+        super().__init__(reference_df, column_name=time_column)
+        self.signal_uuid = signal_uuid
+        self.event_uuid = event_uuid
+        self.value_column = value_column
+        self.time_column = time_column
+        if n_resample < 4:
+            raise ValueError("n_resample must be >= 4 for a useful comparison")
+        self.n_resample = n_resample
+        self._validate_uuid(self.dataframe, signal_uuid)
+
+        ref = (
+            self.dataframe[self.dataframe["uuid"] == signal_uuid][
+                [self.time_column, self.value_column]
+            ]
+            .copy()
+            .sort_values(self.time_column)
+            .reset_index(drop=True)
+        )
+        if ref.empty:
+            raise ValueError(
+                f"No samples found for reference signal_uuid={signal_uuid!r}"
+            )
+        self._ref_resampled = self._resample_to_grid(
+            ref[self.time_column], ref[self.value_column].to_numpy(dtype=float)
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resample_to_grid(self, times: pd.Series, values: np.ndarray) -> np.ndarray:
+        """Resample a batch trace to ``n_resample`` evenly-spaced batch-time points.
+
+        Batch time is normalised to [0, 1]; the trace is linearly
+        interpolated onto an evenly spaced grid so two batches of
+        different wall-clock durations are directly comparable.
+        """
+        t = pd.to_datetime(times).to_numpy()
+        if len(t) < 2:
+            return np.full(self.n_resample, float(values[0]) if len(values) else np.nan)
+        t_sec = (t - t[0]) / np.timedelta64(1, "s")
+        total = float(t_sec[-1])
+        if total <= 0:
+            return np.full(self.n_resample, float(values[0]))
+        norm = t_sec / total
+        grid = np.linspace(0.0, 1.0, self.n_resample)
+        return np.interp(grid, norm, values)
+
+    @staticmethod
+    def _dtw_distance(a: np.ndarray, b: np.ndarray, band: int) -> float:
+        """Dynamic time warping distance with a Sakoe-Chiba band.
+
+        Pure-numpy O(n * band) implementation. Returns the *normalised*
+        DTW distance (total cost divided by warping-path length).
+        """
+        n, m = len(a), len(b)
+        if n == 0 or m == 0:
+            return float("nan")
+        band = max(int(band), abs(n - m) + 1)
+        inf = np.inf
+        prev = np.full(m + 1, inf, dtype=float)
+        curr = np.full(m + 1, inf, dtype=float)
+        prev[0] = 0.0
+        for i in range(1, n + 1):
+            curr[:] = inf
+            j_lo = max(1, i - band)
+            j_hi = min(m, i + band)
+            for j in range(j_lo, j_hi + 1):
+                cost = abs(a[i - 1] - b[j - 1])
+                curr[j] = cost + min(prev[j], curr[j - 1], prev[j - 1])
+            prev, curr = curr, prev
+        total = prev[m]
+        if not np.isfinite(total):
+            return float("nan")
+        return float(total / (n + m))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compare(
+        self,
+        batch_df: pd.DataFrame,
+        *,
+        mode: str = "pointwise",
+        dtw_band_frac: float = 0.1,
+    ) -> pd.DataFrame:
+        """Compare a single new batch to the stored golden reference.
+
+        Args:
+            batch_df: Long-form DataFrame containing the candidate batch's
+                signal. The configured ``signal_uuid`` is used to extract
+                the trace.
+            mode: ``"pointwise"``, ``"area"``, or ``"dtw"``.
+            dtw_band_frac: Sakoe-Chiba band width as a fraction of the
+                resampled grid length. Only used for ``mode="dtw"``.
+
+        Returns:
+            Interval-shape DataFrame with one row, columns: ``start``,
+            ``end``, ``duration_seconds``, ``uuid``, ``mode``,
+            ``deviation_score``, ``max_abs_residual``,
+            ``batch_time_at_max``.
+        """
+        cols = [
+            "start",
+            "end",
+            "duration_seconds",
+            "uuid",
+            "mode",
+            "deviation_score",
+            "max_abs_residual",
+            "batch_time_at_max",
+        ]
+        if batch_df.empty:
+            return pd.DataFrame(columns=cols)
+        sel = batch_df[batch_df["uuid"] == self.signal_uuid][
+            [self.time_column, self.value_column]
+        ].copy()
+        if sel.empty:
+            return pd.DataFrame(columns=cols)
+        sel = sel.sort_values(self.time_column).reset_index(drop=True)
+
+        candidate = self._resample_to_grid(
+            sel[self.time_column], sel[self.value_column].to_numpy(dtype=float)
+        )
+        residual = candidate - self._ref_resampled
+        max_abs = float(np.max(np.abs(residual)))
+        argmax = int(np.argmax(np.abs(residual)))
+        batch_time_at_max = float(argmax / (self.n_resample - 1))
+
+        if mode == "pointwise":
+            score = max_abs
+        elif mode == "area":
+            # Trapezoid integral of |residual| on the normalised grid (0..1).
+            grid = np.linspace(0.0, 1.0, self.n_resample)
+            score = float(np.trapezoid(np.abs(residual), grid))
+        elif mode == "dtw":
+            band = max(2, int(dtw_band_frac * self.n_resample))
+            score = self._dtw_distance(candidate, self._ref_resampled, band)
+        else:
+            raise ValueError(
+                f"Unknown mode {mode!r}; choose 'pointwise', 'area', or 'dtw'."
+            )
+
+        start = pd.to_datetime(sel[self.time_column].iloc[0])
+        end = pd.to_datetime(sel[self.time_column].iloc[-1])
+        row: dict[str, Any] = {
+            "start": start,
+            "end": end,
+            "duration_seconds": (end - start).total_seconds(),
+            "uuid": self.event_uuid,
+            "mode": mode,
+            "deviation_score": score,
+            "max_abs_residual": max_abs,
+            "batch_time_at_max": batch_time_at_max,
+        }
+        return pd.DataFrame([row], columns=cols)
+
+    def phase_breakdown(
+        self,
+        batch_df: pd.DataFrame,
+        phase_df: pd.DataFrame,
+        *,
+        phase_uuid: str,
+    ) -> pd.DataFrame:
+        """Per-phase deviation of a batch against the golden reference.
+
+        The reference batch is sliced into phases by the same boundaries
+        applied to the candidate batch -- this assumes the phase sequence
+        is consistent across runs, which is true for recipes that are
+        executed phase-by-phase under recipe control.
+
+        Args:
+            batch_df: Long-form signal DataFrame for the candidate batch.
+            phase_df: Long-form DataFrame containing the phase-tracking
+                signal, where ``value_string`` (or the configured value
+                column) carries the phase name.
+            phase_uuid: UUID of the phase signal in ``phase_df``.
+
+        Returns:
+            Summary DataFrame: ``start``, ``end``, ``duration_seconds``,
+            ``phase``, ``deviation_score``, ``max_abs_residual``.
+        """
+        cols = [
+            "start",
+            "end",
+            "duration_seconds",
+            "phase",
+            "deviation_score",
+            "max_abs_residual",
+        ]
+        if batch_df.empty or phase_df.empty:
+            return pd.DataFrame(columns=cols)
+
+        # Determine phase intervals from the phase signal.
+        phase_col = "value_string" if "value_string" in phase_df.columns else self.value_column
+        ph = (
+            phase_df[phase_df["uuid"] == phase_uuid][[self.time_column, phase_col]]
+            .copy()
+            .sort_values(self.time_column)
+            .reset_index(drop=True)
+        )
+        if ph.empty:
+            return pd.DataFrame(columns=cols)
+
+        # Build contiguous phase intervals.
+        ph["_change"] = (ph[phase_col] != ph[phase_col].shift()).cumsum()
+        intervals = (
+            ph.groupby("_change")
+            .agg(start=(self.time_column, "first"), end=(self.time_column, "last"), phase=(phase_col, "first"))
+            .reset_index(drop=True)
+        )
+
+        # Extract candidate batch trace once.
+        sel = (
+            batch_df[batch_df["uuid"] == self.signal_uuid][
+                [self.time_column, self.value_column]
+            ]
+            .copy()
+            .sort_values(self.time_column)
+            .reset_index(drop=True)
+        )
+        if sel.empty:
+            return pd.DataFrame(columns=cols)
+        sel[self.time_column] = pd.to_datetime(sel[self.time_column])
+
+        rows: list[dict[str, Any]] = []
+        for _, ivl in intervals.iterrows():
+            mask = (sel[self.time_column] >= ivl["start"]) & (
+                sel[self.time_column] <= ivl["end"]
+            )
+            window = sel.loc[mask]
+            if len(window) < 2:
+                continue
+            candidate = self._resample_to_grid(
+                window[self.time_column], window[self.value_column].to_numpy(dtype=float)
+            )
+            residual = candidate - self._ref_resampled
+            grid = np.linspace(0.0, 1.0, self.n_resample)
+            rows.append(
+                {
+                    "start": ivl["start"],
+                    "end": ivl["end"],
+                    "duration_seconds": (ivl["end"] - ivl["start"]).total_seconds(),
+                    "phase": ivl["phase"],
+                    "deviation_score": float(np.trapezoid(np.abs(residual), grid)),
+                    "max_abs_residual": float(np.max(np.abs(residual))),
+                }
+            )
+        return pd.DataFrame(rows, columns=cols) if rows else pd.DataFrame(columns=cols)

--- a/src/ts_shape/events/development/recipe_phase_adherence.py
+++ b/src/ts_shape/events/development/recipe_phase_adherence.py
@@ -74,8 +74,14 @@ class RecipePhaseAdherenceEvents(Base):
         if sel.empty:
             return pd.DataFrame(columns=["start", "end", "phase"])
         # Phase name lives in value_string if present, else value_column.
-        phase_col = "value_string" if "value_string" in sel.columns else self.value_column
-        sel = sel[[self.time_column, phase_col]].sort_values(self.time_column).reset_index(drop=True)
+        phase_col = (
+            "value_string" if "value_string" in sel.columns else self.value_column
+        )
+        sel = (
+            sel[[self.time_column, phase_col]]
+            .sort_values(self.time_column)
+            .reset_index(drop=True)
+        )
         sel = sel.dropna(subset=[phase_col])
         if sel.empty:
             return pd.DataFrame(columns=["start", "end", "phase"])

--- a/src/ts_shape/events/development/recipe_phase_adherence.py
+++ b/src/ts_shape/events/development/recipe_phase_adherence.py
@@ -1,0 +1,205 @@
+"""Recipe-phase adherence: check each batch phase against a spec.
+
+Batch processes execute a sequence of named phases (heat-up, hold,
+cool-down, ...). Each phase has a development-defined spec: an expected
+duration window, a hold-value window, a maximum ramp rate, sometimes a
+peak ceiling. This detector iterates the phase intervals in a batch and
+emits one event per phase carrying pass/fail plus which criterion failed.
+
+The spec format is intentionally a plain dict so it can be authored by a
+process engineer (or loaded from YAML/JSON) without inventing a new
+schema class -- see :meth:`evaluate` for the recognised keys.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from ts_shape.utils.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+class RecipePhaseAdherenceEvents(Base):
+    """Evaluate batch recipe phases against a declarative spec.
+
+    The spec is a mapping ``{phase_name: criteria_dict}``. Recognised
+    criteria keys (all optional) per phase:
+
+    * ``duration_s``        -- ``(min, max)`` seconds.
+    * ``hold_value``        -- ``(min, max)`` for the mean value during
+      the phase.
+    * ``ramp_rate_max``     -- maximum absolute slope (value-units per
+      second) computed from the first to the last sample.
+    * ``peak_value``        -- ``(min, max)`` for the phase max.
+    * ``trough_value``      -- ``(min, max)`` for the phase min.
+
+    Missing criteria are not checked. A phase whose name is absent from
+    the spec is reported with ``pass=True`` and an empty
+    ``criteria_failed`` list (the phase was observed but not constrained).
+    """
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        phase_uuid: str,
+        value_uuid: str,
+        spec: dict[str, dict[str, Any]],
+        *,
+        event_uuid: str = "dev:recipe_phase_adherence",
+        value_column: str = "value_double",
+        time_column: str = "systime",
+    ) -> None:
+        super().__init__(dataframe, column_name=time_column)
+        self.phase_uuid = phase_uuid
+        self.value_uuid = value_uuid
+        self.event_uuid = event_uuid
+        self.value_column = value_column
+        self.time_column = time_column
+        self.spec = dict(spec)
+        self._validate_uuid(self.dataframe, phase_uuid)
+        self._validate_uuid(self.dataframe, value_uuid)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _phase_intervals(self) -> pd.DataFrame:
+        """Return contiguous phase intervals from the phase signal."""
+        sel = self.dataframe[self.dataframe["uuid"] == self.phase_uuid].copy()
+        if sel.empty:
+            return pd.DataFrame(columns=["start", "end", "phase"])
+        # Phase name lives in value_string if present, else value_column.
+        phase_col = "value_string" if "value_string" in sel.columns else self.value_column
+        sel = sel[[self.time_column, phase_col]].sort_values(self.time_column).reset_index(drop=True)
+        sel = sel.dropna(subset=[phase_col])
+        if sel.empty:
+            return pd.DataFrame(columns=["start", "end", "phase"])
+        sel["_chg"] = (sel[phase_col] != sel[phase_col].shift()).cumsum()
+        out = (
+            sel.groupby("_chg")
+            .agg(
+                start=(self.time_column, "first"),
+                end=(self.time_column, "last"),
+                phase=(phase_col, "first"),
+            )
+            .reset_index(drop=True)
+        )
+        return out
+
+    @staticmethod
+    def _check_range(value: float, bounds: Any) -> bool:
+        try:
+            lo, hi = bounds
+        except (TypeError, ValueError):
+            return True  # malformed spec entry -> skip silently
+        return (value >= lo) and (value <= hi)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(self) -> pd.DataFrame:
+        """Evaluate every observed phase interval against the spec.
+
+        Returns:
+            Interval-shape DataFrame, one row per phase occurrence,
+            columns: ``start``, ``end``, ``duration_seconds``, ``uuid``,
+            ``phase``, ``mean_value``, ``min_value``, ``max_value``,
+            ``observed_ramp_per_s``, ``criteria_failed`` (list[str]),
+            ``pass``.
+        """
+        cols = [
+            "start",
+            "end",
+            "duration_seconds",
+            "uuid",
+            "phase",
+            "mean_value",
+            "min_value",
+            "max_value",
+            "observed_ramp_per_s",
+            "criteria_failed",
+            "pass",
+        ]
+        intervals = self._phase_intervals()
+        if intervals.empty:
+            return pd.DataFrame(columns=cols)
+
+        # Pre-extract the value series sorted by time.
+        vals = (
+            self.dataframe[self.dataframe["uuid"] == self.value_uuid][
+                [self.time_column, self.value_column]
+            ]
+            .copy()
+            .sort_values(self.time_column)
+            .reset_index(drop=True)
+        )
+        if vals.empty:
+            return pd.DataFrame(columns=cols)
+        vals[self.time_column] = pd.to_datetime(vals[self.time_column])
+
+        rows: list[dict[str, Any]] = []
+        for _, ivl in intervals.iterrows():
+            mask = (vals[self.time_column] >= ivl["start"]) & (
+                vals[self.time_column] <= ivl["end"]
+            )
+            window = vals.loc[mask]
+            if window.empty:
+                continue
+            v = window[self.value_column].to_numpy(dtype=float)
+            duration_s = (ivl["end"] - ivl["start"]).total_seconds()
+            mean_v = float(np.mean(v))
+            min_v = float(np.min(v))
+            max_v = float(np.max(v))
+            # End-to-end ramp rate; for spec checking we use absolute value.
+            if duration_s > 0 and len(v) >= 2:
+                ramp = float((v[-1] - v[0]) / duration_s)
+            else:
+                ramp = 0.0
+
+            failed: list[str] = []
+            phase_spec = self.spec.get(ivl["phase"], {})
+
+            if "duration_s" in phase_spec and not self._check_range(
+                duration_s, phase_spec["duration_s"]
+            ):
+                failed.append("duration_s")
+            if "hold_value" in phase_spec and not self._check_range(
+                mean_v, phase_spec["hold_value"]
+            ):
+                failed.append("hold_value")
+            if "peak_value" in phase_spec and not self._check_range(
+                max_v, phase_spec["peak_value"]
+            ):
+                failed.append("peak_value")
+            if "trough_value" in phase_spec and not self._check_range(
+                min_v, phase_spec["trough_value"]
+            ):
+                failed.append("trough_value")
+            if "ramp_rate_max" in phase_spec:
+                limit = float(phase_spec["ramp_rate_max"])
+                if abs(ramp) > limit:
+                    failed.append("ramp_rate_max")
+
+            rows.append(
+                {
+                    "start": ivl["start"],
+                    "end": ivl["end"],
+                    "duration_seconds": duration_s,
+                    "uuid": self.event_uuid,
+                    "phase": ivl["phase"],
+                    "mean_value": mean_v,
+                    "min_value": min_v,
+                    "max_value": max_v,
+                    "observed_ramp_per_s": ramp,
+                    "criteria_failed": failed,
+                    "pass": len(failed) == 0,
+                }
+            )
+
+        return pd.DataFrame(rows, columns=cols) if rows else pd.DataFrame(columns=cols)

--- a/tests/eventlog/test_adapter_coverage.py
+++ b/tests/eventlog/test_adapter_coverage.py
@@ -100,6 +100,7 @@ def test_every_label_rule_has_valid_pack():
         "supplychain",
         "energy",
         "correlation",
+        "development",
     }
     bad = [(k, r.pack) for k, r in REGISTRY.items() if r.pack not in valid]
     assert not bad, f"invalid pack on entries: {bad[:10]}"

--- a/tests/test_development_events.py
+++ b/tests/test_development_events.py
@@ -20,7 +20,6 @@ from ts_shape.events.development import (
     RecipePhaseAdherenceEvents,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -64,14 +63,22 @@ class TestDesignOfExperimentsEvents:
         per_run = 4
         n_runs = 4
         t = pd.date_range("2024-01-01", periods=per_run * n_runs, freq="1min")
-        f1 = np.concatenate([
-            np.full(per_run, 10.0), np.full(per_run, 10.0),
-            np.full(per_run, 20.0), np.full(per_run, 20.0),
-        ])
-        f2 = np.concatenate([
-            np.full(per_run, 1.0), np.full(per_run, 2.0),
-            np.full(per_run, 2.0), np.full(per_run, 3.0),
-        ])
+        f1 = np.concatenate(
+            [
+                np.full(per_run, 10.0),
+                np.full(per_run, 10.0),
+                np.full(per_run, 20.0),
+                np.full(per_run, 20.0),
+            ]
+        )
+        f2 = np.concatenate(
+            [
+                np.full(per_run, 1.0),
+                np.full(per_run, 2.0),
+                np.full(per_run, 2.0),
+                np.full(per_run, 3.0),
+            ]
+        )
         # Response = 2*F1 + 5*F2, so F2 has the larger main effect.
         response = 2.0 * f1 + 5.0 * f2
 
@@ -226,9 +233,7 @@ class TestGoldenBatchDeviationEvents:
 
         # Candidate batch is the golden trace shifted up by 5.
         t = pd.date_range("2024-02-01", periods=128, freq="1min")
-        v = (
-            np.concatenate([np.linspace(20.0, 80.0, 64), np.full(64, 80.0)]) + 5.0
-        )
+        v = np.concatenate([np.linspace(20.0, 80.0, 64), np.full(64, 80.0)]) + 5.0
         cand = _make_long_df(t, v, "sig:temp")
 
         out = det.compare(cand, mode="pointwise")
@@ -353,15 +358,16 @@ class TestCriticalParameterRankingEvents:
         x_weak = rng.normal(size=n)
         noise = rng.normal(scale=0.5, size=n)
         outcome = 3.0 * x_strong + 0.1 * x_weak + noise
-        return pd.DataFrame(
-            {"strong": x_strong, "weak": x_weak, "yield": outcome}
-        )
+        return pd.DataFrame({"strong": x_strong, "weak": x_weak, "yield": outcome})
 
     def test_rank_orders_strong_first_with_pearson(self):
         runs = self._per_run_table()
         det = CriticalParameterRankingEvents(pd.DataFrame())
         out = det.rank(
-            runs, candidate_columns=["strong", "weak"], outcome_column="yield", method="pearson"
+            runs,
+            candidate_columns=["strong", "weak"],
+            outcome_column="yield",
+            method="pearson",
         )
         assert list(out["parameter"])[0] == "strong"
         assert out.iloc[0]["abs_effect_size"] > out.iloc[1]["abs_effect_size"]
@@ -383,7 +389,20 @@ class TestCriticalParameterRankingEvents:
             {
                 "x": [0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2],
                 "noise": np.random.default_rng(0).normal(size=12),
-                "yield": [10, 10.2, 9.8, 20, 19.7, 20.3, 30, 30.2, 29.8, 40, 40.1, 39.9],
+                "yield": [
+                    10,
+                    10.2,
+                    9.8,
+                    20,
+                    19.7,
+                    20.3,
+                    30,
+                    30.2,
+                    29.8,
+                    40,
+                    40.1,
+                    39.9,
+                ],
             }
         )
         det = CriticalParameterRankingEvents(pd.DataFrame())
@@ -413,9 +432,7 @@ class TestCriticalParameterRankingEvents:
         runs = self._per_run_table()
         det = CriticalParameterRankingEvents(pd.DataFrame())
         with pytest.raises(ValueError):
-            det.rank(
-                runs, candidate_columns=["strong"], outcome_column="not-a-column"
-            )
+            det.rank(runs, candidate_columns=["strong"], outcome_column="not-a-column")
 
     def test_unknown_method_raises(self):
         runs = self._per_run_table()

--- a/tests/test_development_events.py
+++ b/tests/test_development_events.py
@@ -1,0 +1,429 @@
+"""Tests for the events.development pack.
+
+Five detectors target product- and process-development workflows:
+``DesignOfExperimentsEvents``, ``DesignSpaceEvents``,
+``GoldenBatchDeviationEvents``, ``RecipePhaseAdherenceEvents``,
+``CriticalParameterRankingEvents``.
+"""
+
+from __future__ import annotations
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+import pytest
+
+from ts_shape.events.development import (
+    CriticalParameterRankingEvents,
+    DesignOfExperimentsEvents,
+    DesignSpaceEvents,
+    GoldenBatchDeviationEvents,
+    RecipePhaseAdherenceEvents,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_long_df(times, values, uuid):
+    return pd.DataFrame(
+        {
+            "systime": times,
+            "uuid": [uuid] * len(times),
+            "value_double": values,
+            "is_delta": [True] * len(times),
+        }
+    )
+
+
+def _make_multi_uuid_df(rows: dict[str, tuple[pd.DatetimeIndex, np.ndarray]]):
+    parts = []
+    for uid, (t, v) in rows.items():
+        parts.append(_make_long_df(t, v, uid))
+    return pd.concat(parts, ignore_index=True)
+
+
+# ===========================================================================
+# DesignOfExperimentsEvents
+# ===========================================================================
+
+
+class TestDesignOfExperimentsEvents:
+
+    def _build_doe_dataset(self):
+        """Two factors with three steps each, plus a response signal.
+
+        Run layout (3 distinct levels per factor, 4 samples per run):
+
+            run 0:  F1=10, F2=1
+            run 1:  F1=10, F2=2
+            run 2:  F1=20, F2=2
+            run 3:  F1=20, F2=3
+        """
+        per_run = 4
+        n_runs = 4
+        t = pd.date_range("2024-01-01", periods=per_run * n_runs, freq="1min")
+        f1 = np.concatenate([
+            np.full(per_run, 10.0), np.full(per_run, 10.0),
+            np.full(per_run, 20.0), np.full(per_run, 20.0),
+        ])
+        f2 = np.concatenate([
+            np.full(per_run, 1.0), np.full(per_run, 2.0),
+            np.full(per_run, 2.0), np.full(per_run, 3.0),
+        ])
+        # Response = 2*F1 + 5*F2, so F2 has the larger main effect.
+        response = 2.0 * f1 + 5.0 * f2
+
+        df = _make_multi_uuid_df(
+            {
+                "factor:F1": (t, f1),
+                "factor:F2": (t, f2),
+                "response:Y": (t, response),
+            }
+        )
+        return df
+
+    def test_detect_runs_recovers_segment_count(self):
+        df = self._build_doe_dataset()
+        det = DesignOfExperimentsEvents(df, factor_uuids=["factor:F1", "factor:F2"])
+        runs = det.detect_runs(min_duration="2min", stability_tol=0.01)
+        assert len(runs) == 4
+        assert set(runs.columns) >= {
+            "start",
+            "end",
+            "duration_seconds",
+            "uuid",
+            "run_id",
+            "factor__factor:F1_level",
+            "factor__factor:F2_level",
+        }
+        # Each detected run carries the right factor level.
+        f1_levels = runs["factor__factor:F1_level"].tolist()
+        f2_levels = runs["factor__factor:F2_level"].tolist()
+        assert f1_levels == [10.0, 10.0, 20.0, 20.0]
+        assert f2_levels == [1.0, 2.0, 2.0, 3.0]
+
+    def test_compute_effects_ranks_factor_impact(self):
+        df = self._build_doe_dataset()
+        det = DesignOfExperimentsEvents(df, factor_uuids=["factor:F1", "factor:F2"])
+        effects = det.compute_effects(
+            response_uuid="response:Y",
+            statistic="mean",
+            min_duration="2min",
+            stability_tol=0.01,
+        )
+        assert not effects.empty
+        # Factor F2 swings the response by 5 per level, F1 swings 2 per level → F2
+        # should have larger |main_effect| magnitude at its extremes.
+        f1_eff = effects[effects["factor"] == "factor:F1"]["main_effect"].abs().max()
+        f2_eff = effects[effects["factor"] == "factor:F2"]["main_effect"].abs().max()
+        assert f2_eff > f1_eff
+
+    def test_empty_factors_raises(self):
+        with pytest.raises(ValueError):
+            DesignOfExperimentsEvents(pd.DataFrame(), factor_uuids=[])
+
+
+# ===========================================================================
+# DesignSpaceEvents
+# ===========================================================================
+
+
+class TestDesignSpaceEvents:
+
+    def _qualification_df(self):
+        """100 samples inside an axis-aligned box: temp in [60, 80], pH in [6.8, 7.2]."""
+        np.random.seed(0)
+        n = 100
+        t = pd.date_range("2024-01-01", periods=n, freq="1min")
+        temp = np.random.uniform(60.0, 80.0, n)
+        ph = np.random.uniform(6.8, 7.2, n)
+        return _make_multi_uuid_df({"cpp:temp": (t, temp), "cpp:ph": (t, ph)})
+
+    def test_fit_box_then_detect_excursions(self):
+        qual = self._qualification_df()
+        det = DesignSpaceEvents(qual, cpp_uuids=["cpp:temp", "cpp:ph"])
+        det.fit_box(quantiles=(0.0, 1.0))
+
+        # Operation: 30 samples inside, 10 samples outside (temp = 90).
+        t_op = pd.date_range("2024-02-01", periods=40, freq="1min")
+        temp = np.concatenate([np.full(30, 70.0), np.full(10, 90.0)])
+        ph = np.full(40, 7.0)
+        op = _make_multi_uuid_df({"cpp:temp": (t_op, temp), "cpp:ph": (t_op, ph)})
+
+        excursions = det.detect_excursions(op)
+        assert len(excursions) == 1
+        assert excursions["excursion_mode"].iloc[0] == "box"
+        assert excursions["duration_seconds"].iloc[0] > 0
+
+    def test_boundary_proximity_flags_near_boundary(self):
+        qual = self._qualification_df()
+        det = DesignSpaceEvents(qual, cpp_uuids=["cpp:temp", "cpp:ph"])
+        det.fit_box(quantiles=(0.0, 1.0))
+
+        # 5 samples comfortably inside, 5 samples almost at the upper temp bound.
+        t_op = pd.date_range("2024-02-01", periods=10, freq="1min")
+        temp = np.concatenate([np.full(5, 70.0), np.full(5, 79.5)])
+        ph = np.full(10, 7.0)
+        op = _make_multi_uuid_df({"cpp:temp": (t_op, temp), "cpp:ph": (t_op, ph)})
+
+        near = det.boundary_proximity(op, warn_margin=0.1)
+        assert not near.empty
+        assert (near["closest_axis"] == "cpp:temp").all()
+
+    def test_fit_hull_then_detect_excursions(self):
+        qual = self._qualification_df()
+        det = DesignSpaceEvents(qual, cpp_uuids=["cpp:temp", "cpp:ph"])
+        det.fit_hull()
+
+        # Sample far outside the hull on both axes.
+        t_op = pd.date_range("2024-02-01", periods=5, freq="1min")
+        temp = np.full(5, 200.0)
+        ph = np.full(5, 4.0)
+        op = _make_multi_uuid_df({"cpp:temp": (t_op, temp), "cpp:ph": (t_op, ph)})
+
+        excursions = det.detect_excursions(op)
+        assert len(excursions) == 1
+        assert excursions["excursion_mode"].iloc[0] == "hull"
+
+    def test_too_few_cpps_raises(self):
+        with pytest.raises(ValueError):
+            DesignSpaceEvents(pd.DataFrame(), cpp_uuids=["only:one"])
+
+    def test_detect_excursions_before_fit_raises(self):
+        qual = self._qualification_df()
+        det = DesignSpaceEvents(qual, cpp_uuids=["cpp:temp", "cpp:ph"])
+        with pytest.raises(RuntimeError):
+            det.detect_excursions(qual)
+
+
+# ===========================================================================
+# GoldenBatchDeviationEvents
+# ===========================================================================
+
+
+class TestGoldenBatchDeviationEvents:
+
+    def _golden_trace(self, n=128):
+        t = pd.date_range("2024-01-01", periods=n, freq="1min")
+        # Smooth ramp-then-plateau.
+        v = np.concatenate([np.linspace(20.0, 80.0, n // 2), np.full(n - n // 2, 80.0)])
+        return _make_long_df(t, v, "sig:temp")
+
+    def test_compare_pointwise_zero_when_identical(self):
+        ref = self._golden_trace()
+        det = GoldenBatchDeviationEvents(ref, signal_uuid="sig:temp", n_resample=64)
+        out = det.compare(ref, mode="pointwise")
+        assert len(out) == 1
+        assert out["mode"].iloc[0] == "pointwise"
+        assert out["deviation_score"].iloc[0] == pytest.approx(0.0, abs=1e-9)
+        assert out["max_abs_residual"].iloc[0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_compare_pointwise_detects_offset(self):
+        ref = self._golden_trace()
+        det = GoldenBatchDeviationEvents(ref, signal_uuid="sig:temp", n_resample=64)
+
+        # Candidate batch is the golden trace shifted up by 5.
+        t = pd.date_range("2024-02-01", periods=128, freq="1min")
+        v = (
+            np.concatenate([np.linspace(20.0, 80.0, 64), np.full(64, 80.0)]) + 5.0
+        )
+        cand = _make_long_df(t, v, "sig:temp")
+
+        out = det.compare(cand, mode="pointwise")
+        # Resampling onto the same normalised grid → max_abs_residual is ~5.
+        assert out["max_abs_residual"].iloc[0] == pytest.approx(5.0, abs=0.05)
+
+    def test_compare_area_mode_returns_positive_score_on_deviation(self):
+        ref = self._golden_trace()
+        det = GoldenBatchDeviationEvents(ref, signal_uuid="sig:temp", n_resample=64)
+        t = pd.date_range("2024-02-01", periods=128, freq="1min")
+        v = np.concatenate([np.linspace(20.0, 80.0, 64), np.full(64, 80.0)]) + 3.0
+        cand = _make_long_df(t, v, "sig:temp")
+        out = det.compare(cand, mode="area")
+        assert out["mode"].iloc[0] == "area"
+        assert out["deviation_score"].iloc[0] > 0
+
+    def test_compare_dtw_mode_shape_distance(self):
+        ref = self._golden_trace()
+        det = GoldenBatchDeviationEvents(ref, signal_uuid="sig:temp", n_resample=32)
+        # Same shape, slower batch (twice as many samples, same min/max).
+        t = pd.date_range("2024-02-01", periods=256, freq="1min")
+        v = np.concatenate([np.linspace(20.0, 80.0, 128), np.full(128, 80.0)])
+        cand = _make_long_df(t, v, "sig:temp")
+        out = det.compare(cand, mode="dtw")
+        assert out["mode"].iloc[0] == "dtw"
+        # Shape is preserved under time-warping; DTW distance should be small.
+        assert out["deviation_score"].iloc[0] == pytest.approx(0.0, abs=0.5)
+
+    def test_unknown_mode_raises(self):
+        ref = self._golden_trace()
+        det = GoldenBatchDeviationEvents(ref, signal_uuid="sig:temp")
+        with pytest.raises(ValueError):
+            det.compare(ref, mode="not-a-mode")
+
+
+# ===========================================================================
+# RecipePhaseAdherenceEvents
+# ===========================================================================
+
+
+class TestRecipePhaseAdherenceEvents:
+
+    def _phase_and_value_df(self):
+        # Three phases: heat_up (10 min, 20→80°C), hold (15 min @ 80°C),
+        # cool_down (10 min, 80→25°C).
+        t_heat = pd.date_range("2024-01-01 00:00", periods=10, freq="1min")
+        t_hold = pd.date_range("2024-01-01 00:10", periods=15, freq="1min")
+        t_cool = pd.date_range("2024-01-01 00:25", periods=10, freq="1min")
+        t_all = t_heat.append([t_hold, t_cool])
+
+        v_heat = np.linspace(20.0, 80.0, 10)
+        v_hold = np.full(15, 80.0)
+        v_cool = np.linspace(80.0, 25.0, 10)
+        v_all = np.concatenate([v_heat, v_hold, v_cool])
+
+        # Build the phase signal in long form with value_string.
+        phase_names = ["heat_up"] * 10 + ["hold"] * 15 + ["cool_down"] * 10
+        phase_df = pd.DataFrame(
+            {
+                "systime": t_all,
+                "uuid": ["phase:reactor"] * len(t_all),
+                "value_string": phase_names,
+                "value_double": [float("nan")] * len(t_all),
+            }
+        )
+        value_df = pd.DataFrame(
+            {
+                "systime": t_all,
+                "uuid": ["temp:reactor"] * len(t_all),
+                "value_double": v_all,
+                "value_string": [None] * len(t_all),
+            }
+        )
+        return pd.concat([phase_df, value_df], ignore_index=True)
+
+    def test_evaluate_all_pass(self):
+        df = self._phase_and_value_df()
+        spec = {
+            "heat_up": {"ramp_rate_max": 5.0},  # actual ramp ≈ 0.1°C/s
+            "hold": {"hold_value": (78.0, 82.0)},
+            "cool_down": {"trough_value": (20.0, 30.0)},
+        }
+        det = RecipePhaseAdherenceEvents(
+            df, phase_uuid="phase:reactor", value_uuid="temp:reactor", spec=spec
+        )
+        out = det.evaluate()
+        assert len(out) == 3
+        assert out["pass"].all(), out
+
+    def test_evaluate_flags_hold_value_violation(self):
+        df = self._phase_and_value_df()
+        spec = {"hold": {"hold_value": (60.0, 70.0)}}  # actual hold ≈ 80°C
+        det = RecipePhaseAdherenceEvents(
+            df, phase_uuid="phase:reactor", value_uuid="temp:reactor", spec=spec
+        )
+        out = det.evaluate()
+        hold_row = out[out["phase"] == "hold"].iloc[0]
+        assert hold_row["pass"] is False or hold_row["pass"] is np.False_
+        assert "hold_value" in hold_row["criteria_failed"]
+
+    def test_unconstrained_phase_passes_with_empty_criteria(self):
+        df = self._phase_and_value_df()
+        det = RecipePhaseAdherenceEvents(
+            df, phase_uuid="phase:reactor", value_uuid="temp:reactor", spec={}
+        )
+        out = det.evaluate()
+        # All phases are observed but unconstrained → pass with empty failed list.
+        assert (out["pass"]).all()
+        assert all(len(x) == 0 for x in out["criteria_failed"])
+
+
+# ===========================================================================
+# CriticalParameterRankingEvents
+# ===========================================================================
+
+
+class TestCriticalParameterRankingEvents:
+
+    def _per_run_table(self, n=40):
+        rng = np.random.default_rng(123)
+        x_strong = rng.normal(size=n)
+        x_weak = rng.normal(size=n)
+        noise = rng.normal(scale=0.5, size=n)
+        outcome = 3.0 * x_strong + 0.1 * x_weak + noise
+        return pd.DataFrame(
+            {"strong": x_strong, "weak": x_weak, "yield": outcome}
+        )
+
+    def test_rank_orders_strong_first_with_pearson(self):
+        runs = self._per_run_table()
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        out = det.rank(
+            runs, candidate_columns=["strong", "weak"], outcome_column="yield", method="pearson"
+        )
+        assert list(out["parameter"])[0] == "strong"
+        assert out.iloc[0]["abs_effect_size"] > out.iloc[1]["abs_effect_size"]
+
+    def test_rank_supports_spearman(self):
+        runs = self._per_run_table()
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        out = det.rank(
+            runs,
+            candidate_columns=["strong", "weak"],
+            outcome_column="yield",
+            method="spearman",
+        )
+        assert list(out["parameter"])[0] == "strong"
+
+    def test_rank_supports_anova_f(self):
+        # Distinct groups: outcome jumps by group label.
+        runs = pd.DataFrame(
+            {
+                "x": [0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2],
+                "noise": np.random.default_rng(0).normal(size=12),
+                "yield": [10, 10.2, 9.8, 20, 19.7, 20.3, 30, 30.2, 29.8, 40, 40.1, 39.9],
+            }
+        )
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        out = det.rank(
+            runs,
+            candidate_columns=["x", "noise"],
+            outcome_column="yield",
+            method="anova_f",
+            anova_bins=4,
+        )
+        assert list(out["parameter"])[0] == "x"
+        assert out.iloc[0]["p_value"] < 0.01
+
+    def test_top_drivers_filters_by_alpha(self):
+        runs = self._per_run_table()
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        out = det.top_drivers(
+            runs,
+            candidate_columns=["strong", "weak"],
+            outcome_column="yield",
+            method="pearson",
+            alpha=1e-6,  # strict — only the strong driver should pass.
+        )
+        assert "weak" not in set(out["parameter"])
+
+    def test_unknown_outcome_column_raises(self):
+        runs = self._per_run_table()
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        with pytest.raises(ValueError):
+            det.rank(
+                runs, candidate_columns=["strong"], outcome_column="not-a-column"
+            )
+
+    def test_unknown_method_raises(self):
+        runs = self._per_run_table()
+        det = CriticalParameterRankingEvents(pd.DataFrame())
+        with pytest.raises(ValueError):
+            det.rank(
+                runs,
+                candidate_columns=["strong"],
+                outcome_column="yield",
+                method="bogus",
+            )


### PR DESCRIPTION
Introduces events/development/ with five detectors targeting activities
that precede commercial production: design of experiments, multivariate
design-space qualification, golden-batch trajectory comparison,
recipe-phase spec compliance, and outcome-driven critical-parameter
ranking. All use pandas/numpy/scipy only, follow the canonical
point/interval/summary/static output schema, and inherit from Base.

- DesignOfExperimentsEvents: recover DOE runs from continuous data and
  estimate per-factor main effects
- DesignSpaceEvents: fit multivariate operating window (box or convex
  hull) and detect commercial-operation excursions
- GoldenBatchDeviationEvents: pointwise / area / pure-numpy DTW deviation
  against a reference batch
- RecipePhaseAdherenceEvents: pass/fail evaluation per phase against a
  declarative spec (duration / hold / ramp / peak / trough)
- CriticalParameterRankingEvents: rank candidate CPPs by Pearson,
  Spearman, or one-way ANOVA F-statistic vs. a quality outcome

Wires the new pack into _LAZY, eventlog taxonomy/archetypes, lambda-rule
spec, and README, and extends the manufacturing-operations research doc
with a dedicated chapter. Adds 22 unit tests covering the five
detectors; full suite stays green at 913 passed.

https://claude.ai/code/session_01L1iU26nHkJgw4jKmCkpkpb