### PR TITLE
Add DatabricksUnityCatalogParquetLoader

### DIFF
--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -118,7 +118,7 @@ _LAZY: dict[str, str] = {
     "AzureBlobParquetLoader": "ts_shape.loader.timeseries.azure_blob_loader",
     "AzureBlobFlexibleFileLoader": "ts_shape.loader.timeseries.azure_blob_loader",
     "AzureBlobEnergyLoader": "ts_shape.loader.timeseries.azure_blob_energy_loader",
-    "DatabricksUnityCatalogParquetLoader": "ts_shape.loader.timeseries.databricks_unity_parquet_loader",
+    "DatabricksUnityParquetLoader": "ts_shape.loader.timeseries.databricks_unity_parquet_loader",
     "EnergyAPILoader": "ts_shape.loader.timeseries.energy_api_loader",
     "TimescaleDBDataAccess": "ts_shape.loader.timeseries.timescale_loader",
     "MetadataJsonLoader": "ts_shape.loader.metadata.metadata_json_loader",

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -118,6 +118,7 @@ _LAZY: dict[str, str] = {
     "AzureBlobParquetLoader": "ts_shape.loader.timeseries.azure_blob_loader",
     "AzureBlobFlexibleFileLoader": "ts_shape.loader.timeseries.azure_blob_loader",
     "AzureBlobEnergyLoader": "ts_shape.loader.timeseries.azure_blob_energy_loader",
+    "DatabricksUnityCatalogParquetLoader": "ts_shape.loader.timeseries.databricks_unity_parquet_loader",
     "EnergyAPILoader": "ts_shape.loader.timeseries.energy_api_loader",
     "TimescaleDBDataAccess": "ts_shape.loader.timeseries.timescale_loader",
     "MetadataJsonLoader": "ts_shape.loader.metadata.metadata_json_loader",

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -119,6 +119,7 @@ _LAZY: dict[str, str] = {
     "AzureBlobFlexibleFileLoader": "ts_shape.loader.timeseries.azure_blob_loader",
     "AzureBlobEnergyLoader": "ts_shape.loader.timeseries.azure_blob_energy_loader",
     "DatabricksUnityParquetLoader": "ts_shape.loader.timeseries.databricks_unity_parquet_loader",
+    "DatabricksUnityEnergyLoader": "ts_shape.loader.timeseries.databricks_unity_energy_loader",
     "EnergyAPILoader": "ts_shape.loader.timeseries.energy_api_loader",
     "TimescaleDBDataAccess": "ts_shape.loader.timeseries.timescale_loader",
     "MetadataJsonLoader": "ts_shape.loader.metadata.metadata_json_loader",

--- a/src/ts_shape/loader/timeseries/__init__.py
+++ b/src/ts_shape/loader/timeseries/__init__.py
@@ -41,6 +41,17 @@ Classes:
   - stream_by_time_range: Yield (series_id, DataFrame) incrementally.
   - list_series: List all series IDs available in the blob store.
 
+- DatabricksUnityEnergyLoader: Load CSV energy timeseries + metadata governed by Unity Catalog.
+  Reads the same .meta/series.csv and csv/YYYY/MM/DD/<series_id>.csv files
+  directly from a FUSE-mounted UC Volume, for use inside Databricks
+  notebooks/pipelines -- no download, no SDK, low resource footprint.
+  - load_series_metadata: Read .meta/series.csv as a DataFrame.
+  - load_by_time_range: Load only the day folders between start and end.
+  - load_by_series_ids: Load specific series by ID, optional date filter.
+  - stream_by_time_range: Yield (series_id, DataFrame) incrementally (low memory).
+  - list_series: List all series IDs available in the Volume.
+  - fetch_data_as_dataframe: Combined DataFrame for Pipeline/DataIntegratorHybrid.
+
 - AzureBlobFlexibleFileLoader: Load arbitrary file types from Azure Blob Storage.
   - list_files_by_time_range: List matching files (by extension) under hourly folders.
   - iter_file_names_by_time_range: Generator of names without downloading.

--- a/src/ts_shape/loader/timeseries/__init__.py
+++ b/src/ts_shape/loader/timeseries/__init__.py
@@ -22,6 +22,18 @@ Classes:
   - stream_files_by_time_range_and_uuids: Yield per-UUID frames incrementally.
   - list_structure: List folders and files under a prefix.
 
+- DatabricksUnityCatalogParquetLoader: Load canonical parquet governed by Unity Catalog.
+  Reads the same parquet files directly from a FUSE-mounted UC Volume
+  (/Volumes/<catalog>/<schema>/<volume>/...), for use inside Databricks
+  notebooks/pipelines -- no download, no SDK, low resource footprint.
+  - load_all_files: Load all parquet under the Volume path (optional prefix).
+  - load_by_time_range: Load only the hourly folders between start and end.
+  - stream_by_time_range: Yield (path, DataFrame) incrementally (low memory).
+  - load_files_by_time_range_and_uuids: Load per-hour per-UUID parquet files.
+  - stream_files_by_time_range_and_uuids: Yield per-UUID frames incrementally.
+  - list_structure: List folders and files under the Volume path.
+  - fetch_data_as_dataframe: Combined DataFrame for Pipeline/DataIntegratorHybrid.
+
 - AzureBlobEnergyLoader: Load CSV energy timeseries and series metadata from Azure Blob.
   - load_series_metadata: Download .meta/series.csv as a DataFrame.
   - load_by_time_range: Load CSVs by date range, optional series filter.

--- a/src/ts_shape/loader/timeseries/__init__.py
+++ b/src/ts_shape/loader/timeseries/__init__.py
@@ -22,7 +22,7 @@ Classes:
   - stream_files_by_time_range_and_uuids: Yield per-UUID frames incrementally.
   - list_structure: List folders and files under a prefix.
 
-- DatabricksUnityCatalogParquetLoader: Load canonical parquet governed by Unity Catalog.
+- DatabricksUnityParquetLoader: Load canonical parquet governed by Unity Catalog.
   Reads the same parquet files directly from a FUSE-mounted UC Volume
   (/Volumes/<catalog>/<schema>/<volume>/...), for use inside Databricks
   notebooks/pipelines -- no download, no SDK, low resource footprint.

--- a/src/ts_shape/loader/timeseries/databricks_unity_energy_loader.py
+++ b/src/ts_shape/loader/timeseries/databricks_unity_energy_loader.py
@@ -1,0 +1,388 @@
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Union
+import logging
+import os
+import warnings
+
+import pandas as pd  # type: ignore
+
+from ts_shape.errors import LoaderConfigWarning
+
+logger = logging.getLogger(__name__)
+
+_METADATA_PATH = ".meta/series.csv"
+_CSV_PREFIX = "csv"
+_EMPTY_SCHEMA = ["systime", "uuid", "value_double", "is_delta"]
+_META_COLUMNS = [
+    "id",
+    "label_lvl1",
+    "label_lvl2",
+    "label_lvl3",
+    "label_lvl4",
+    "description",
+    "unit",
+    "hierarchy_lvl1",
+    "hierarchy_lvl2",
+    "hierarchy_lvl3",
+    "hierarchy_lvl4",
+    "hierarchy_lvl5",
+    "hierarchy_lvl6",
+]
+
+
+class DatabricksUnityEnergyLoader:
+    """
+    Load CSV energy timeseries and series metadata governed by **Unity Catalog**.
+
+    Unity Catalog exposes the *same* CSV energy files that already live in your
+    cloud storage (an external UC Volume over, e.g., an Azure blob container).
+    The on-disk layout is unchanged::
+
+        <volume_root>/<prefix>/
+          .meta/
+            series.csv           ← series metadata (tab-separated)
+          csv/
+            YYYY/MM/DD/
+              <series_id>.csv    ← interval readings: time, value columns
+
+    All load methods return the standard ts-shape schema::
+
+        systime | uuid | value_double | is_delta
+
+    where ``uuid`` is the ``series_id`` (stem of the CSV filename), so the frames
+    flow straight into every ts-shape transformation, event detector, ``Pipeline``
+    and ``DataIntegratorHybrid`` without any change.
+
+    **Designed for use inside Databricks notebooks / pipelines.** A UC Volume is
+    FUSE-mounted at ``/Volumes/<catalog>/<schema>/<volume>/...``, so this loader
+    reads CSV *directly from that mounted path* with ``pandas.read_csv`` and keeps
+    the resource footprint low:
+
+    - **No download step and no ``databricks-sdk`` / network client** -- the
+      mounted Volume is read like a local directory.
+    - **Navigates only the day folders in range** (``csv/YYYY/MM/DD``) instead of
+      scanning the whole tree, so a one-day query never lists the whole Volume.
+    - **Streaming generator** (:meth:`stream_by_time_range`) yields one series at a
+      time so the driver never has to hold the full dataset in memory.
+
+    Reads are sequential by design (no thread pool) to avoid adding CPU/memory
+    pressure on a shared cluster driver.
+
+    Off-cluster (outside Databricks) the same code works against any mounted or
+    synced copy of the Volume; if you cannot mount it, use
+    :class:`AzureBlobEnergyLoader` against the underlying storage instead.
+    """
+
+    def __init__(
+        self,
+        volume_path: str | None = None,
+        *,
+        catalog: str | None = None,
+        schema: str | None = None,
+        volume: str | None = None,
+        prefix: str = "",
+        base_path: str = "/Volumes",
+        thousands: str | None = None,
+        decimal: str = ".",
+        validate: bool = True,
+    ) -> None:
+        """
+        Resolve the mounted Unity Catalog Volume root to read from.
+
+        Provide *either* an explicit ``volume_path`` *or* the
+        ``catalog`` / ``schema`` / ``volume`` triple (joined under ``base_path``)::
+
+            # explicit mounted path
+            DatabricksUnityEnergyLoader(
+                volume_path="/Volumes/main/plant/energy",
+            )
+
+            # from catalog/schema/volume parts
+            DatabricksUnityEnergyLoader(
+                catalog="main", schema="plant", volume="energy",
+            )
+
+        Args:
+            volume_path: Full mounted Volume root, e.g.
+                ``/Volumes/<catalog>/<schema>/<volume>``.
+            catalog: UC catalog name (used when ``volume_path`` is omitted).
+            schema: UC schema name (used when ``volume_path`` is omitted).
+            volume: UC volume name (used when ``volume_path`` is omitted).
+            prefix: Optional sub-path beneath the Volume root holding the
+                ``.meta/`` and ``csv/`` folders.
+            base_path: Mount root for Volumes; ``/Volumes`` inside Databricks.
+            thousands: Thousands separator for ``pd.read_csv`` (default None).
+            decimal: Decimal separator for ``pd.read_csv`` (default ".").
+            validate: Warn (``LoaderConfigWarning``) if the resolved root does
+                not exist, so a missing/mistyped mount fails loudly but cheaply.
+        """
+        if volume_path:
+            root = Path(volume_path)
+        elif catalog and schema and volume:
+            root = Path(base_path) / catalog / schema / volume
+        else:
+            raise ValueError(
+                "Provide either volume_path or all of catalog, schema and volume "
+                "(e.g. volume_path='/Volumes/<catalog>/<schema>/<volume>')."
+            )
+
+        self.volume_root = root
+        self.prefix = prefix.strip("/")
+        # Directory under which .meta/ and csv/ live: <volume_root>/<prefix>
+        self.base_path = root / self.prefix if self.prefix else root
+        self.thousands = thousands
+        self.decimal = decimal
+
+        if validate and not self.base_path.exists():
+            warnings.warn(
+                "DatabricksUnityEnergyLoader path does not exist: "
+                f"{self.base_path}. Inside Databricks ensure the Unity Catalog "
+                "Volume is mounted (default '/Volumes/<catalog>/<schema>/<volume>') "
+                "and that catalog/schema/volume/prefix are correct.",
+                LoaderConfigWarning,
+                stacklevel=2,
+            )
+
+    # ── Metadata ────────────────────────────────────────────────────────────
+
+    def load_series_metadata(self) -> pd.DataFrame:
+        """
+        Read ``.meta/series.csv`` and return as a DataFrame.
+
+        Columns: id, label_lvl1, label_lvl2, label_lvl3, label_lvl4,
+                 description, unit, hierarchy_lvl1 … hierarchy_lvl6
+
+        Returns an empty DataFrame with the expected columns when the file
+        does not exist.
+        """
+        path = self.base_path / _METADATA_PATH
+        try:
+            df = pd.read_csv(path, sep="\t", dtype=str)
+            for col in _META_COLUMNS:
+                if col not in df.columns:
+                    df[col] = pd.NA
+            return df[_META_COLUMNS].reset_index(drop=True)
+        except Exception as exc:
+            logger.debug("Could not load series metadata from '%s': %s", path, exc)
+            return pd.DataFrame(columns=_META_COLUMNS)
+
+    # ── Timeseries ───────────────────────────────────────────────────────────
+
+    def load_by_time_range(
+        self,
+        start: Union[str, "pd.Timestamp"],
+        end: Union[str, "pd.Timestamp"],
+        series_ids: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load all CSV files in ``csv/YYYY/MM/DD/`` for each date in [start, end].
+
+        Args:
+            start: Start date/datetime (inclusive).
+            end: End date/datetime (inclusive).
+            series_ids: Optional list of series IDs to load. Loads all if None.
+
+        Returns:
+            Standard schema DataFrame: systime | uuid | value_double | is_delta
+        """
+        ids_set = set(series_ids) if series_ids else None
+        paths = self._list_csv_by_date_range(start, end, ids_set)
+        return self._read_and_concat(paths)
+
+    def load_by_series_ids(
+        self,
+        series_ids: list[str],
+        start: Union[str, "pd.Timestamp"] | None = None,
+        end: Union[str, "pd.Timestamp"] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load specific series by ID.
+
+        With start/end: visits only the day folders in range and keeps files
+        whose stem matches a requested series_id. Without dates: walks ``csv/``
+        and filters by stem.
+
+        Args:
+            series_ids: Series IDs to load.
+            start: Optional start date filter.
+            end: Optional end date filter.
+
+        Returns:
+            Standard schema DataFrame: systime | uuid | value_double | is_delta
+        """
+        ids_set = set(series_ids)
+        if start is not None and end is not None:
+            paths = self._list_csv_by_date_range(start, end, ids_set)
+        else:
+            paths = [
+                p
+                for p in self._walk_csv(self.base_path / _CSV_PREFIX)
+                if self._series_id_from_path(p) in ids_set
+            ]
+        return self._read_and_concat(paths)
+
+    def stream_by_time_range(
+        self,
+        start: Union[str, "pd.Timestamp"],
+        end: Union[str, "pd.Timestamp"],
+        series_ids: list[str] | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
+        """
+        Stream CSV files one at a time as (series_id, DataFrame) tuples.
+
+        Memory-efficient alternative to :meth:`load_by_time_range` for large
+        date ranges -- the recommended low-memory entry point in pipelines.
+
+        Args:
+            start: Start date/datetime (inclusive).
+            end: End date/datetime (inclusive).
+            series_ids: Optional series filter.
+
+        Yields:
+            (series_id, DataFrame) where DataFrame has the standard schema.
+        """
+        ids_set = set(series_ids) if series_ids else None
+        for path in self._list_csv_by_date_range(start, end, ids_set):
+            df = self._read_csv(path)
+            if df is not None and not df.empty:
+                yield self._series_id_from_path(path), df
+
+    def list_series(self) -> list[str]:
+        """
+        List all series IDs present in the Volume by scanning ``csv/``.
+
+        Returns:
+            Sorted list of unique series ID strings.
+        """
+        seen: set[str] = set()
+        for path in self._walk_csv(self.base_path / _CSV_PREFIX):
+            seen.add(self._series_id_from_path(path))
+        return sorted(seen)
+
+    def fetch_data_as_dataframe(
+        self,
+        start: Union[str, "pd.Timestamp"] | None = None,
+        end: Union[str, "pd.Timestamp"] | None = None,
+        series_ids: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Return a combined DataFrame, for ``Pipeline`` / ``DataIntegratorHybrid``.
+
+        With a ``start``/``end`` pair this delegates to :meth:`load_by_time_range`
+        (visiting only the in-range day folders); with no bounds it loads every
+        series under ``csv/``.
+        """
+        if start is not None and end is not None:
+            return self.load_by_time_range(start, end, series_ids=series_ids)
+        if series_ids:
+            return self.load_by_series_ids(series_ids)
+        paths = self._walk_csv(self.base_path / _CSV_PREFIX)
+        return self._read_and_concat(paths)
+
+    # ── Internal helpers ─────────────────────────────────────────────────────
+
+    def _day_dirs(
+        self,
+        start: Union[str, "pd.Timestamp"],
+        end: Union[str, "pd.Timestamp"],
+    ) -> list[Path]:
+        """Return the day-level directories: <base>/csv/YYYY/MM/DD."""
+        dates = pd.date_range(
+            start=pd.to_datetime(start).normalize(),
+            end=pd.to_datetime(end).normalize(),
+            freq="D",
+        )
+        csv_root = self.base_path / _CSV_PREFIX
+        return [
+            csv_root / str(ts.year) / str(ts.month).zfill(2) / str(ts.day).zfill(2)
+            for ts in dates
+        ]
+
+    def _list_csv_in(self, directory: Path) -> list[Path]:
+        """List ``*.csv`` files in a single day directory (no recursion)."""
+        try:
+            with os.scandir(directory) as it:
+                return [
+                    Path(entry.path)
+                    for entry in it
+                    if entry.is_file() and entry.name.endswith(".csv")
+                ]
+        except (FileNotFoundError, NotADirectoryError):
+            return []
+        except OSError as exc:
+            logger.debug("Failed to list directory '%s': %s", directory, exc)
+            return []
+
+    def _walk_csv(self, root: Path) -> list[Path]:
+        """Recursively find all ``*.csv`` files under ``root`` (sorted)."""
+        if not root.exists():
+            return []
+        return sorted(root.rglob("*.csv"))
+
+    def _list_csv_by_date_range(
+        self,
+        start: Union[str, "pd.Timestamp"],
+        end: Union[str, "pd.Timestamp"],
+        ids_set: set | None,
+    ) -> list[Path]:
+        """List CSV files across the date range, optionally filtered by ids_set."""
+        paths: list[Path] = []
+        for directory in self._day_dirs(start, end):
+            for path in self._list_csv_in(directory):
+                if (
+                    ids_set is not None
+                    and self._series_id_from_path(path) not in ids_set
+                ):
+                    continue
+                paths.append(path)
+        return paths
+
+    @staticmethod
+    def _series_id_from_path(path: Path) -> str:
+        """Extract series_id from path: csv/2026/01/13/sensor_001.csv → sensor_001."""
+        return path.stem
+
+    def _read_csv(self, path: Path) -> pd.DataFrame | None:
+        """Read a single CSV file and normalize to standard schema; None on error."""
+        try:
+            raw = pd.read_csv(path, thousands=self.thousands, decimal=self.decimal)
+            return self._normalize_df(raw, self._series_id_from_path(path))
+        except Exception as exc:
+            logger.debug("Failed to read CSV '%s': %s", path, exc)
+            return None
+
+    @staticmethod
+    def _normalize_df(raw: pd.DataFrame, series_id: str) -> pd.DataFrame:
+        """
+        Convert raw two-column CSV DataFrame to standard ts-shape schema.
+
+        Input columns: time, value
+        Output columns: systime, uuid, value_double, is_delta
+        """
+        if raw.empty or "time" not in raw.columns or "value" not in raw.columns:
+            return pd.DataFrame(columns=_EMPTY_SCHEMA)
+
+        out = pd.DataFrame()
+        out["systime"] = pd.to_datetime(raw["time"], utc=True)
+        out["uuid"] = series_id
+        out["value_double"] = pd.to_numeric(raw["value"], errors="coerce")
+        out["is_delta"] = True
+        return out.sort_values("systime").reset_index(drop=True)
+
+    def _read_and_concat(self, paths: list[Path]) -> pd.DataFrame:
+        """Read a list of CSV files sequentially and concatenate results."""
+        if not paths:
+            return pd.DataFrame(columns=_EMPTY_SCHEMA)
+
+        frames: list[pd.DataFrame] = []
+        for path in paths:
+            df = self._read_csv(path)
+            if df is not None and not df.empty:
+                frames.append(df)
+
+        if not frames:
+            return pd.DataFrame(columns=_EMPTY_SCHEMA)
+
+        combined = pd.concat(frames, ignore_index=True)
+        return combined.sort_values("systime").reset_index(drop=True)

--- a/src/ts_shape/loader/timeseries/databricks_unity_parquet_loader.py
+++ b/src/ts_shape/loader/timeseries/databricks_unity_parquet_loader.py
@@ -1,0 +1,515 @@
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+import logging
+import os
+import warnings
+
+import pandas as pd  # type: ignore
+
+from ts_shape.errors import LoaderConfigWarning
+
+logger = logging.getLogger(__name__)
+
+
+class DatabricksUnityCatalogParquetLoader:
+    """
+    Load canonical parquet files governed by **Databricks Unity Catalog**.
+
+    Unity Catalog exposes the *same* parquet files that already live in your
+    cloud storage (an external UC Volume over, e.g., an Azure blob container).
+    The on-disk layout is unchanged -- ``<prefix>/YYYY/MM/DD/HH/<uuid>.parquet``
+    with the canonical columns ``systime, uuid, value_double, value_integer,
+    value_string, value_bool, is_delta`` -- so the frames returned here flow
+    straight into every ts-shape transformation, event detector, ``Pipeline``
+    and ``DataIntegratorHybrid`` without any change.
+
+    **Designed for use inside Databricks notebooks / pipelines.** A UC Volume is
+    FUSE-mounted at ``/Volumes/<catalog>/<schema>/<volume>/...``, so this loader
+    reads parquet *directly from that mounted path* with ``pandas.read_parquet``.
+    It deliberately keeps the resource footprint low:
+
+    - **No download step and no ``databricks-sdk`` / network client** -- the
+      mounted Volume is read like a local directory.
+    - **Navigates only the hour folders in range** (``YYYY/MM/DD/HH``) instead of
+      scanning the whole tree, so a one-hour query never lists the whole Volume.
+    - **Column projection and row-predicate pushdown** via ``columns`` / ``filters``
+      forwarded to ``pandas.read_parquet`` (pyarrow), so only needed bytes are read.
+    - **Streaming generators** (:meth:`stream_by_time_range`,
+      :meth:`stream_files_by_time_range_and_uuids`) yield one frame at a time so
+      the driver never has to hold the full dataset in memory.
+
+    Reads are sequential by design (no thread pool) to avoid adding CPU/memory
+    pressure on a shared cluster driver; pushdown + streaming keep them cheap.
+
+    Off-cluster (outside Databricks) the same code works against any mounted or
+    synced copy of the Volume; if you cannot mount it, use
+    :class:`AzureBlobParquetLoader` against the underlying storage instead.
+    """
+
+    def __init__(
+        self,
+        volume_path: str | None = None,
+        *,
+        catalog: str | None = None,
+        schema: str | None = None,
+        volume: str | None = None,
+        prefix: str = "",
+        base_path: str = "/Volumes",
+        hour_pattern: str = "{Y}/{m}/{d}/{H}/",
+        validate: bool = True,
+    ) -> None:
+        """
+        Resolve the mounted Unity Catalog Volume root to read from.
+
+        Provide *either* an explicit ``volume_path`` *or* the
+        ``catalog`` / ``schema`` / ``volume`` triple (joined under ``base_path``)::
+
+            # explicit mounted path
+            DatabricksUnityCatalogParquetLoader(
+                volume_path="/Volumes/main/plant/timeseries", prefix="parquet",
+            )
+
+            # from catalog/schema/volume parts
+            DatabricksUnityCatalogParquetLoader(
+                catalog="main", schema="plant", volume="timeseries",
+                prefix="parquet",
+            )
+
+        Args:
+            volume_path: Full mounted Volume root, e.g.
+                ``/Volumes/<catalog>/<schema>/<volume>``.
+            catalog: UC catalog name (used when ``volume_path`` is omitted).
+            schema: UC schema name (used when ``volume_path`` is omitted).
+            volume: UC volume name (used when ``volume_path`` is omitted).
+            prefix: Optional sub-path beneath the Volume root (e.g. ``"parquet"``).
+            base_path: Mount root for Volumes; ``/Volumes`` inside Databricks.
+            hour_pattern: Pattern for the hour-level subpath; tokens
+                ``{Y} {m} {d} {H}``. Default ``YYYY/MM/DD/HH/``.
+            validate: Warn (``LoaderConfigWarning``) if the resolved root does
+                not exist, so a missing/mistyped mount fails loudly but cheaply.
+        """
+        if volume_path:
+            root = Path(volume_path)
+        elif catalog and schema and volume:
+            root = Path(base_path) / catalog / schema / volume
+        else:
+            raise ValueError(
+                "Provide either volume_path or all of catalog, schema and volume "
+                "(e.g. volume_path='/Volumes/<catalog>/<schema>/<volume>')."
+            )
+
+        self.volume_root = root
+        self.prefix = prefix.strip("/")
+        # Directory under which hour folders live: <volume_root>/<prefix>
+        self.base_path = root / self.prefix if self.prefix else root
+        self.hour_pattern = hour_pattern
+
+        if validate and not self.base_path.exists():
+            warnings.warn(
+                "DatabricksUnityCatalogParquetLoader path does not exist: "
+                f"{self.base_path}. Inside Databricks ensure the Unity Catalog "
+                "Volume is mounted (default '/Volumes/<catalog>/<schema>/<volume>') "
+                "and that catalog/schema/volume/prefix are correct.",
+                LoaderConfigWarning,
+                stacklevel=2,
+            )
+
+    # ---- Hourly-layout helpers (mirror AzureBlobParquetLoader) ----
+    @staticmethod
+    def _hourly_slots(
+        start_timestamp: str | pd.Timestamp, end_timestamp: str | pd.Timestamp
+    ) -> Iterable[pd.Timestamp]:
+        start = pd.to_datetime(start_timestamp)
+        end = pd.to_datetime(end_timestamp)
+        # Inclusive hourly range
+        return pd.date_range(start=start, end=end, freq="h")
+
+    def _hour_dir(self, ts: pd.Timestamp) -> Path:
+        """Return the directory for a given hour, e.g. <base>/2024/01/31/09."""
+        y = str(ts.year)
+        m = str(ts.month).zfill(2)
+        d = str(ts.day).zfill(2)
+        h = str(ts.hour).zfill(2)
+        sub = (
+            self.hour_pattern.replace("{Y}", y)
+            .replace("{m}", m)
+            .replace("{d}", d)
+            .replace("{H}", h)
+        )
+        return self.base_path / sub.strip("/")
+
+    # ---- Filesystem listing (cheap; no file contents read) ----
+    def _list_parquet_in(self, directory: Path) -> list[Path]:
+        """List ``*.parquet`` files in a single hour directory (no recursion)."""
+        try:
+            with os.scandir(directory) as it:
+                return [
+                    Path(entry.path)
+                    for entry in it
+                    if entry.is_file() and entry.name.endswith(".parquet")
+                ]
+        except (FileNotFoundError, NotADirectoryError):
+            return []
+        except OSError as exc:
+            logger.debug("Failed to list directory '%s': %s", directory, exc)
+            return []
+
+    def _walk_parquet(self, root: Path) -> list[Path]:
+        """Recursively find all ``*.parquet`` files under ``root``.
+
+        Only used by the explicit "load everything" entry points
+        (:meth:`load_all_files`, :meth:`list_structure`).
+        """
+        if not root.exists():
+            return []
+        return sorted(root.rglob("*.parquet"))
+
+    def _read_parquet(
+        self,
+        path: Path,
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame | None:
+        """Read one mounted parquet file with column/predicate pushdown.
+
+        Returns ``None`` on failure (missing, unauthorized, or corrupt) so the
+        caller can count and report it rather than aborting the whole load.
+        """
+        try:
+            return pd.read_parquet(path, columns=columns, filters=filters)
+        except Exception as exc:
+            logger.debug("Failed to read parquet '%s': %s", path, exc)
+            return None
+
+    def _read_many(
+        self,
+        paths: list[Path],
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> tuple[list[pd.DataFrame], int, int]:
+        """Read a set of parquet files sequentially.
+
+        Returns ``(frames, n_failed, n_empty)`` where ``frames`` are the
+        non-empty DataFrames, ``n_failed`` counts files that could not be read
+        or parsed, and ``n_empty`` counts files that parsed but had no rows.
+        """
+        frames: list[pd.DataFrame] = []
+        n_failed = 0
+        n_empty = 0
+        for path in paths:
+            df = self._read_parquet(path, columns, filters)
+            if df is None:
+                n_failed += 1
+            elif df.empty:
+                n_empty += 1
+            else:
+                frames.append(df)
+        return frames, n_failed, n_empty
+
+    def _warn_empty(
+        self, method: str, detail: str, filters: list | None = None
+    ) -> None:
+        """Emit a ``LoaderConfigWarning`` explaining why a load returned no data."""
+        if filters is not None:
+            detail = f"{detail} The filters argument may be too strict."
+        warnings.warn(
+            f"DatabricksUnityCatalogParquetLoader.{method} returned an empty "
+            f"DataFrame. {detail}",
+            LoaderConfigWarning,
+            stacklevel=3,
+        )
+
+    def _time_search_detail(self, slots: list[pd.Timestamp]) -> str:
+        """Describe the path/pattern/hour-range probed by a time-range load."""
+        base_repr = repr(str(self.base_path))
+        pattern_repr = repr(self.hour_pattern)
+        if not slots:
+            return (
+                f"base_path={base_repr}, hour_pattern={pattern_repr}, "
+                "0 hour-folders (the time range is empty)"
+            )
+        first = slots[0].strftime("%Y-%m-%d %H:00")
+        last = slots[-1].strftime("%Y-%m-%d %H:00")
+        return (
+            f"base_path={base_repr}, hour_pattern={pattern_repr}, "
+            f"{len(slots)} hour-folder(s) {first} .. {last}"
+        )
+
+    # ---- Public API (mirrors AzureBlobParquetLoader) ----
+    def load_all_files(
+        self,
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load every parquet file under the Volume root (optionally below ``prefix``).
+
+        This walks the whole tree; for large Volumes prefer
+        :meth:`load_by_time_range` or :meth:`stream_by_time_range`.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
+        """
+        paths = self._walk_parquet(self.base_path)
+        base_repr = repr(str(self.base_path))
+        if not paths:
+            self._warn_empty(
+                "load_all_files",
+                f"No .parquet files found under base_path={base_repr}. Check that "
+                "the Unity Catalog Volume is mounted and that the prefix matches "
+                "the stored layout.",
+            )
+            return pd.DataFrame()
+
+        frames, n_failed, n_empty = self._read_many(paths, columns, filters)
+        if not frames:
+            self._warn_empty(
+                "load_all_files",
+                f"Found {len(paths)} .parquet file(s) under base_path={base_repr} "
+                f"but none yielded rows ({n_failed} failed to read/parse, "
+                f"{n_empty} had no rows). Check read permission on the Volume and "
+                "that the files are valid parquet.",
+                filters=filters,
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
+
+    def load_by_time_range(
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load parquet files under the hourly folders within ``[start, end]``.
+
+        Visits only the ``YYYY/MM/DD/HH`` folders in range, so the rest of the
+        Volume is never scanned.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
+        """
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        paths: list[Path] = []
+        for ts in slots:
+            paths.extend(self._list_parquet_in(self._hour_dir(ts)))
+
+        search = self._time_search_detail(slots)
+        if not paths:
+            self._warn_empty(
+                "load_by_time_range",
+                f"No .parquet files found. {search}. Check that hour_pattern "
+                "matches the real folder layout and that the time range overlaps "
+                "the stored data.",
+            )
+            return pd.DataFrame()
+
+        frames, n_failed, n_empty = self._read_many(paths, columns, filters)
+        if not frames:
+            self._warn_empty(
+                "load_by_time_range",
+                f"Found {len(paths)} .parquet file(s) but none yielded rows "
+                f"({n_failed} failed to read/parse, {n_empty} had no rows). "
+                f"{search}. Check read permission and file validity.",
+                filters=filters,
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
+
+    def stream_by_time_range(
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
+        """
+        Stream parquet frames under the hourly folders within ``[start, end]``.
+
+        Yields ``(file_path, DataFrame)`` one at a time so the full dataset is
+        never held in memory -- the recommended low-memory entry point for
+        Databricks pipelines.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
+        """
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        yielded = 0
+        for ts in slots:
+            for path in self._list_parquet_in(self._hour_dir(ts)):
+                df = self._read_parquet(path, columns, filters)
+                if df is not None and not df.empty:
+                    yielded += 1
+                    yield (str(path), df)
+
+        if yielded == 0:
+            self._warn_empty(
+                "stream_by_time_range",
+                f"Yielded no DataFrames. {self._time_search_detail(slots)}. Check "
+                "that hour_pattern matches the real folder layout and that the "
+                "time range overlaps the stored data.",
+                filters=filters,
+            )
+
+    def load_files_by_time_range_and_uuids(
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        uuid_list: list[str],
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load parquet files for the given UUIDs within ``[start, end]`` hours.
+
+        Each hour folder is scanned once and files whose basename matches a
+        requested UUID (``<uuid>.parquet``, case-insensitive) are read.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
+        """
+        if not uuid_list:
+            return pd.DataFrame()
+
+        variants = self._uuid_basenames(uuid_list)
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        paths: list[Path] = []
+        for ts in slots:
+            for path in self._list_parquet_in(self._hour_dir(ts)):
+                if path.name.lower() in variants:
+                    paths.append(path)
+
+        search = self._time_search_detail(slots)
+        uuid_note = f"{len(variants)} UUID basename(s) searched"
+        if not paths:
+            self._warn_empty(
+                "load_files_by_time_range_and_uuids",
+                f"No matching .parquet files found. {search}, {uuid_note}. Check "
+                "that the UUIDs, hour_pattern and time range match the stored data.",
+            )
+            return pd.DataFrame()
+
+        frames, n_failed, n_empty = self._read_many(paths, columns, filters)
+        if not frames:
+            self._warn_empty(
+                "load_files_by_time_range_and_uuids",
+                f"Resolved {len(paths)} file(s) but none yielded rows "
+                f"({n_failed} failed to read/parse, {n_empty} had no rows). "
+                f"{search}, {uuid_note}. Check read permission and file validity.",
+                filters=filters,
+            )
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
+
+    def stream_files_by_time_range_and_uuids(
+        self,
+        start_timestamp: str | pd.Timestamp,
+        end_timestamp: str | pd.Timestamp,
+        uuid_list: list[str],
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> Iterator[tuple[str, pd.DataFrame]]:
+        """
+        Stream parquet frames for the given UUIDs within ``[start, end]`` hours.
+
+        Yields ``(file_path, DataFrame)`` as they are read, keeping memory flat.
+
+        Args:
+            columns: Subset of parquet columns to read; None reads all columns.
+            filters: pyarrow-style predicate pushdown in DNF form, e.g.
+                ``[("value_double", ">", 0.0)]``; None reads all rows.
+        """
+        if not uuid_list:
+            return
+
+        variants = self._uuid_basenames(uuid_list)
+        slots = list(self._hourly_slots(start_timestamp, end_timestamp))
+        yielded = 0
+        for ts in slots:
+            for path in self._list_parquet_in(self._hour_dir(ts)):
+                if path.name.lower() not in variants:
+                    continue
+                df = self._read_parquet(path, columns, filters)
+                if df is not None and not df.empty:
+                    yielded += 1
+                    yield (str(path), df)
+
+        if yielded == 0:
+            self._warn_empty(
+                "stream_files_by_time_range_and_uuids",
+                f"Yielded no DataFrames. {self._time_search_detail(slots)}, "
+                f"{len(variants)} UUID basename(s) searched. Check that the "
+                "UUIDs, hour_pattern and time range match the stored data.",
+                filters=filters,
+            )
+
+    @staticmethod
+    def _uuid_basenames(uuid_list: list[str]) -> set[str]:
+        """Build the set of lowercase ``<uuid>.parquet`` basenames to match."""
+        variants: set[str] = set()
+        for u in uuid_list:
+            s = str(u).strip().strip("{}").strip().lower()
+            if s:
+                variants.add(f"{s}.parquet")
+        return variants
+
+    def list_structure(
+        self, parquet_only: bool = True, limit: int | None = None
+    ) -> dict[str, list[str]]:
+        """
+        List the folders (hours) and files under the configured Volume path.
+
+        Args:
+            parquet_only: If True, only include files ending with ``.parquet``.
+            limit: Optional cap on number of files collected for quick inspection.
+
+        Returns:
+            A dict with ``folders`` (sorted unique parent folders) and ``files``
+            (sorted file paths) as strings relative-free full mounted paths.
+        """
+        folders: set[str] = set()
+        files: list[str] = []
+        collected = 0
+        if not self.base_path.exists():
+            return {"folders": [], "files": []}
+
+        pattern = "*.parquet" if parquet_only else "*"
+        for path in sorted(self.base_path.rglob(pattern)):
+            if not path.is_file():
+                continue
+            files.append(str(path))
+            folders.add(str(path.parent) + "/")
+            collected += 1
+            if limit is not None and collected >= limit:
+                break
+
+        return {"folders": sorted(folders), "files": sorted(files)}
+
+    def fetch_data_as_dataframe(
+        self,
+        start_timestamp: str | pd.Timestamp | None = None,
+        end_timestamp: str | pd.Timestamp | None = None,
+        columns: list[str] | None = None,
+        filters: list | None = None,
+    ) -> pd.DataFrame:
+        """
+        Return a combined DataFrame, for ``Pipeline`` / ``DataIntegratorHybrid``.
+
+        With a ``start``/``end`` pair this delegates to :meth:`load_by_time_range`
+        (visiting only the in-range hour folders); with no bounds it falls back to
+        :meth:`load_all_files`.
+        """
+        if start_timestamp is not None and end_timestamp is not None:
+            return self.load_by_time_range(
+                start_timestamp, end_timestamp, columns=columns, filters=filters
+            )
+        return self.load_all_files(columns=columns, filters=filters)

--- a/src/ts_shape/loader/timeseries/databricks_unity_parquet_loader.py
+++ b/src/ts_shape/loader/timeseries/databricks_unity_parquet_loader.py
@@ -11,7 +11,7 @@ from ts_shape.errors import LoaderConfigWarning
 logger = logging.getLogger(__name__)
 
 
-class DatabricksUnityCatalogParquetLoader:
+class DatabricksUnityParquetLoader:
     """
     Load canonical parquet files governed by **Databricks Unity Catalog**.
 
@@ -65,12 +65,12 @@ class DatabricksUnityCatalogParquetLoader:
         ``catalog`` / ``schema`` / ``volume`` triple (joined under ``base_path``)::
 
             # explicit mounted path
-            DatabricksUnityCatalogParquetLoader(
+            DatabricksUnityParquetLoader(
                 volume_path="/Volumes/main/plant/timeseries", prefix="parquet",
             )
 
             # from catalog/schema/volume parts
-            DatabricksUnityCatalogParquetLoader(
+            DatabricksUnityParquetLoader(
                 catalog="main", schema="plant", volume="timeseries",
                 prefix="parquet",
             )
@@ -106,7 +106,7 @@ class DatabricksUnityCatalogParquetLoader:
 
         if validate and not self.base_path.exists():
             warnings.warn(
-                "DatabricksUnityCatalogParquetLoader path does not exist: "
+                "DatabricksUnityParquetLoader path does not exist: "
                 f"{self.base_path}. Inside Databricks ensure the Unity Catalog "
                 "Volume is mounted (default '/Volumes/<catalog>/<schema>/<volume>') "
                 "and that catalog/schema/volume/prefix are correct.",
@@ -213,7 +213,7 @@ class DatabricksUnityCatalogParquetLoader:
         if filters is not None:
             detail = f"{detail} The filters argument may be too strict."
         warnings.warn(
-            f"DatabricksUnityCatalogParquetLoader.{method} returned an empty "
+            f"DatabricksUnityParquetLoader.{method} returned an empty "
             f"DataFrame. {detail}",
             LoaderConfigWarning,
             stacklevel=3,

--- a/tests/test_databricks_unity_energy_loader.py
+++ b/tests/test_databricks_unity_energy_loader.py
@@ -1,0 +1,254 @@
+import warnings
+
+import pandas as pd  # type: ignore
+import pytest
+
+from ts_shape.errors import LoaderConfigWarning
+from ts_shape.loader.timeseries.databricks_unity_energy_loader import (
+    DatabricksUnityEnergyLoader,
+)
+
+_CSV_TEXT = (
+    "time,value\n"
+    "2026-01-13T00:00:00Z,107.603588867188\n"
+    "2026-01-13T00:15:00Z,184.093249511719\n"
+    "2026-01-13T00:30:00Z,288.517919921875\n"
+)
+
+_META_TEXT = (
+    "id\tlabel_lvl1\tlabel_lvl2\tlabel_lvl3\tlabel_lvl4\tdescription\tunit"
+    "\thierarchy_lvl1\thierarchy_lvl2\thierarchy_lvl3"
+    "\thierarchy_lvl4\thierarchy_lvl5\thierarchy_lvl6\n"
+    "sensor_001\tBuilding A\tFloor 1\tLine 1\t\tMain meter\tkWh"
+    "\tSite\tBuilding\tFloor\tLine\t\t\n"
+)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _make_volume(tmp_path, prefix=""):
+    """Build a mini mounted UC Volume tree with the energy CSV layout."""
+    root = tmp_path / "Volumes" / "main" / "plant" / "energy"
+    base = root / prefix if prefix else root
+    _write(base / ".meta/series.csv", _META_TEXT)
+    _write(base / "csv/2026/01/13/sensor_001.csv", _CSV_TEXT)
+    _write(base / "csv/2026/01/13/sensor_002.csv", _CSV_TEXT)
+    _write(base / "csv/2026/01/14/sensor_001.csv", _CSV_TEXT)
+    return root
+
+
+def _loader(tmp_path, **kwargs):
+    prefix = kwargs.pop("prefix", "")
+    root = _make_volume(tmp_path, prefix=prefix)
+    return (
+        DatabricksUnityEnergyLoader(volume_path=str(root), prefix=prefix, **kwargs),
+        root,
+    )
+
+
+# ── Init / resolution ─────────────────────────────────────────────────────────
+
+
+def test_resolve_from_volume_path(tmp_path):
+    loader, root = _loader(tmp_path)
+    assert loader.base_path == root
+
+
+def test_resolve_from_catalog_parts(tmp_path):
+    root = _make_volume(tmp_path)
+    loader = DatabricksUnityEnergyLoader(
+        catalog="main",
+        schema="plant",
+        volume="energy",
+        base_path=str(tmp_path / "Volumes"),
+    )
+    assert loader.base_path == root
+
+
+def test_missing_parts_raises_value_error():
+    with pytest.raises(ValueError, match="volume_path"):
+        DatabricksUnityEnergyLoader(catalog="main", schema="plant")
+
+
+def test_validate_warns_on_missing_root(tmp_path):
+    missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
+    with pytest.warns(LoaderConfigWarning, match="path does not exist"):
+        DatabricksUnityEnergyLoader(volume_path=str(missing))
+
+
+def test_validate_false_is_silent(tmp_path):
+    missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LoaderConfigWarning)
+        DatabricksUnityEnergyLoader(volume_path=str(missing), validate=False)
+
+
+# ── Metadata ──────────────────────────────────────────────────────────────────
+
+
+def test_load_series_metadata(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_series_metadata()
+    assert list(df.columns)[0] == "id"
+    assert "hierarchy_lvl6" in df.columns
+    assert df.iloc[0]["id"] == "sensor_001"
+    assert df.iloc[0]["unit"] == "kWh"
+
+
+def test_load_series_metadata_missing_returns_empty(tmp_path):
+    root = tmp_path / "Volumes" / "main" / "plant" / "energy"
+    (root / "csv").mkdir(parents=True)
+    loader = DatabricksUnityEnergyLoader(volume_path=str(root))
+    df = loader.load_series_metadata()
+    assert df.empty
+    assert "id" in df.columns
+
+
+# ── load_by_time_range ────────────────────────────────────────────────────────
+
+
+def test_load_by_time_range_standard_schema(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_time_range("2026-01-13", "2026-01-13")
+    assert list(df.columns) == ["systime", "uuid", "value_double", "is_delta"]
+    # Two series on 2026-01-13, 3 rows each.
+    assert len(df) == 6
+    assert set(df["uuid"]) == {"sensor_001", "sensor_002"}
+
+
+def test_load_by_time_range_filters_series(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_time_range(
+        "2026-01-13", "2026-01-13", series_ids=["sensor_001"]
+    )
+    assert set(df["uuid"]) == {"sensor_001"}
+    assert len(df) == 3
+
+
+def test_load_by_time_range_empty_returns_schema(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_time_range("2030-01-01", "2030-01-01")
+    assert df.empty
+    assert list(df.columns) == ["systime", "uuid", "value_double", "is_delta"]
+
+
+def test_load_by_time_range_visits_only_in_range_days(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path)
+    visited: list[str] = []
+    orig = loader._read_csv
+
+    def spy(path):
+        visited.append(str(path))
+        return orig(path)
+
+    monkeypatch.setattr(loader, "_read_csv", spy)
+    loader.load_by_time_range("2026-01-13", "2026-01-13")
+    # The 01/14 folder must never have been read.
+    assert all("/14/" not in v for v in visited)
+
+
+def test_values_are_numeric(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_time_range("2026-01-13", "2026-01-13")
+    assert df["value_double"].dtype == float
+    assert df["value_double"].iloc[0] == pytest.approx(107.603588867188)
+
+
+# ── load_by_series_ids ────────────────────────────────────────────────────────
+
+
+def test_load_by_series_ids_with_dates(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_series_ids(["sensor_001"], start="2026-01-13", end="2026-01-14")
+    assert set(df["uuid"]) == {"sensor_001"}
+    assert len(df) == 6  # two days
+
+
+def test_load_by_series_ids_without_dates(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_series_ids(["sensor_002"])
+    assert set(df["uuid"]) == {"sensor_002"}
+
+
+def test_load_by_series_ids_unknown_returns_empty(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.load_by_series_ids(["unknown"])
+    assert df.empty
+
+
+# ── stream_by_time_range ──────────────────────────────────────────────────────
+
+
+def test_stream_by_time_range_yields_tuples(tmp_path):
+    loader, _ = _loader(tmp_path)
+    results = list(loader.stream_by_time_range("2026-01-13", "2026-01-13"))
+    assert len(results) == 2
+    series_ids = {sid for sid, _ in results}
+    assert series_ids == {"sensor_001", "sensor_002"}
+    for _, df in results:
+        assert list(df.columns) == ["systime", "uuid", "value_double", "is_delta"]
+
+
+def test_stream_by_time_range_empty(tmp_path):
+    loader, _ = _loader(tmp_path)
+    results = list(loader.stream_by_time_range("2030-01-01", "2030-01-01"))
+    assert results == []
+
+
+# ── list_series ───────────────────────────────────────────────────────────────
+
+
+def test_list_series_sorted_unique(tmp_path):
+    loader, _ = _loader(tmp_path)
+    assert loader.list_series() == ["sensor_001", "sensor_002"]
+
+
+def test_list_series_empty(tmp_path):
+    root = tmp_path / "Volumes" / "main" / "plant" / "energy"
+    (root / "csv").mkdir(parents=True)
+    loader = DatabricksUnityEnergyLoader(volume_path=str(root))
+    assert loader.list_series() == []
+
+
+# ── fetch_data_as_dataframe ───────────────────────────────────────────────────
+
+
+def test_fetch_data_as_dataframe_time_range(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.fetch_data_as_dataframe("2026-01-13", "2026-01-13")
+    assert set(df["uuid"]) == {"sensor_001", "sensor_002"}
+
+
+def test_fetch_data_as_dataframe_all(tmp_path):
+    loader, _ = _loader(tmp_path)
+    df = loader.fetch_data_as_dataframe()
+    assert set(df["uuid"]) == {"sensor_001", "sensor_002"}
+    assert len(df) == 9  # 3 files * 3 rows
+
+
+# ── prefix handling ───────────────────────────────────────────────────────────
+
+
+def test_prefix_subpath(tmp_path):
+    loader, root = _loader(tmp_path, prefix="plantA")
+    assert loader.base_path == root / "plantA"
+    df = loader.load_by_time_range("2026-01-13", "2026-01-13")
+    assert set(df["uuid"]) == {"sensor_001", "sensor_002"}
+
+
+# ── _normalize_df edge cases ──────────────────────────────────────────────────
+
+
+def test_normalize_df_bad_values_become_nan():
+    raw = pd.DataFrame({"time": ["2026-01-13T00:00:00Z"], "value": ["not_a_number"]})
+    out = DatabricksUnityEnergyLoader._normalize_df(raw, "s1")
+    assert pd.isna(out["value_double"].iloc[0])
+
+
+def test_normalize_df_missing_value_column():
+    raw = pd.DataFrame({"time": ["2026-01-13T00:00:00Z"]})
+    out = DatabricksUnityEnergyLoader._normalize_df(raw, "s1")
+    assert out.empty

--- a/tests/test_databricks_unity_parquet_loader.py
+++ b/tests/test_databricks_unity_parquet_loader.py
@@ -6,7 +6,7 @@ import pytest
 
 from ts_shape.errors import LoaderConfigWarning
 from ts_shape.loader.timeseries.databricks_unity_parquet_loader import (
-    DatabricksUnityCatalogParquetLoader,
+    DatabricksUnityParquetLoader,
 )
 
 
@@ -36,7 +36,7 @@ def _fake_read_by_stem(p, columns=None, filters=None):
 
 def _loader(tmp_path, monkeypatch=None):
     root = _make_volume(tmp_path)
-    loader = DatabricksUnityCatalogParquetLoader(volume_path=str(root), prefix="parquet")
+    loader = DatabricksUnityParquetLoader(volume_path=str(root), prefix="parquet")
     if monkeypatch is not None:
         monkeypatch.setattr(pd, "read_parquet", _fake_read_by_stem)
     return loader, root
@@ -49,7 +49,7 @@ def test_resolve_from_volume_path(tmp_path):
 
 def test_resolve_from_catalog_parts(tmp_path):
     root = _make_volume(tmp_path)
-    loader = DatabricksUnityCatalogParquetLoader(
+    loader = DatabricksUnityParquetLoader(
         catalog="main",
         schema="plant",
         volume="timeseries",
@@ -61,7 +61,7 @@ def test_resolve_from_catalog_parts(tmp_path):
 
 def test_missing_parts_raises_value_error():
     with pytest.raises(ValueError, match="volume_path"):
-        DatabricksUnityCatalogParquetLoader(catalog="main", schema="plant")
+        DatabricksUnityParquetLoader(catalog="main", schema="plant")
 
 
 def test_hour_dir_and_slots(tmp_path):
@@ -180,7 +180,7 @@ def test_fetch_data_as_dataframe_all(tmp_path, monkeypatch):
 def test_load_all_empty_warns(tmp_path):
     root = tmp_path / "Volumes" / "main" / "plant" / "empty"
     (root / "parquet").mkdir(parents=True)
-    loader = DatabricksUnityCatalogParquetLoader(volume_path=str(root), prefix="parquet")
+    loader = DatabricksUnityParquetLoader(volume_path=str(root), prefix="parquet")
     with pytest.warns(LoaderConfigWarning, match="No .parquet files"):
         df = loader.load_all_files()
     assert df.empty
@@ -204,14 +204,14 @@ def test_happy_load_emits_no_warning(tmp_path, monkeypatch):
 def test_validate_warns_on_missing_root(tmp_path):
     missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
     with pytest.warns(LoaderConfigWarning, match="path does not exist"):
-        DatabricksUnityCatalogParquetLoader(volume_path=str(missing), prefix="parquet")
+        DatabricksUnityParquetLoader(volume_path=str(missing), prefix="parquet")
 
 
 def test_validate_false_is_silent_on_missing_root(tmp_path):
     missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
     with warnings.catch_warnings():
         warnings.simplefilter("error", LoaderConfigWarning)
-        DatabricksUnityCatalogParquetLoader(
+        DatabricksUnityParquetLoader(
             volume_path=str(missing), prefix="parquet", validate=False
         )
 

--- a/tests/test_databricks_unity_parquet_loader.py
+++ b/tests/test_databricks_unity_parquet_loader.py
@@ -1,0 +1,228 @@
+import warnings
+from pathlib import Path
+
+import pandas as pd  # type: ignore
+import pytest
+
+from ts_shape.errors import LoaderConfigWarning
+from ts_shape.loader.timeseries.databricks_unity_parquet_loader import (
+    DatabricksUnityCatalogParquetLoader,
+)
+
+
+def _touch(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def _make_volume(tmp_path, prefix="parquet"):
+    """Build a mini mounted UC Volume tree with the canonical hourly layout.
+
+    Files are empty placeholders; tests monkeypatch ``pd.read_parquet`` so no
+    parquet engine is required (matching test_parquet_loader.py).
+    """
+    root = tmp_path / "Volumes" / "main" / "plant" / "timeseries"
+    base = root / prefix if prefix else root
+    _touch(base / "2024/01/01/09/u1.parquet")
+    _touch(base / "2024/01/01/10/u1.parquet")
+    _touch(base / "2024/01/01/11/u2.parquet")
+    return root
+
+
+def _fake_read_by_stem(p, columns=None, filters=None):
+    """Return a 1-row frame whose uuid is the file's stem (e.g. 'u1')."""
+    return pd.DataFrame({"uuid": [Path(p).stem]})
+
+
+def _loader(tmp_path, monkeypatch=None):
+    root = _make_volume(tmp_path)
+    loader = DatabricksUnityCatalogParquetLoader(volume_path=str(root), prefix="parquet")
+    if monkeypatch is not None:
+        monkeypatch.setattr(pd, "read_parquet", _fake_read_by_stem)
+    return loader, root
+
+
+def test_resolve_from_volume_path(tmp_path):
+    loader, root = _loader(tmp_path)
+    assert loader.base_path == root / "parquet"
+
+
+def test_resolve_from_catalog_parts(tmp_path):
+    root = _make_volume(tmp_path)
+    loader = DatabricksUnityCatalogParquetLoader(
+        catalog="main",
+        schema="plant",
+        volume="timeseries",
+        prefix="parquet",
+        base_path=str(tmp_path / "Volumes"),
+    )
+    assert loader.base_path == root / "parquet"
+
+
+def test_missing_parts_raises_value_error():
+    with pytest.raises(ValueError, match="volume_path"):
+        DatabricksUnityCatalogParquetLoader(catalog="main", schema="plant")
+
+
+def test_hour_dir_and_slots(tmp_path):
+    loader, _ = _loader(tmp_path)
+    hd = loader._hour_dir(pd.Timestamp("2024-01-01 09:05:00"))
+    assert str(hd).endswith("parquet/2024/01/01/09")
+    slots = list(loader._hourly_slots("2024-01-01 08:00:00", "2024-01-01 10:00:00"))
+    assert len(slots) == 3
+
+
+def test_load_all_and_list_structure(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    all_df = loader.load_all_files()
+    assert set(all_df["uuid"]) == {"u1", "u2"}
+
+    listed = loader.list_structure()
+    assert all(f.endswith(".parquet") for f in listed["files"])
+    assert len(listed["files"]) == 3
+    assert all(p.endswith("/") for p in listed["folders"])
+
+
+def test_load_by_time_range_visits_only_in_range_hours(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path)
+    visited: list[str] = []
+
+    def spy(p, columns=None, filters=None):
+        visited.append(str(p))
+        return _fake_read_by_stem(p)
+
+    monkeypatch.setattr(pd, "read_parquet", spy)
+    df = loader.load_by_time_range("2024-01-01 09:00:00", "2024-01-01 10:30:00")
+    assert set(df["uuid"]) == {"u1"}
+    # The 11:00 file must never have been read.
+    assert all("/11/" not in v for v in visited)
+
+
+def test_load_files_by_time_range_and_uuids(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    df = loader.load_files_by_time_range_and_uuids(
+        "2024-01-01 09:00:00", "2024-01-01 11:00:00", ["u2"]
+    )
+    assert set(df["uuid"]) == {"u2"}
+
+
+def test_load_files_by_uuids_unknown_warns(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    with pytest.warns(LoaderConfigWarning, match="No matching .parquet files"):
+        df = loader.load_files_by_time_range_and_uuids(
+            "2024-01-01 09:00:00", "2024-01-01 11:00:00", ["does-not-exist"]
+        )
+    assert df.empty
+
+
+def test_stream_by_time_range_is_incremental(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    out = list(
+        loader.stream_by_time_range("2024-01-01 09:00:00", "2024-01-01 11:00:00")
+    )
+    assert len(out) == 3
+    assert all(isinstance(p, str) and isinstance(d, pd.DataFrame) for p, d in out)
+
+
+def test_stream_by_time_range_empty_warns(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    with pytest.warns(LoaderConfigWarning, match="Yielded no DataFrames"):
+        out = list(
+            loader.stream_by_time_range("2030-01-01 00:00:00", "2030-01-01 00:00:00")
+        )
+    assert out == []
+
+
+def test_pushdown_passes_columns_and_filters(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path)
+    seen: dict = {}
+
+    def fake_read_parquet(path, columns=None, filters=None):
+        seen["columns"] = columns
+        seen["filters"] = filters
+        return pd.DataFrame({"uuid": ["u1"]})
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read_parquet)
+    df = loader.load_all_files(columns=["uuid"], filters=[("uuid", "==", "u1")])
+    assert not df.empty
+    assert seen["columns"] == ["uuid"]
+    assert seen["filters"] == [("uuid", "==", "u1")]
+
+
+def test_pushdown_defaults_none(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path)
+    seen: dict = {}
+
+    def fake_read_parquet(path, columns=None, filters=None):
+        seen["columns"] = columns
+        seen["filters"] = filters
+        return pd.DataFrame({"uuid": ["u1"]})
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read_parquet)
+    df = loader.load_all_files()
+    assert not df.empty
+    assert seen["columns"] is None
+    assert seen["filters"] is None
+
+
+def test_fetch_data_as_dataframe_time_range(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    df = loader.fetch_data_as_dataframe("2024-01-01 09:00:00", "2024-01-01 10:30:00")
+    assert set(df["uuid"]) == {"u1"}
+
+
+def test_fetch_data_as_dataframe_all(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    df = loader.fetch_data_as_dataframe()
+    assert set(df["uuid"]) == {"u1", "u2"}
+
+
+def test_load_all_empty_warns(tmp_path):
+    root = tmp_path / "Volumes" / "main" / "plant" / "empty"
+    (root / "parquet").mkdir(parents=True)
+    loader = DatabricksUnityCatalogParquetLoader(volume_path=str(root), prefix="parquet")
+    with pytest.warns(LoaderConfigWarning, match="No .parquet files"):
+        df = loader.load_all_files()
+    assert df.empty
+
+
+def test_load_by_time_range_outside_data_warns(tmp_path):
+    loader, _ = _loader(tmp_path)
+    with pytest.warns(LoaderConfigWarning, match="hour_pattern"):
+        df = loader.load_by_time_range("2030-01-01 00:00:00", "2030-01-01 00:00:00")
+    assert df.empty
+
+
+def test_happy_load_emits_no_warning(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path, monkeypatch)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LoaderConfigWarning)
+        df = loader.load_by_time_range("2024-01-01 09:00:00", "2024-01-01 10:30:00")
+    assert not df.empty
+
+
+def test_validate_warns_on_missing_root(tmp_path):
+    missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
+    with pytest.warns(LoaderConfigWarning, match="path does not exist"):
+        DatabricksUnityCatalogParquetLoader(volume_path=str(missing), prefix="parquet")
+
+
+def test_validate_false_is_silent_on_missing_root(tmp_path):
+    missing = tmp_path / "Volumes" / "main" / "plant" / "nope"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LoaderConfigWarning)
+        DatabricksUnityCatalogParquetLoader(
+            volume_path=str(missing), prefix="parquet", validate=False
+        )
+
+
+def test_filters_too_strict_warning_hint(tmp_path, monkeypatch):
+    loader, _ = _loader(tmp_path)
+    monkeypatch.setattr(
+        pd,
+        "read_parquet",
+        lambda path, columns=None, filters=None: pd.DataFrame(),
+    )
+    with pytest.warns(LoaderConfigWarning, match="filters argument may be too strict"):
+        df = loader.load_all_files(filters=[("value_double", ">", 1e9)])
+    assert df.empty


### PR DESCRIPTION
Load canonical parquet governed by Databricks Unity Catalog. UC exposes the
same parquet files already in cloud storage (an external UC Volume), so the
returned frames flow into every existing transformation, event detector,
Pipeline and DataIntegratorHybrid unchanged.

Designed for use inside Databricks notebooks/pipelines: reads directly from
the FUSE-mounted /Volumes/<catalog>/<schema>/<volume> path with
pandas.read_parquet. Keeps resource usage low -- no download step, no
databricks-sdk/network client, no new dependency; navigates only the in-range
hour folders (YYYY/MM/DD/HH), pushes columns/filters down to pyarrow, and
offers streaming generators so the driver never holds the full dataset.

Mirrors AzureBlobParquetLoader's public API (load_all_files,
load_by_time_range, stream_by_time_range, load/stream_files_by_time_range_
and_uuids, list_structure, fetch_data_as_dataframe) and reuses
LoaderConfigWarning for empty-result diagnostics. Registered as a lazy public
export; adds filesystem-based tests that need no parquet engine.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ML62W9dAuFXd4y6pwvVWkB