### PR TITLE
feat(eventlog): trim empty extra columns, add align_columns, rename exporters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,19 @@
+# June 2, 2026
+changed: event-log output now trims entirely-empty extra columns. The 9
+  canonical core columns (ocel:eid, ocel:activity, ocel:timestamp,
+  ts_shape:start_timestamp, ts_shape:duration_s, ts_shape:detector,
+  ts_shape:pack, ts_shape:severity, ts_shape:value) are always emitted, so
+  every event log keeps an identical append-friendly core schema; per-detector
+  extras (<pack>:<col> passthroughs, standard-attr extensions) are dropped when
+  all-empty instead of shipped full of NaN.
+add: align_columns(*logs) -- reindex multiple EventLogs' events tables to their
+  shared column union (core first, extras sorted) so each frame exposes an
+  identical column set before appending/stacking. concat(...) already unions
+  columns on merge; this is for callers stacking frames themselves.
+changed: event-log exporters renamed for a consistent to_event_log* family:
+  to_flat_df -> to_event_log_xes, to_ocel_tables -> to_event_log_ocel. The old
+  names remain as deprecated aliases (DeprecationWarning) for back-compat.
+
 # May 20, 2026
 add: Pipeline -- the single declarative orchestrator for ts-shape. Chains
   transform and detector steps into one reusable definition: .transform()

--- a/docs/examples/eventlog.md
+++ b/docs/examples/eventlog.md
@@ -4,7 +4,7 @@ Demonstrates the canonical OCEL 2.0 / XES-shaped event log produced by the `ts_s
 
 **Run it:** `python examples/eventlog_demo.py`
 
-**Modules demonstrated:** `to_event_log`, `concat`, `to_flat_df`, `to_ocel_tables`, `MachineStateEvents`, `OutlierDetectionEvents`
+**Modules demonstrated:** `to_event_log`, `concat`, `to_event_log_xes`, `to_event_log_ocel`, `MachineStateEvents`, `OutlierDetectionEvents`
 
 **Related guides:** [Event Log: pm4py-shaped output for process mining](../guides/eventlog.md)
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -27,4 +27,4 @@ Runnable demo scripts covering every ts-shape module. Each example generates syn
 | [Cycle Extractor](cycle-extractor.md) | `CycleExtractor` (6 detection methods) | `python examples/cycle_extractor_enhancements_demo.py` |
 | [Context Enricher](context-enricher.md) | `ContextEnricher`, `ValueMapping` | `python examples/context_enricher_demo.py` |
 | [Statistics (Basic)](statistics-basic.md) | `NumericStatistics`, `StringStatistics`, `BooleanStatistics` | `python examples/statistics_demo.py` |
-| [Event Log (XES & OCEL)](eventlog.md) | `to_event_log`, `concat`, `to_flat_df`, `to_ocel_tables` | `python examples/eventlog_demo.py` |
+| [Event Log (XES & OCEL)](eventlog.md) | `to_event_log`, `concat`, `to_event_log_xes`, `to_event_log_ocel` | `python examples/eventlog_demo.py` |

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -100,12 +100,12 @@ intervals = MachineStateEvents(df, run_state_uuid="machine_run_state") \
 
 ```python
 from ts_shape.events.production.machine_state import MachineStateEvents
-from ts_shape.eventlog import to_event_log, to_ocel_tables
+from ts_shape.eventlog import to_event_log, to_event_log_ocel
 
 intervals = MachineStateEvents(df, run_state_uuid="machine_run_state") \
     .detect_run_idle()
 log = to_event_log(intervals, detector="MachineStateEvents.detect_run_idle")
-events_df, objects_df, relations_df = to_ocel_tables(log)
+events_df, objects_df, relations_df = to_event_log_ocel(log)
 ```
 
 ## Cross-cutting modules

--- a/docs/guides/eventlog.md
+++ b/docs/guides/eventlog.md
@@ -14,8 +14,8 @@ flowchart LR
     LD2["Detector B<br/><i>legacy DataFrame</i>"]
     NORM["to_event_log(...)<br/><i>shape-driven adapter</i>"]
     LOG["EventLog<br/><i>events / objects / relations</i>"]
-    XES["to_flat_df(...)<br/><i>XES style</i>"]
-    OCEL["to_ocel_tables(...)<br/><i>OCEL 2.0 style</i>"]
+    XES["to_event_log_xes(...)<br/><i>XES style</i>"]
+    OCEL["to_event_log_ocel(...)<br/><i>OCEL 2.0 style</i>"]
 
     LD1 --> NORM --> LOG
     LD2 --> NORM
@@ -28,7 +28,7 @@ flowchart LR
 
 - One adapter layer normalizes **all 290+** public DataFrame-returning detector methods into the same schema. User-authored detectors via the [Lambda Rules](lambda-rules.md) subsystem flow through the same adapter without any extra plumbing.
 - The event log keeps OCEL's separation of **events**, **objects**, and **event-to-object relations** — no single "case" is forced.
-- `to_flat_df(case_object_type=...)` defers the case-id question to export time: flatten the same log per asset, per batch, per cycle, etc.
+- `to_event_log_xes(case_object_type=...)` defers the case-id question to export time: flatten the same log per asset, per batch, per cycle, etc.
 
 !!! tip "Need a rule without writing a Python class?"
     The [Lambda Rules guide](lambda-rules.md) walks through declaring detectors in YAML. They register dynamically with the same taxonomy and flow through the same adapter described below.
@@ -52,10 +52,26 @@ An :class:`EventLog` holds three pandas DataFrames.
 | `ts_shape:start_timestamp` | `datetime64[ns, UTC]` | Interval start; `NaT` for point events. |
 | `ts_shape:duration_s` | float | Interval duration in seconds. |
 | `ts_shape:detector` | string | `"ClassName.method_name"` — what produced this event. |
-| `ts_shape:pack` | string | One of: `quality`, `production`, `engineering`, `maintenance`, `supplychain`, `energy`, `correlation`. |
+| `ts_shape:pack` | string | One of: `quality`, `production`, `engineering`, `maintenance`, `supplychain`, `energy`, `correlation`, `development`. |
 | `ts_shape:severity` | string | `info` / `warn` / `critical`, mapped from numeric severity scores. |
 | `ts_shape:value` | float | Primary numeric measurement, when applicable. |
 | `<pack>:<col>` | various | Detector-specific attributes, prefixed with the pack name. |
+
+The **9 canonical core columns** above (`ocel:eid` … `ts_shape:value`) are
+**always present** on every events table, regardless of detector or shape — so
+every event log shares an identical core schema and frames line up when
+appended. Everything beyond them — the [standard-attr extensions](#standard-attribute-extension)
+(`ts_shape:method`, `ts_shape:lifecycle_state`, …) and the `<pack>:<col>`
+passthroughs — is a per-detector **extra**, emitted only when it actually
+carries a value. An all-empty extra column is dropped rather than shipped full
+of `NaN`, so different detectors produce different *extra* columns.
+
+To append per-detector logs, use `concat(...)`, which unions columns across
+inputs and fills gaps with `NaN` (so appending never fails). If you need every
+*individual* frame to expose the identical full column set **before** appending
+or stacking them yourself, call `align_columns(*logs)` — it reindexes each
+log's events table to the shared union (core first, extras sorted), leaving
+`objects` / `relations` untouched.
 
 ### Objects
 
@@ -160,6 +176,10 @@ shape live in `src/ts_shape/eventlog/adapters.py` (function `adapt`).
     - **Prefix attributes**: every legacy column not consumed above is
       added as `<pack>:<col>` so it's namespaced and never clashes with
       OCEL/XES columns.
+    - **Trim empty extras**: any non-core column (a `<pack>:<col>`
+      passthrough or a standard-attr extension) that is entirely empty is
+      dropped — only the 9 canonical core columns are kept unconditionally,
+      preserving a stable append-friendly schema.
     - **Auto-extract objects**: for each type in `rule.produces_objects`,
       look for the standard binding column (today: `source_uuid → asset`)
       and create relations. Merge in caller-supplied `objects=` (any
@@ -312,7 +332,7 @@ Severity is **never** a templated segment — it lives in
 | `ocel:` | OCEL 2.0 spec | `ocel:eid`, `ocel:activity`, `ocel:timestamp`, `ocel:oid`, `ocel:type`, `ocel:qualifier` |
 | `ts_shape:` | ts-shape canonical fields with no OCEL counterpart | `ts_shape:start_timestamp`, `ts_shape:duration_s`, `ts_shape:detector`, `ts_shape:pack`, `ts_shape:severity`, `ts_shape:value` |
 | `<pack>:` | Detector-specific legacy columns | `production:state`, `quality:rule_violated`, `engineering:overshoot`, `maintenance:health_score` |
-| `concept:`, `time:`, `case:`, `lifecycle:`, `org:` | XES spec — added only by `to_flat_df` | `concept:name`, `time:timestamp`, `case:concept:name`, `lifecycle:transition`, `org:resource` |
+| `concept:`, `time:`, `case:`, `lifecycle:`, `org:` | XES spec — added only by `to_event_log_xes` | `concept:name`, `time:timestamp`, `case:concept:name`, `lifecycle:transition`, `org:resource` |
 
 The pack prefix prevents any clash between detectors (e.g. two packs
 that both use a `state` column become `production:state` and
@@ -527,7 +547,7 @@ to_event_log(
 )
 ```
 
-If a method has no natural object association at all (e.g. a global cross-signal correlation statistic), the adapter declares `produces_objects = ()` and the resulting `EventLog` has empty `objects` and `relations` tables. Calling `to_flat_df(...)` on such a log raises a clear error rather than fabricating object ids.
+If a method has no natural object association at all (e.g. a global cross-signal correlation statistic), the adapter declares `produces_objects = ()` and the resulting `EventLog` has empty `objects` and `relations` tables. Calling `to_event_log_xes(...)` on such a log raises a clear error rather than fabricating object ids.
 
 ---
 
@@ -536,7 +556,7 @@ If a method has no natural object association at all (e.g. a global cross-signal
 ```python
 from ts_shape.events.production.machine_state import MachineStateEvents
 from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
-from ts_shape.eventlog import to_event_log, concat, to_flat_df, to_ocel_tables
+from ts_shape.eventlog import to_event_log, concat, to_event_log_xes, to_event_log_ocel
 
 # 1. Run two detectors on the same input.
 state_legacy = MachineStateEvents(df, run_state_uuid="asset-A").detect_run_idle()
@@ -554,11 +574,11 @@ outlier_log = to_event_log(
 log = concat(state_log, outlier_log)
 
 # 4a. Flatten for XES tools (pm4py, Disco, Celonis).
-xes_df = to_flat_df(log, case_object_type="asset")
+xes_df = to_event_log_xes(log, case_object_type="asset")
 # Now xes_df has case:concept:name / concept:name / time:timestamp columns.
 
 # 4b. Or hand the OCEL tables to pm4py directly.
-events_df, objects_df, relations_df = to_ocel_tables(log)
+events_df, objects_df, relations_df = to_event_log_ocel(log)
 # import pm4py; pm4py.write_ocel2_json(...)
 ```
 
@@ -572,8 +592,8 @@ OCEL events have a single timestamp; XES traces care about start/complete pairs.
 - `lifecycle="two_row"`: expands intervals into a `start` row + `complete` row, paired by `concept:instance` for strict XES-compliance.
 
 ```python
-xes_complete_only = to_flat_df(log, case_object_type="asset", lifecycle="single")
-xes_with_starts = to_flat_df(log, case_object_type="asset", lifecycle="two_row")
+xes_complete_only = to_event_log_xes(log, case_object_type="asset", lifecycle="single")
+xes_with_starts = to_event_log_xes(log, case_object_type="asset", lifecycle="two_row")
 ```
 
 ---

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -175,7 +175,7 @@ Pick the stage that matches where you are in your analysis.
 
     Normalize any detector's output into a canonical event log with OCEL 2.0 / XES column names. Concatenate logs across detectors, then export per-asset / per-batch / per-cycle traces for pm4py, Disco, or Celonis.
 
-    `to_event_log` | `concat` | `to_flat_df` | `to_ocel_tables`
+    `to_event_log` | `concat` | `to_event_log_xes` | `to_event_log_ocel`
 
 </div>
 

--- a/examples/eventlog_demo.py
+++ b/examples/eventlog_demo.py
@@ -33,8 +33,8 @@ from ts_shape.eventlog import (
     concat,
     register_adapter,
     to_event_log,
-    to_flat_df,
-    to_ocel_tables,
+    to_event_log_ocel,
+    to_event_log_xes,
 )
 from ts_shape.eventlog import schema as S
 from ts_shape.eventlog import taxonomy
@@ -208,7 +208,7 @@ def main() -> None:
     print("=" * 70)
     print("Flat XES export — case = asset")
     print("=" * 70)
-    xes_asset = to_flat_df(log, case_object_type="asset", lifecycle="single")
+    xes_asset = to_event_log_xes(log, case_object_type="asset", lifecycle="single")
     print(xes_asset[
         ["case:concept:name", "concept:name", "time:timestamp",
          "lifecycle:transition"]
@@ -218,7 +218,7 @@ def main() -> None:
     print("=" * 70)
     print("Flat XES export — case = batch (only outlier events have batches)")
     print("=" * 70)
-    xes_batch = to_flat_df(log, case_object_type="batch")
+    xes_batch = to_event_log_xes(log, case_object_type="batch")
     print(xes_batch[
         ["case:concept:name", "concept:name", "time:timestamp"]
     ].to_string(index=False))
@@ -295,7 +295,7 @@ def main() -> None:
     # 4. OCEL 2.0 export (column names match the spec verbatim)
     # ---------------------------------------------------------------------
 
-    events_df, objects_df, relations_df = to_ocel_tables(log)
+    events_df, objects_df, relations_df = to_event_log_ocel(log)
     print("=" * 70)
     print("OCEL 2.0 tables")
     print("=" * 70)

--- a/examples/lambda_rules_demo.py
+++ b/examples/lambda_rules_demo.py
@@ -31,8 +31,8 @@ from ts_shape.eventlog import (
     concat,
     load_yaml,
     run_backtest,
-    to_flat_df,
-    to_ocel_tables,
+    to_event_log_ocel,
+    to_event_log_xes,
     unregister_lambda_rule,
 )
 
@@ -123,7 +123,7 @@ def main() -> None:
         # -----------------------------------------------------------------
         # 3. XES and OCEL 2.0 round-trip.
         # -----------------------------------------------------------------
-        xes = to_flat_df(log, case_object_type="asset")
+        xes = to_event_log_xes(log, case_object_type="asset")
         print("=" * 70)
         print("Flat XES export — case = asset (first 10 rows)")
         print("=" * 70)
@@ -132,7 +132,7 @@ def main() -> None:
         ].head(10).to_string(index=False))
         print()
 
-        events_df, objects_df, relations_df = to_ocel_tables(log)
+        events_df, objects_df, relations_df = to_event_log_ocel(log)
         print("=" * 70)
         print("OCEL 2.0 tables")
         print("=" * 70)

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -137,6 +137,7 @@ _LAZY: dict[str, str] = {
 _EVENTLOG_NAMES = (
     "BacktestResult",
     "EventLog",
+    "align_columns",
     "LabelRule",
     "LambdaDetector",
     "REGISTRY",
@@ -152,6 +153,8 @@ _EVENTLOG_NAMES = (
     "register_object_type",
     "run_backtest",
     "to_event_log",
+    "to_event_log_ocel",
+    "to_event_log_xes",
     "to_flat_df",
     "to_ocel_tables",
     "unregister_lambda_rule",

--- a/src/ts_shape/eventlog/__init__.py
+++ b/src/ts_shape/eventlog/__init__.py
@@ -7,7 +7,9 @@ pm4py / Disco / Celonis / OCEL viewers directly.
 
 Typical use::
 
-    from ts_shape.eventlog import to_event_log, concat, to_flat_df, to_ocel_tables
+    from ts_shape.eventlog import (
+        to_event_log, concat, to_event_log_xes, to_event_log_ocel,
+    )
     from ts_shape.events.production.machine_state import MachineStateEvents
     from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
 
@@ -20,13 +22,14 @@ Typical use::
         detector="OutlierDetectionEvents.detect_outliers_zscore",
     )
     log = concat(state_log, outlier_log)
-    xes_df = to_flat_df(log, case_object_type="asset")
-    events_df, objects_df, relations_df = to_ocel_tables(log)
+    xes_df = to_event_log_xes(log, case_object_type="asset")
+    events_df, objects_df, relations_df = to_event_log_ocel(log)
 """
 
 from .adapters import register_adapter
+from .align import align_columns
 from .concat import concat
-from .flat import to_flat_df
+from .flat import to_event_log_xes, to_flat_df
 from .lambda_rules import (
     BacktestResult,
     LambdaDetector,
@@ -42,7 +45,7 @@ from .lambda_rules import (
 )
 from .model import EventLog
 from .normalizer import to_event_log
-from .ocel import to_ocel_tables
+from .ocel import to_event_log_ocel, to_ocel_tables
 from .schema import (
     OCEL_ACTIVITY,
     OCEL_EID,
@@ -69,6 +72,7 @@ from .taxonomy import REGISTRY, LabelRule
 __all__ = [
     "BacktestResult",
     "EventLog",
+    "align_columns",
     "LabelRule",
     "LambdaDetector",
     "REGISTRY",
@@ -84,6 +88,8 @@ __all__ = [
     "register_object_type",
     "run_backtest",
     "to_event_log",
+    "to_event_log_ocel",
+    "to_event_log_xes",
     "to_flat_df",
     "to_ocel_tables",
     "unregister_lambda_rule",

--- a/src/ts_shape/eventlog/adapters.py
+++ b/src/ts_shape/eventlog/adapters.py
@@ -377,6 +377,21 @@ def adapt(
         }
     )
 
+    # Trim *empty* variable-extra columns. The canonical core
+    # (EVENT_REQUIRED_COLUMNS ∪ EVENT_OPTIONAL_COLUMNS) is always retained so
+    # every event log exposes an identical core schema — this keeps appends /
+    # ``concat`` consistent and ``schema.validate`` / ``filter_by_pack``
+    # working. Standard-attr extensions and ``<pack>:<col>`` passthroughs are
+    # per-detector extras; an all-null one carries no information, so drop it.
+    keep_always = set(schema.EVENT_REQUIRED_COLUMNS) | set(
+        schema.EVENT_OPTIONAL_COLUMNS
+    )
+    drop_empty = [
+        c for c in events.columns if c not in keep_always and events[c].isna().all()
+    ]
+    if drop_empty:
+        events = events.drop(columns=drop_empty)
+
     object_bindings = _resolve_objects(legacy, rule, objects)
     objects_df, relations_df = _to_relations(eids, object_bindings, qualifiers)
 

--- a/src/ts_shape/eventlog/align.py
+++ b/src/ts_shape/eventlog/align.py
@@ -1,0 +1,65 @@
+"""Align the ``events`` tables of multiple :class:`EventLog` instances to a
+shared column set.
+
+Different detectors emit the same 9-column canonical core but different
+*extra* columns (standard-attr extensions, ``<pack>:<col>`` passthroughs).
+:func:`concat` already unions columns on merge, but when callers want to
+append / stack the per-detector frames themselves they need every frame to
+expose an identical column set first. :func:`align_columns` provides that.
+"""
+
+from __future__ import annotations
+
+from . import schema
+from .model import EventLog
+
+# Canonical emit order of the core columns (mirrors ``adapters.adapt``).
+_CORE_ORDER: tuple[str, ...] = (
+    schema.OCEL_EID,
+    schema.OCEL_ACTIVITY,
+    schema.OCEL_TIMESTAMP,
+    schema.TS_START_TIMESTAMP,
+    schema.TS_DURATION_S,
+    schema.TS_DETECTOR,
+    schema.TS_PACK,
+    schema.TS_SEVERITY,
+    schema.TS_VALUE,
+)
+_CORE_SET = frozenset(_CORE_ORDER)
+
+
+def align_columns(*logs: EventLog) -> list[EventLog]:
+    """Reindex every log's ``events`` table to the union of their columns.
+
+    Each returned :class:`EventLog` exposes an identical, identically-ordered
+    set of event columns — the canonical core first (in emit order), then the
+    remaining attribute columns sorted for determinism. Columns absent from a
+    given log are added and filled with NA, so the frames can be appended or
+    stacked directly without a column mismatch. ``objects`` and ``relations``
+    already have fixed schemas and are returned unchanged.
+
+    Returns a list parallel to the inputs. An empty call returns ``[]``.
+    """
+    if not logs:
+        return []
+
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for log in logs:
+        for col in log.events.columns:
+            if col not in seen_set:
+                seen.append(col)
+                seen_set.add(col)
+
+    core = [c for c in _CORE_ORDER if c in seen_set]
+    extras = sorted(c for c in seen if c not in _CORE_SET)
+    union = core + extras
+
+    return [
+        EventLog(
+            events=log.events.reindex(columns=union),
+            objects=log.objects,
+            relations=log.relations,
+        )
+        for log in logs
+    ]

--- a/src/ts_shape/eventlog/flat.py
+++ b/src/ts_shape/eventlog/flat.py
@@ -6,13 +6,15 @@ pass this DataFrame to ``pm4py.format_dataframe`` themselves.
 
 from __future__ import annotations
 
+import warnings
+
 import pandas as pd
 
 from . import schema
 from .model import EventLog
 
 
-def to_flat_df(
+def to_event_log_xes(
     eventlog: EventLog,
     *,
     case_object_type: str = "asset",
@@ -33,8 +35,8 @@ def to_flat_df(
     """
     if not eventlog.has_objects:
         raise ValueError(
-            "to_flat_df requires objects: this event log was produced by a "
-            "detector with no object association. Use to_ocel_tables() or "
+            "to_event_log_xes requires objects: this event log was produced by "
+            "a detector with no object association. Use to_event_log_ocel() or "
             "supply objects to the adapter."
         )
     if lifecycle not in ("single", "two_row"):
@@ -90,3 +92,13 @@ def _arrange_columns(df: pd.DataFrame) -> pd.DataFrame:
     head = [c for c in head if c in df.columns]
     rest = [c for c in df.columns if c not in head]
     return df[head + rest]
+
+
+def to_flat_df(*args, **kwargs) -> pd.DataFrame:
+    """Deprecated alias for :func:`to_event_log_xes`."""
+    warnings.warn(
+        "to_flat_df is deprecated; use to_event_log_xes",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_event_log_xes(*args, **kwargs)

--- a/src/ts_shape/eventlog/lambda_rules/backtest.py
+++ b/src/ts_shape/eventlog/lambda_rules/backtest.py
@@ -4,7 +4,7 @@ The first-slice MVP supports "run rule, count hits" only — no
 label-matching, no precision/recall. The returned
 :class:`BacktestResult` still carries the full :class:`EventLog` so the
 caller can inspect any individual hit and run their own downstream
-analysis (e.g. ``to_flat_df`` for pm4py, ``filter_by_pack`` for
+analysis (e.g. ``to_event_log_xes`` for pm4py, ``filter_by_pack`` for
 domain-specific drill-down).
 """
 

--- a/src/ts_shape/eventlog/model.py
+++ b/src/ts_shape/eventlog/model.py
@@ -15,7 +15,7 @@ class EventLog:
 
     Objects/relations are empty when the source detector has no natural object
     association (e.g. a global cross-signal correlation statistic). Use
-    :attr:`has_objects` to check before calling :meth:`to_flat_df`.
+    :attr:`has_objects` to check before calling :func:`to_event_log_xes`.
     """
 
     events: pd.DataFrame = field(default_factory=schema.empty_events)

--- a/src/ts_shape/eventlog/ocel.py
+++ b/src/ts_shape/eventlog/ocel.py
@@ -7,12 +7,14 @@ The column names match the OCEL 2.0 spec verbatim.
 
 from __future__ import annotations
 
+import warnings
+
 import pandas as pd
 
 from .model import EventLog
 
 
-def to_ocel_tables(
+def to_event_log_ocel(
     eventlog: EventLog,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Return ``(events, objects, relations)`` DataFrames as-is.
@@ -25,3 +27,15 @@ def to_ocel_tables(
         eventlog.objects.copy(),
         eventlog.relations.copy(),
     )
+
+
+def to_ocel_tables(
+    eventlog: EventLog,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Deprecated alias for :func:`to_event_log_ocel`."""
+    warnings.warn(
+        "to_ocel_tables is deprecated; use to_event_log_ocel",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_event_log_ocel(eventlog)

--- a/tests/eventlog/test_align.py
+++ b/tests/eventlog/test_align.py
@@ -1,0 +1,94 @@
+"""Tests for align_columns — making per-detector event frames share a schema."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ts_shape.eventlog import (
+    align_columns,
+    concat,
+    to_event_log,
+)
+from ts_shape.eventlog.schema import EVENT_OPTIONAL_COLUMNS, EVENT_REQUIRED_COLUMNS
+from ts_shape.events.production.machine_state import MachineStateEvents
+from ts_shape.events.quality.outlier_detection import OutlierDetectionEvents
+
+_CORE = set(EVENT_REQUIRED_COLUMNS) | set(EVENT_OPTIONAL_COLUMNS)
+
+
+def _interval_log():
+    df = pd.DataFrame(
+        {
+            "systime": pd.date_range("2026-05-07", periods=12, freq="30s", tz="UTC"),
+            "value_bool": [True] * 3 + [False] * 3 + [True] * 3 + [False] * 3,
+            "uuid": ["A"] * 12,
+            "source_uuid": ["A"] * 12,
+        }
+    )
+    return to_event_log(
+        MachineStateEvents(df, run_state_uuid="A").detect_run_idle(),
+        detector="MachineStateEvents.detect_run_idle",
+    )
+
+
+def _point_log():
+    df = pd.DataFrame(
+        {
+            "systime": pd.date_range("2026-05-07", periods=12, freq="1min", tz="UTC"),
+            "value_double": [1.0] * 5 + [50.0] + [1.0] * 5 + [-30.0],
+            "uuid": ["A"] * 12,
+            "source_uuid": ["A"] * 12,
+        }
+    )
+    return to_event_log(
+        OutlierDetectionEvents(
+            df, value_column="value_double"
+        ).detect_outliers_zscore(),
+        detector="OutlierDetectionEvents.detect_outliers_zscore",
+    )
+
+
+def test_align_columns_makes_frames_identical():
+    a, b = _interval_log(), _point_log()
+    # Precondition: the raw frames differ in total column count.
+    assert list(a.events.columns) != list(b.events.columns)
+
+    aligned = align_columns(a, b)
+    cols = [list(log.events.columns) for log in aligned]
+    # Every aligned frame has the exact same columns, in the same order.
+    assert cols[0] == cols[1]
+    # The union preserves every original column.
+    assert set(cols[0]) == set(a.events.columns) | set(b.events.columns)
+
+
+def test_align_columns_core_leads_in_canonical_order():
+    aligned = align_columns(_point_log(), _interval_log())
+    leading = list(aligned[0].events.columns)[: len(_CORE)]
+    assert set(leading) == _CORE
+    # Core block comes before any extra column.
+    rest = list(aligned[0].events.columns)[len(_CORE) :]
+    assert not (set(rest) & _CORE)
+
+
+def test_align_columns_preserves_rows_and_values():
+    a, b = _interval_log(), _point_log()
+    aligned = align_columns(a, b)
+    assert len(aligned[0].events) == len(a.events)
+    assert len(aligned[1].events) == len(b.events)
+    # Columns the point log never had are filled with NA (no spurious values).
+    extra = "ts_shape:lifecycle_state"
+    if extra in aligned[1].events.columns:
+        assert aligned[1].events[extra].isna().all()
+
+
+def test_align_columns_appendable_with_plain_concat():
+    aligned = align_columns(_interval_log(), _point_log())
+    stacked = pd.concat([log.events for log in aligned], ignore_index=True)
+    assert len(stacked) == sum(len(log.events) for log in aligned)
+    # Matches what eventlog.concat produces, column-set-wise.
+    merged = concat(_interval_log(), _point_log())
+    assert set(stacked.columns) == set(merged.events.columns)
+
+
+def test_align_columns_empty_call():
+    assert align_columns() == []

--- a/tests/eventlog/test_flat_and_ocel.py
+++ b/tests/eventlog/test_flat_and_ocel.py
@@ -1,4 +1,4 @@
-"""Tests for to_flat_df (XES-style) and to_ocel_tables exporters."""
+"""Tests for to_event_log_xes (XES-style) and to_event_log_ocel exporters."""
 
 from __future__ import annotations
 
@@ -13,6 +13,8 @@ from ts_shape.eventlog import (
     XES_TIMESTAMP,
     concat,
     to_event_log,
+    to_event_log_ocel,
+    to_event_log_xes,
     to_flat_df,
     to_ocel_tables,
 )
@@ -63,8 +65,8 @@ def small_log():
     return concat(state_log, out_log)
 
 
-def test_to_flat_df_single_lifecycle(small_log):
-    flat = to_flat_df(small_log, case_object_type="asset", lifecycle="single")
+def test_to_event_log_xes_single_lifecycle(small_log):
+    flat = to_event_log_xes(small_log, case_object_type="asset", lifecycle="single")
     assert {XES_CASE, XES_ACTIVITY, XES_TIMESTAMP, XES_LIFECYCLE}.issubset(flat.columns)
     assert (flat[XES_CASE] == "asset-A").all()
     assert (flat[XES_LIFECYCLE] == "complete").all()
@@ -73,35 +75,51 @@ def test_to_flat_df_single_lifecycle(small_log):
     assert "quality.outlier.zscore" in activities
 
 
-def test_to_flat_df_two_row_lifecycle(small_log):
-    flat = to_flat_df(small_log, case_object_type="asset", lifecycle="two_row")
+def test_to_event_log_xes_two_row_lifecycle(small_log):
+    flat = to_event_log_xes(small_log, case_object_type="asset", lifecycle="two_row")
     # Interval rows expand to start+complete; point rows stay as one row.
     assert (flat[XES_LIFECYCLE].isin(["start", "complete"])).all()
     # At least one start row exists (for the run/idle intervals).
     assert (flat[XES_LIFECYCLE] == "start").sum() > 0
 
 
-def test_to_flat_df_unknown_object_type_raises(small_log):
+def test_to_event_log_xes_unknown_object_type_raises(small_log):
     with pytest.raises(ValueError, match="no objects of type"):
-        to_flat_df(small_log, case_object_type="batch")
+        to_event_log_xes(small_log, case_object_type="batch")
 
 
-def test_to_flat_df_no_objects_raises():
+def test_to_event_log_xes_no_objects_raises():
     log = EventLog()  # empty, no objects
     with pytest.raises(ValueError, match="requires objects"):
-        to_flat_df(log)
+        to_event_log_xes(log)
 
 
-def test_to_flat_df_invalid_lifecycle(small_log):
+def test_to_event_log_xes_invalid_lifecycle(small_log):
     with pytest.raises(ValueError, match="invalid lifecycle"):
-        to_flat_df(small_log, lifecycle="weird")
+        to_event_log_xes(small_log, lifecycle="weird")
 
 
-def test_to_ocel_tables_returns_three_frames(small_log):
-    events, objects, relations = to_ocel_tables(small_log)
+def test_to_event_log_ocel_returns_three_frames(small_log):
+    events, objects, relations = to_event_log_ocel(small_log)
     assert isinstance(events, pd.DataFrame)
     assert isinstance(objects, pd.DataFrame)
     assert isinstance(relations, pd.DataFrame)
+    assert len(events) == len(small_log.events)
+    assert len(objects) == len(small_log.objects)
+    assert len(relations) == len(small_log.relations)
+
+
+def test_deprecated_to_flat_df_alias(small_log):
+    with pytest.warns(DeprecationWarning, match="to_event_log_xes"):
+        flat = to_flat_df(small_log, case_object_type="asset")
+    # Same result as the new name.
+    expected = to_event_log_xes(small_log, case_object_type="asset")
+    pd.testing.assert_frame_equal(flat, expected)
+
+
+def test_deprecated_to_ocel_tables_alias(small_log):
+    with pytest.warns(DeprecationWarning, match="to_event_log_ocel"):
+        events, objects, relations = to_ocel_tables(small_log)
     assert len(events) == len(small_log.events)
     assert len(objects) == len(small_log.objects)
     assert len(relations) == len(small_log.relations)

--- a/tests/eventlog/test_lambda_rules.py
+++ b/tests/eventlog/test_lambda_rules.py
@@ -30,8 +30,8 @@ from ts_shape.eventlog import (
     register_lambda_rule,
     run_backtest,
     to_event_log,
-    to_flat_df,
-    to_ocel_tables,
+    to_event_log_ocel,
+    to_event_log_xes,
     unregister_lambda_rule,
 )
 from ts_shape.eventlog.archetypes import ARCHETYPE_BY_METHOD
@@ -384,11 +384,11 @@ def test_lambda_log_round_trips_to_flat_and_ocel(torque_df, bearing_df):
         i_det = register_lambda_rule(i_spec)
         log = concat(p_det.to_event_log(torque_df), i_det.to_event_log(bearing_df))
 
-        xes = to_flat_df(log, case_object_type="asset")
+        xes = to_event_log_xes(log, case_object_type="asset")
         assert not xes.empty
         assert "concept:name" in xes.columns
 
-        events_df, objects_df, relations_df = to_ocel_tables(log)
+        events_df, objects_df, relations_df = to_event_log_ocel(log)
         assert len(events_df) == len(log.events)
         assert len(relations_df) == len(log.relations)
     finally:


### PR DESCRIPTION
Trim static/empty output columns:
- adapt() now drops entirely-null non-core columns. The 9 canonical core
  columns (ocel:eid, ocel:activity, ocel:timestamp, ts_shape:start_timestamp,
  ts_shape:duration_s, ts_shape:detector, ts_shape:pack, ts_shape:severity,
  ts_shape:value) are always emitted, so every event log keeps an identical
  append-friendly core schema. Per-detector extras (<pack>:<col> passthroughs
  and standard-attr extensions) are emitted only when non-empty instead of
  shipped full of NaN.

Add align_columns(*logs):
- Reindexes multiple EventLogs' events tables to their shared column union
  (core first, extras sorted) so each individual frame exposes an identical
  column set before appending/stacking. concat() already unions on merge; this
  is for callers stacking frames themselves.

Rename exporters to a consistent to_event_log* family:
- to_flat_df -> to_event_log_xes, to_ocel_tables -> to_event_log_ocel. Old
  names kept as deprecated aliases (DeprecationWarning) for back-compat.

Updates __init__ exports (eventlog + top-level), docstrings, examples, docs,
and CHANGES.txt. Adds tests for align_columns and the deprecated aliases.