### PR TITLE
Add counter reset handling to PartProductionTracking

### DIFF
--- a/docs/modules/production/part-tracking.md
+++ b/docs/modules/production/part-tracking.md
@@ -39,16 +39,37 @@ print(hourly.head(10))
 
 | Method | Purpose | Returns |
 |--------|---------|---------|
-| `production_by_part(part_id_uuid, counter_uuid, window='1h')` | Count parts produced per part number per time window | DataFrame with window, part_id, and quantity |
-| `daily_production_summary(part_id_uuid, counter_uuid)` | Aggregate daily production totals by part number | DataFrame with date, part_id, and daily quantity |
-| `production_totals(part_id_uuid, counter_uuid)` | Compute total production by part number over the entire date range | DataFrame with part_id and total quantity |
+| `production_by_part(part_id_uuid, counter_uuid, window='1h', handle_resets=False)` | Count parts produced per part number per time window | DataFrame with window, part_id, and quantity (plus `resets` when `handle_resets=True`) |
+| `daily_production_summary(part_id_uuid, counter_uuid, handle_resets=False)` | Aggregate daily production totals by part number | DataFrame with date, part_id, and daily quantity |
+| `production_totals(part_id_uuid, counter_uuid, handle_resets=False)` | Compute total production by part number over the entire date range | DataFrame with part_id and total quantity |
+| `detect_resets(part_id_uuid, counter_uuid)` | Find when the counter was reset | DataFrame with timestamp, part_id, `count_before`, `count_after`, `drop` |
+
+---
+
+## Counter Resets
+
+Production counters are assumed to increase as parts are produced. Many counters reset back to zero (or a lower value) — at a shift change, a part change, or a controller restart. By default (`handle_resets=False`), a window where the counter drops reports `quantity = max(0, last_count - first_count)`, which **clamps to 0 and loses all production in that window**.
+
+Pass `handle_resets=True` to count production correctly across resets. The quantity is then the sum of per-reading increments, where a drop is treated as a reset that contributes the new counter value. The result gains a `resets` column counting resets per window.
+
+```python
+# Reset-aware hourly production
+hourly = pt.production_by_part(
+    part_id_uuid="part_id", counter_uuid="part_counter",
+    window="1h", handle_resets=True,
+)
+
+# Inspect exactly when the counter reset
+resets = pt.detect_resets(part_id_uuid="part_id", counter_uuid="part_counter")
+print(resets)   # timestamp, part_number, count_before, count_after, drop
+```
 
 ---
 
 ## Tips & Hints
 
-!!! tip "Handle counter resets at part changes"
-    When the part number changes, the counter may reset. The module handles this automatically, but verify your counter signal behavior — some PLCs maintain a running total while others reset per batch.
+!!! tip "Enable reset handling when counters reset"
+    If your counter resets at part changes, shift boundaries, or controller restarts, pass `handle_resets=True` so production is not silently dropped. Use `detect_resets()` first to confirm whether and when your counter resets.
 
 !!! info "Related modules"
     - [Line Throughput](line-throughput.md) — aggregate throughput without part-level breakdown

--- a/src/ts_shape/eventlog/archetypes.py
+++ b/src/ts_shape/eventlog/archetypes.py
@@ -216,6 +216,7 @@ ARCHETYPE_BY_METHOD: dict[tuple[str, str], str] = {
     ("PartProductionTracking", "daily_production_summary"): "aggregate",
     ("PartProductionTracking", "production_by_part"): "aggregate",
     ("PartProductionTracking", "production_totals"): "aggregate",
+    ("PartProductionTracking", "detect_resets"): "threshold",
     ("PerformanceLossTracking", "performance_by_shift"): "aggregate",
     ("PerformanceLossTracking", "performance_trend"): "aggregate",
     ("PerformanceLossTracking", "slow_periods"): "interval",

--- a/src/ts_shape/eventlog/taxonomy.py
+++ b/src/ts_shape/eventlog/taxonomy.py
@@ -1387,6 +1387,16 @@ REGISTRY: dict[tuple[str, str], LabelRule] = {
         objs=("asset", "part"),
         standard_attrs={"ts_shape:sample_count": None},
     ),
+    ("PartProductionTracking", "detect_resets"): _r(
+        "production.part.counter_reset",
+        _PR,
+        P,
+        objs=("asset", "part"),
+        standard_attrs={
+            "ts_shape:method": "counter_reset",
+            "ts_shape:direction": "decrease",
+        },
+    ),
     ("PerformanceLossTracking", "performance_by_shift"): _r(
         "production.performance.by_shift",
         _PR,

--- a/src/ts_shape/events/production/part_tracking.py
+++ b/src/ts_shape/events/production/part_tracking.py
@@ -311,7 +311,9 @@ class PartProductionTracking(Base):
             {
                 self.time_column: resets[self.time_column].values,
                 "part_number": resets["part_number"].values,
-                "count_before": resets["_prev"].astype(resets[value_column_counter].dtype).values,
+                "count_before": resets["_prev"]
+                .astype(resets[value_column_counter].dtype)
+                .values,
                 "count_after": resets[value_column_counter].values,
             }
         )
@@ -372,13 +374,14 @@ class PartProductionTracking(Base):
 
         hourly["date"] = hourly["start"].dt.date
 
-        agg = {"total_quantity": ("quantity", "sum"), "hours_active": ("start", "count")}
+        agg = {
+            "total_quantity": ("quantity", "sum"),
+            "hours_active": ("start", "count"),
+        }
         if handle_resets:
             agg["resets"] = ("resets", "sum")
 
-        daily = (
-            hourly.groupby(["date", "part_number"]).agg(**agg).reset_index()
-        )
+        daily = hourly.groupby(["date", "part_number"]).agg(**agg).reset_index()
 
         return daily
 
@@ -438,7 +441,10 @@ class PartProductionTracking(Base):
         if end_date:
             daily = daily[daily["date"] <= pd.to_datetime(end_date)]
 
-        agg = {"total_quantity": ("total_quantity", "sum"), "days_produced": ("date", "count")}
+        agg = {
+            "total_quantity": ("total_quantity", "sum"),
+            "days_produced": ("date", "count"),
+        }
         if handle_resets:
             agg["resets"] = ("resets", "sum")
 

--- a/src/ts_shape/events/production/part_tracking.py
+++ b/src/ts_shape/events/production/part_tracking.py
@@ -4,6 +4,14 @@ Simple, practical module for daily production reporting:
 - How many parts were produced?
 - Production by part number and time window
 - Daily summaries
+
+Counters are assumed to be monotonically increasing during normal
+operation. Many real-world counters reset back to zero (or to a lower
+value) - for example at a shift change, a part change, or a controller
+restart. A naive ``last - first`` calculation silently loses all of the
+production that happened in a window where a reset occurred. Pass
+``handle_resets=True`` to account for these resets, and use
+:meth:`PartProductionTracking.detect_resets` to inspect when they happened.
 """
 
 import logging
@@ -21,20 +29,33 @@ class PartProductionTracking(Base):
     - part_id_uuid: string signal with current part number
     - counter_uuid: monotonic counter for production count
 
+    The counter is expected to increase as parts are produced. If the
+    counter is reset during operation (back to zero or a lower value),
+    enable ``handle_resets`` so the reset is treated as new production
+    instead of being discarded.
+
     Example usage:
         tracker = PartProductionTracking(df)
 
-        # Hourly production by part
+        # Hourly production by part, accounting for counter resets
         hourly = tracker.production_by_part(
             part_id_uuid='part_number_signal',
             counter_uuid='counter_signal',
-            window='1h'
+            window='1h',
+            handle_resets=True,
         )
 
         # Daily summary
         daily = tracker.daily_production_summary(
             part_id_uuid='part_number_signal',
-            counter_uuid='counter_signal'
+            counter_uuid='counter_signal',
+            handle_resets=True,
+        )
+
+        # When did the counter reset?
+        resets = tracker.detect_resets(
+            part_id_uuid='part_number_signal',
+            counter_uuid='counter_signal',
         )
     """
 
@@ -53,77 +74,36 @@ class PartProductionTracking(Base):
         super().__init__(dataframe, column_name=time_column)
         self.time_column = time_column
 
-    def production_by_part(
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _merge_part_counter(
         self,
         part_id_uuid: str,
         counter_uuid: str,
-        *,
-        window: str = "1h",
-        value_column_part: str = "value_string",
-        value_column_counter: str = "value_integer",
-    ) -> pd.DataFrame:
-        """Calculate production quantity per part number.
+        value_column_part: str,
+        value_column_counter: str,
+    ) -> pd.DataFrame | None:
+        """Merge counter readings with the active part number.
 
-        Args:
-            part_id_uuid: UUID for part number signal
-            counter_uuid: UUID for production counter
-            window: Time window for aggregation (e.g., '1h', '8h', '1d')
-            value_column_part: Column containing part numbers
-            value_column_counter: Column containing counter values
-
-        Returns:
-            DataFrame with columns:
-            - start: Start of time window
-            - part_number: Part number/ID
-            - quantity: Parts produced in window
-            - first_count: Counter value at window start
-            - last_count: Counter value at window end
-
-        Example:
-            >>> production_by_part('part_id', 'counter', window='1h')
-                start         part_number  quantity  first_count  last_count
-            0   2024-01-01 08:00:00  PART_A       150       1000        1150
-            1   2024-01-01 09:00:00  PART_A       145       1150        1295
-            2   2024-01-01 10:00:00  PART_B       98        1295        1393
+        Returns a time-sorted DataFrame with the counter value and a
+        ``part_number`` column, or ``None`` if either signal is missing.
         """
-        # Get part ID changes
         part_data = (
             self.dataframe[self.dataframe["uuid"] == part_id_uuid]
             .copy()
             .sort_values(self.time_column)
         )
-
-        if part_data.empty:
-            return pd.DataFrame(
-                columns=[
-                    "start",
-                    "part_number",
-                    "quantity",
-                    "first_count",
-                    "last_count",
-                ]
-            )
-
-        part_data[self.time_column] = pd.to_datetime(part_data[self.time_column])
-
-        # Get counter data
         counter_data = (
             self.dataframe[self.dataframe["uuid"] == counter_uuid]
             .copy()
             .sort_values(self.time_column)
         )
 
-        if counter_data.empty:
-            return pd.DataFrame(
-                columns=[
-                    "start",
-                    "part_number",
-                    "quantity",
-                    "first_count",
-                    "last_count",
-                ]
-            )
+        if part_data.empty or counter_data.empty:
+            return None
 
+        part_data[self.time_column] = pd.to_datetime(part_data[self.time_column])
         counter_data[self.time_column] = pd.to_datetime(counter_data[self.time_column])
 
         # Merge part ID with counter data (backward fill - use most recent part)
@@ -145,6 +125,97 @@ class PartProductionTracking(Base):
             merged = merged.rename(columns={f"{value_column_part}_y": "part_number"})
 
         merged = merged.dropna(subset=["part_number"])
+        return merged
+
+    @staticmethod
+    def _add_increments(merged: pd.DataFrame, value_column_counter: str) -> None:
+        """Annotate a merged frame with per-reading production increments.
+
+        Adds three columns in place:
+        - ``_prev``: the previous counter reading
+        - ``_increment``: parts produced since the previous reading. A
+          decreasing counter is interpreted as a reset, so the increment
+          is the new counter value (production after the reset).
+        - ``_is_reset``: True where the counter decreased.
+
+        The first reading has no predecessor, so its increment is 0 - it
+        establishes the baseline rather than counting as production.
+        """
+        counter = merged[value_column_counter]
+        prev = counter.shift(1)
+        delta = counter - prev
+        is_reset = delta < 0
+
+        # On a reset, assume the counter dropped to (at most) zero and
+        # climbed to its current value, so the new value is the production.
+        increment = delta.where(~is_reset, counter).fillna(0)
+
+        merged["_prev"] = prev
+        merged["_increment"] = increment
+        merged["_is_reset"] = is_reset.fillna(False)
+
+    @staticmethod
+    def _empty_production_frame(handle_resets: bool) -> pd.DataFrame:
+        columns = ["start", "part_number", "quantity", "first_count", "last_count"]
+        if handle_resets:
+            columns.append("resets")
+        return pd.DataFrame(columns=columns)
+
+    def production_by_part(
+        self,
+        part_id_uuid: str,
+        counter_uuid: str,
+        *,
+        window: str = "1h",
+        value_column_part: str = "value_string",
+        value_column_counter: str = "value_integer",
+        handle_resets: bool = False,
+    ) -> pd.DataFrame:
+        """Calculate production quantity per part number.
+
+        Args:
+            part_id_uuid: UUID for part number signal
+            counter_uuid: UUID for production counter
+            window: Time window for aggregation (e.g., '1h', '8h', '1d')
+            value_column_part: Column containing part numbers
+            value_column_counter: Column containing counter values
+            handle_resets: When True, treat a decreasing counter as a reset
+                and count the production after the reset instead of losing
+                it. The result gains a ``resets`` column with the number of
+                resets observed in each window. When False (default), the
+                quantity is simply ``max(0, last_count - first_count)`` and a
+                window containing a reset reports 0.
+
+        Returns:
+            DataFrame with columns:
+            - start: Start of time window
+            - part_number: Part number/ID
+            - quantity: Parts produced in window
+            - first_count: Counter value at window start
+            - last_count: Counter value at window end
+            - resets: Number of counter resets in window (only when
+              ``handle_resets=True``)
+
+        Example:
+            >>> production_by_part('part_id', 'counter', window='1h')
+                start         part_number  quantity  first_count  last_count
+            0   2024-01-01 08:00:00  PART_A       150       1000        1150
+            1   2024-01-01 09:00:00  PART_A       145       1150        1295
+            2   2024-01-01 10:00:00  PART_B       98        1295        1393
+
+            With ``handle_resets=True``, a window where the counter drops
+            from 432 to 61 reports a quantity of 61 (and ``resets=1``)
+            instead of 0.
+        """
+        merged = self._merge_part_counter(
+            part_id_uuid, counter_uuid, value_column_part, value_column_counter
+        )
+
+        if merged is None or merged.empty:
+            return self._empty_production_frame(handle_resets)
+
+        if handle_resets:
+            self._add_increments(merged, value_column_counter)
 
         # Group by time window and part number
         merged = merged.set_index(self.time_column)
@@ -158,21 +229,31 @@ class PartProductionTracking(Base):
 
             first_count = group[value_column_counter].iloc[0]
             last_count = group[value_column_counter].iloc[-1]
-            quantity = max(0, last_count - first_count)
 
-            results.append(
-                {
-                    "start": start,
-                    "part_number": part_num,
-                    "quantity": quantity,
-                    "first_count": first_count,
-                    "last_count": last_count,
-                }
-            )
+            row = {
+                "start": start,
+                "part_number": part_num,
+                "first_count": first_count,
+                "last_count": last_count,
+            }
 
-        return pd.DataFrame(results)
+            if handle_resets:
+                row["quantity"] = int(group["_increment"].sum())
+                row["resets"] = int(group["_is_reset"].sum())
+            else:
+                row["quantity"] = max(0, last_count - first_count)
 
-    def daily_production_summary(
+            results.append(row)
+
+        if not results:
+            return self._empty_production_frame(handle_resets)
+
+        columns = ["start", "part_number", "quantity", "first_count", "last_count"]
+        if handle_resets:
+            columns.append("resets")
+        return pd.DataFrame(results)[columns]
+
+    def detect_resets(
         self,
         part_id_uuid: str,
         counter_uuid: str,
@@ -180,7 +261,10 @@ class PartProductionTracking(Base):
         value_column_part: str = "value_string",
         value_column_counter: str = "value_integer",
     ) -> pd.DataFrame:
-        """Daily production summary by part number.
+        """Find the points in time where the counter was reset.
+
+        A reset is any reading where the counter value is lower than the
+        previous reading.
 
         Args:
             part_id_uuid: UUID for part number signal
@@ -189,11 +273,79 @@ class PartProductionTracking(Base):
             value_column_counter: Column containing counter values
 
         Returns:
+            DataFrame with one row per reset and columns:
+            - <time_column>: Timestamp of the reading after the reset
+            - part_number: Active part number at the reset
+            - count_before: Counter value just before the reset
+            - count_after: Counter value just after the reset
+            - drop: How far the counter fell (count_before - count_after)
+
+        Example:
+            >>> detect_resets('part_id', 'counter')
+                systime              part_number  count_before  count_after  drop
+            0   2026-06-15 17:00:00  8842580      432           61           371
+            1   2026-06-16 19:00:00  9423376      854           0            854
+        """
+        columns = [
+            self.time_column,
+            "part_number",
+            "count_before",
+            "count_after",
+            "drop",
+        ]
+
+        merged = self._merge_part_counter(
+            part_id_uuid, counter_uuid, value_column_part, value_column_counter
+        )
+
+        if merged is None or merged.empty:
+            return pd.DataFrame(columns=columns)
+
+        self._add_increments(merged, value_column_counter)
+
+        resets = merged[merged["_is_reset"]].copy()
+        if resets.empty:
+            return pd.DataFrame(columns=columns)
+
+        out = pd.DataFrame(
+            {
+                self.time_column: resets[self.time_column].values,
+                "part_number": resets["part_number"].values,
+                "count_before": resets["_prev"].astype(resets[value_column_counter].dtype).values,
+                "count_after": resets[value_column_counter].values,
+            }
+        )
+        out["drop"] = out["count_before"] - out["count_after"]
+        return out.reset_index(drop=True)
+
+    def daily_production_summary(
+        self,
+        part_id_uuid: str,
+        counter_uuid: str,
+        *,
+        value_column_part: str = "value_string",
+        value_column_counter: str = "value_integer",
+        handle_resets: bool = False,
+    ) -> pd.DataFrame:
+        """Daily production summary by part number.
+
+        Args:
+            part_id_uuid: UUID for part number signal
+            counter_uuid: UUID for production counter
+            value_column_part: Column containing part numbers
+            value_column_counter: Column containing counter values
+            handle_resets: Account for counter resets (see
+                :meth:`production_by_part`). Adds a ``resets`` column with
+                the number of resets observed that day.
+
+        Returns:
             DataFrame with columns:
             - date: Production date
             - part_number: Part number/ID
             - total_quantity: Total parts produced that day
             - hours_active: Number of hours with production
+            - resets: Number of counter resets that day (only when
+              ``handle_resets=True``)
 
         Example:
             >>> daily_production_summary('part_id', 'counter')
@@ -208,23 +360,24 @@ class PartProductionTracking(Base):
             window="1h",
             value_column_part=value_column_part,
             value_column_counter=value_column_counter,
+            handle_resets=handle_resets,
         )
 
+        base_columns = ["date", "part_number", "total_quantity", "hours_active"]
+        if handle_resets:
+            base_columns.append("resets")
+
         if hourly.empty:
-            return pd.DataFrame(
-                columns=["date", "part_number", "total_quantity", "hours_active"]
-            )
+            return pd.DataFrame(columns=base_columns)
 
         hourly["date"] = hourly["start"].dt.date
 
-        daily = (
-            hourly.groupby(["date", "part_number"])
-            .agg({"quantity": "sum", "start": "count"})
-            .reset_index()
-        )
+        agg = {"total_quantity": ("quantity", "sum"), "hours_active": ("start", "count")}
+        if handle_resets:
+            agg["resets"] = ("resets", "sum")
 
-        daily = daily.rename(
-            columns={"quantity": "total_quantity", "start": "hours_active"}
+        daily = (
+            hourly.groupby(["date", "part_number"]).agg(**agg).reset_index()
         )
 
         return daily
@@ -238,6 +391,7 @@ class PartProductionTracking(Base):
         end_date: str | None = None,
         value_column_part: str = "value_string",
         value_column_counter: str = "value_integer",
+        handle_resets: bool = False,
     ) -> pd.DataFrame:
         """Total production by part number for a date range.
 
@@ -248,6 +402,9 @@ class PartProductionTracking(Base):
             end_date: End date 'YYYY-MM-DD' (optional)
             value_column_part: Column containing part numbers
             value_column_counter: Column containing counter values
+            handle_resets: Account for counter resets (see
+                :meth:`production_by_part`). Adds a ``resets`` column with
+                the total number of resets in the range.
 
         Returns:
             DataFrame with total production per part
@@ -264,12 +421,15 @@ class PartProductionTracking(Base):
             counter_uuid,
             value_column_part=value_column_part,
             value_column_counter=value_column_counter,
+            handle_resets=handle_resets,
         )
 
+        base_columns = ["part_number", "total_quantity", "days_produced"]
+        if handle_resets:
+            base_columns.append("resets")
+
         if daily.empty:
-            return pd.DataFrame(
-                columns=["part_number", "total_quantity", "days_produced"]
-            )
+            return pd.DataFrame(columns=base_columns)
 
         # Filter by date range
         daily["date"] = pd.to_datetime(daily["date"])
@@ -278,12 +438,10 @@ class PartProductionTracking(Base):
         if end_date:
             daily = daily[daily["date"] <= pd.to_datetime(end_date)]
 
-        totals = (
-            daily.groupby("part_number")
-            .agg({"total_quantity": "sum", "date": "count"})
-            .reset_index()
-        )
+        agg = {"total_quantity": ("total_quantity", "sum"), "days_produced": ("date", "count")}
+        if handle_resets:
+            agg["resets"] = ("resets", "sum")
 
-        totals = totals.rename(columns={"date": "days_produced"})
+        totals = daily.groupby("part_number").agg(**agg).reset_index()
 
         return totals

--- a/tests/test_production_tracking.py
+++ b/tests/test_production_tracking.py
@@ -229,6 +229,143 @@ def test_production_tracking_empty_data():
 
 
 # ============================================================================
+# Counter reset handling
+# ============================================================================
+
+
+@pytest.fixture
+def sample_reset_data():
+    """Production data where the counter resets mid-run and at a part change.
+
+    Part A: counter climbs, resets to 50 mid-run, climbs again.
+    Part B: starts after a reset from Part A's last value, then climbs.
+    """
+    rows = []
+
+    def add(uuid, t, **kw):
+        rows.append({"uuid": uuid, "systime": t, **kw})
+
+    # Part A: 188, 215, 335, 408, 432, [reset] 50, 120, 180
+    times_a = pd.date_range("2026-06-15 14:00:00", periods=8, freq="30min", tz="UTC")
+    counts_a = [188, 215, 335, 408, 432, 50, 120, 180]
+    for t, c in zip(times_a, counts_a):
+        add("production_counter", t, value_integer=c)
+        add("part_number", t, value_string="PART_A")
+
+    # Part B: [reset from 180] 61, 120, 164
+    times_b = pd.date_range("2026-06-15 18:00:00", periods=3, freq="30min", tz="UTC")
+    counts_b = [61, 120, 164]
+    for t, c in zip(times_b, counts_b):
+        add("production_counter", t, value_integer=c)
+        add("part_number", t, value_string="PART_B")
+
+    return pd.DataFrame(rows)
+
+
+def test_production_by_part_loses_production_without_reset_handling(sample_reset_data):
+    """Without reset handling, windows containing a reset under-report."""
+    tracker = PartProductionTracking(sample_reset_data)
+    result = tracker.production_by_part(
+        part_id_uuid="part_number",
+        counter_uuid="production_counter",
+        window="1h",
+    )
+
+    # The window with the reset (432 -> 50) clamps to 0, losing production.
+    reset_window = result[
+        (result["part_number"] == "PART_A") & (result["first_count"] == 432)
+    ]
+    assert (reset_window["quantity"] == 0).all()
+    assert "resets" not in result.columns
+
+
+def test_production_by_part_handles_resets(sample_reset_data):
+    """With reset handling, production after a reset is counted correctly."""
+    tracker = PartProductionTracking(sample_reset_data)
+    result = tracker.production_by_part(
+        part_id_uuid="part_number",
+        counter_uuid="production_counter",
+        window="1h",
+        handle_resets=True,
+    )
+
+    assert "resets" in result.columns
+
+    # True production for PART_A: 27+120+73+24+50+70+60 = 424
+    part_a_total = result[result["part_number"] == "PART_A"]["quantity"].sum()
+    assert part_a_total == 424
+
+    # True production for PART_B (first reading is a reset to 61): 61+59+44 = 164
+    part_b_total = result[result["part_number"] == "PART_B"]["quantity"].sum()
+    assert part_b_total == 164
+
+    # Two resets total: the mid-run reset and the part-change reset.
+    assert result["resets"].sum() == 2
+
+
+def test_detect_resets(sample_reset_data):
+    """detect_resets returns the timestamp and magnitude of each reset."""
+    tracker = PartProductionTracking(sample_reset_data)
+    resets = tracker.detect_resets(
+        part_id_uuid="part_number", counter_uuid="production_counter"
+    )
+
+    assert list(resets.columns) == [
+        "systime",
+        "part_number",
+        "count_before",
+        "count_after",
+        "drop",
+    ]
+    assert len(resets) == 2
+
+    # Mid-run reset of PART_A: 432 -> 50
+    mid = resets.iloc[0]
+    assert mid["part_number"] == "PART_A"
+    assert mid["count_before"] == 432
+    assert mid["count_after"] == 50
+    assert mid["drop"] == 382
+
+    # Part-change reset to PART_B: 180 -> 61
+    switch = resets.iloc[1]
+    assert switch["part_number"] == "PART_B"
+    assert switch["count_before"] == 180
+    assert switch["count_after"] == 61
+
+
+def test_detect_resets_none_when_monotonic(sample_production_data):
+    """A monotonic counter produces no reset events."""
+    tracker = PartProductionTracking(sample_production_data)
+    resets = tracker.detect_resets(
+        part_id_uuid="part_number", counter_uuid="production_counter"
+    )
+    assert resets.empty
+
+
+def test_daily_summary_and_totals_with_resets(sample_reset_data):
+    """Daily summary and totals expose reset counts and corrected quantities."""
+    tracker = PartProductionTracking(sample_reset_data)
+
+    daily = tracker.daily_production_summary(
+        part_id_uuid="part_number",
+        counter_uuid="production_counter",
+        handle_resets=True,
+    )
+    assert "resets" in daily.columns
+    assert daily["resets"].sum() == 2
+    assert daily[daily["part_number"] == "PART_A"]["total_quantity"].iloc[0] == 424
+
+    totals = tracker.production_totals(
+        part_id_uuid="part_number",
+        counter_uuid="production_counter",
+        handle_resets=True,
+    )
+    assert "resets" in totals.columns
+    assert totals[totals["part_number"] == "PART_A"]["total_quantity"].iloc[0] == 424
+    assert totals[totals["part_number"] == "PART_B"]["total_quantity"].iloc[0] == 164
+
+
+# ============================================================================
 # CycleTimeTracking Tests
 # ============================================================================
 


### PR DESCRIPTION
## Problem

`PartProductionTracking` computed `quantity = max(0, last_count - first_count)`. When a production counter reset within a window (back to zero or a lower value — common at shift changes, part changes, or controller restarts), `last_count - first_count` went negative and got clamped to **0**, silently discarding all production in that window.

Example rows that lost real parts:

```
2026-06-15T17:00:00  8842580  0  432  61   ← reset 432→61, real = 61, reported 0
2026-06-17T11:00:00  9423376  0  784  7    ← reset 784→7,  real = 7,  reported 0
2026-06-18T02:00:00  8853932  0  274  74   ← reset 274→74, real = 74, reported 0
```

## Changes

- **Opt-in `handle_resets` flag** on `production_by_part`, `daily_production_summary`, and `production_totals`. When `True`, quantity is the sum of per-reading increments, where a counter drop is treated as a reset contributing the new value. Adds a `resets` column counting resets per window/day/range.
- **New `detect_resets()` method** returning the exact point in time and magnitude of each reset (`count_before`, `count_after`, `drop`).
- Default behavior is unchanged (`handle_resets=False`), preserving backward compatibility.
- Updated tests (5 new) and docs.

## Verification

On a scenario reproducing the reported pattern (resets mid-run and at part changes), the old logic reported 219 parts; the reset-aware logic reports the true 588, confirmed by hand per part (PART_A = 424, PART_B = 164). All 26 tests in `test_production_tracking.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4RdVqWoB2FkRjBFaxForG

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4RdVqWoB2FkRjBFaxForG)_