### PR TITLE
docs: document counter reset handling for PartProductionTracking

### DIFF
--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -184,6 +184,34 @@ totals = tracker.production_totals(
 )
 ```
 
+### Handling counter resets
+
+Production counters are assumed to increase as parts are produced. Many counters reset back to zero (or a lower value) at a shift change, a part change, or a controller restart. By default the quantity is `max(0, last_count - first_count)`, so **any window where the counter drops reports 0 and silently loses that window's production**.
+
+Pass `handle_resets=True` to count production correctly across resets. The quantity becomes the sum of per-reading increments, where a drop is treated as a reset that contributes the new counter value. The result gains a `resets` column counting resets per window/day/range. The same flag is available on `daily_production_summary` and `production_totals`.
+
+```python
+# Reset-aware hourly production (adds a `resets` column)
+hourly = tracker.production_by_part(
+    part_id_uuid='part_number_signal',
+    counter_uuid='counter_signal',
+    window='1h',
+    handle_resets=True,
+)
+
+# Inspect exactly when and how far the counter reset
+resets = tracker.detect_resets(
+    part_id_uuid='part_number_signal',
+    counter_uuid='counter_signal',
+)
+#             systime  part_number  count_before  count_after  drop
+#  2026-06-15 17:00:00  8842580               432           61   371
+#  2026-06-16 19:00:00  9423376               854            0   854
+```
+
+!!! tip "Confirm reset behavior first"
+    Use `detect_resets()` to check whether and when your counter resets. If it never resets, the default (`handle_resets=False`) and the reset-aware result are identical; enable the flag whenever resets are expected.
+
 ---
 
 ## Cycle Time Tracking

--- a/docs/modules/production/part-tracking.md
+++ b/docs/modules/production/part-tracking.md
@@ -15,22 +15,41 @@ Use for part-level production reporting. Tracks how many of each part number wer
 
 ## Quick Example
 
+The tracker reads long-format timeseries data: one row per signal reading, identified by a `uuid` column. The part number lives in a string signal (`value_string`) and the production count in a counter signal (`value_integer`).
+
 ```python
 from ts_shape.events.production.part_tracking import PartProductionTracking
 import pandas as pd
 import numpy as np
 
-df = pd.DataFrame({
-    "timestamp": pd.date_range("2024-01-01 06:00", periods=480, freq="1min"),
-    "part_id": (["PN-100"]*160 + ["PN-200"]*160 + ["PN-100"]*160),
-    "part_counter": np.arange(1, 481),
-})
+t = pd.date_range("2024-01-01 06:00", periods=480, freq="1min")
 
-pt = PartProductionTracking(df, timestamp_column="timestamp")
+# Part-number signal (which part is running) and a counter signal
+parts = pd.DataFrame({
+    "uuid": "part_id",
+    "systime": t,
+    "value_string": (["PN-100"] * 160 + ["PN-200"] * 160 + ["PN-100"] * 160),
+})
+counter = pd.DataFrame({
+    "uuid": "part_counter",
+    "systime": t,
+    "value_integer": np.arange(1, 481),
+})
+df = pd.concat([parts, counter], ignore_index=True)
+
+pt = PartProductionTracking(df, time_column="systime")
 hourly = pt.production_by_part(part_id_uuid="part_id", counter_uuid="part_counter", window="1h")
 daily = pt.daily_production_summary(part_id_uuid="part_id", counter_uuid="part_counter")
 totals = pt.production_totals(part_id_uuid="part_id", counter_uuid="part_counter")
 print(hourly.head(10))
+
+# If the counter resets (shift/part change, controller restart), enable
+# reset handling so production is not silently dropped:
+hourly = pt.production_by_part(
+    part_id_uuid="part_id", counter_uuid="part_counter",
+    window="1h", handle_resets=True,
+)
+resets = pt.detect_resets(part_id_uuid="part_id", counter_uuid="part_counter")
 ```
 
 ---


### PR DESCRIPTION
Follow-up to #80, documenting the new counter-reset features on the dedicated pages.

## Changes

- **Production Monitoring guide** (`docs/guides/production.md`): added a "Handling counter resets" subsection to Part Production Tracking, covering the `handle_resets` flag and `detect_resets()`.
- **Part Tracking module page** (`docs/modules/production/part-tracking.md`): rewrote the Quick Example to use the real long-format `uuid` API and demonstrate reset handling. The previous example was non-functional — it used wide-format columns the API never reads and passed `timestamp_column=` (the constructor argument is `time_column`), which would raise `TypeError`. The corrected example is verified to run.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4RdVqWoB2FkRjBFaxForG

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4RdVqWoB2FkRjBFaxForG)_