### PR TITLE
Generic object detection from timeseries → OCEL 2.0 objects

### DIFF
--- a/docs/guides/eventlog/index.md
+++ b/docs/guides/eventlog/index.md
@@ -6,6 +6,7 @@ The `ts_shape.eventlog` package goes one step further with a **canonical event l
 
 !!! abstract "On this page vs. the rest of the Event Log guide"
     - **This page** — the canonical schema, quick start, and export modes.
+    - **[Object detection](objects.md)** — extract batches, serials, coils, recipes… as OCEL objects from id signals and link them to events.
     - **[Labelling standard & taxonomy](taxonomy.md)** — the activity-name rules, pack/family vocabularies, severity buckets, and standard attributes that make any two detectors compatible.
     - **[Adapter anatomy & custom adapters](adapters.md)** — how a detector's raw DataFrame becomes an `EventLog`, and how to override it.
 

--- a/docs/guides/eventlog/objects.md
+++ b/docs/guides/eventlog/objects.md
@@ -59,15 +59,23 @@ specs = object_specs_from_metadata(metadata_loader.to_df())  # reads `object_typ
 ## Detect objects and their relations
 
 ```python
-log = detect_objects(df, specs)        # an EventLog with NO events
+log = detect_objects(df, specs, hierarchy={"serial": "batch", "batch": "work_order"})
 log.objects          # one row per (oid, type)
-log.o2o              # serial part_of batch, etc. — inferred from interval overlap
+log.o2o              # serial part_of batch (declared hierarchy), else co_occurs
 log.object_changes   # presence lifecycle (active/released) + captured attributes
 ```
 
-Object-to-object relations come from interval overlap: when one object's presence
-interval sits wholly inside another's, the inner is `part_of` the outer (a serial
-inside a batch); otherwise overlapping objects are `co_active`.
+!!! warning "`part_of` is declared, not guessed"
+    A compositional `part_of` relation **cannot** be inferred from time alone — a
+    long-running `tool` or `shift` temporally contains every batch without owning
+    it. So ts-shape asserts `part_of` (child → parent) **only along a declared
+    `hierarchy`** (child type → parent type), when the child's presence overlaps
+    the parent's. Without a hierarchy, overlapping objects of different types get
+    the honest, symmetric `co_occurs` qualifier. Pass `infer_o2o=False` to skip
+    object-to-object relations entirely.
+
+An id is treated as present from when it appears until the **next** id on the same
+signal — so sparse sampling does not leave gaps that orphan events.
 
 ## Attach objects to any event log
 

--- a/docs/guides/eventlog/objects.md
+++ b/docs/guides/eventlog/objects.md
@@ -1,0 +1,102 @@
+# Object Detection: batches, serials, coils, recipes…
+
+The event packs answer *"what happened?"*. This layer answers *"to which **things**?"* —
+the batch, product, material, coil, serial, bundle, customer part-number, family,
+drum, tool, and recipe objects that events refer to. It is one **generic, declarative
+layer**, not another family of detectors: you describe which signals carry which
+object type, and the same run-length kernel that powers batch/traceability detection
+([`SegmentExtractor`](../../reference/index.md)) extracts every object's presence
+interval into the OCEL 2.0 [`objects` / `o2o` / `object_changes`](index.md#the-canonical-schema)
+tables. **New object types are added by data/config — never by writing code.**
+
+```mermaid
+flowchart LR
+    SIG["id signals<br/><i>value_string per uuid</i>"]
+    OI["object_intervals()<br/><i>run-length segmentation</i>"]
+    DO["detect_objects()<br/><i>objects + o2o + changes</i>"]
+    AO["attach_objects()<br/><i>link events by time</i>"]
+    LOG["EventLog<br/><i>OCEL 2.0</i>"]
+    SIG --> OI --> DO --> LOG
+    OI --> AO --> LOG
+    style DO fill:#0f2a3d,stroke:#38bdf8,color:#e0f2fe
+    style AO fill:#3d2a0f,stroke:#fbbf24,color:#fef3c7
+```
+
+## Declare the objects
+
+An `ObjectSpec` maps one signal to one object type. The `object_type` is
+auto-registered if it is not one of the standard 16, so `coil`, `drum`, `bundle`,
+`family`, `customer_partnumber`, … work out of the box.
+
+```python
+from ts_shape.eventlog import ObjectSpec, detect_objects
+
+specs = [
+    ObjectSpec("sig:batch",  "batch",  id_template="{type}:{value}"),
+    ObjectSpec("sig:serial", "serial", id_template="{type}:{value}"),
+    ObjectSpec("sig:coil",   "coil",   id_template="{type}:{value}"),   # auto-registered
+]
+```
+
+| Field | Purpose |
+|---|---|
+| `uuid` | The signal whose value column carries the object id. |
+| `object_type` | OCEL type; auto-registered if unknown. |
+| `value_column` | `value_string` (default) or `value_integer`. |
+| `min_duration` | Drop presence blips shorter than this. |
+| `id_template` | Render the oid — `"{value}"` or `"{type}:{value}"` to namespace. |
+| `attributes` | `{attr_name: signal_uuid}` captured into `object_changes`. |
+
+At scale, skip the hand-written list entirely — tag object types in your signal
+metadata and derive the specs:
+
+```python
+from ts_shape.eventlog import object_specs_from_metadata
+
+specs = object_specs_from_metadata(metadata_loader.to_df())  # reads `object_type` tags
+```
+
+## Detect objects and their relations
+
+```python
+log = detect_objects(df, specs)        # an EventLog with NO events
+log.objects          # one row per (oid, type)
+log.o2o              # serial part_of batch, etc. — inferred from interval overlap
+log.object_changes   # presence lifecycle (active/released) + captured attributes
+```
+
+Object-to-object relations come from interval overlap: when one object's presence
+interval sits wholly inside another's, the inner is `part_of` the outer (a serial
+inside a batch); otherwise overlapping objects are `co_active`.
+
+## Attach objects to any event log
+
+This is the end-to-end win. `attach_objects` links the output of **any** event
+detector to the detected objects by temporal containment — every event gets E2O
+relations to whatever batch / serial / coil was active at its timestamp, with **zero
+per-detector changes**.
+
+```python
+from ts_shape.eventlog import attach_objects, to_event_log
+
+ev_log = to_event_log(intervals, detector="MachineStateEvents.detect_run_idle")
+
+enriched = attach_objects(
+    ev_log, df, specs,
+    qualifiers={"batch": "during_batch", "serial": "identified_by", "coil": "made_of"},
+)
+# enriched.relations now links each run/idle event to its batch, serial and coil.
+```
+
+Because `detect_objects` returns a normal `EventLog`, you can also
+[`concat`](index.md) an objects-only log with any event log instead of attaching by
+time. Either way the result exports through `to_event_log_ocel` /
+`to_event_log_xes` like any other log.
+
+A full runnable walkthrough is in
+[`examples/object_detection_demo.py`](https://github.com/ts-shape/ts-shape/blob/main/examples/object_detection_demo.py).
+
+## See also
+
+- [Event Log overview](index.md) — the five OCEL 2.0 tables.
+- [Labelling standard & taxonomy](taxonomy.md) — the object-type vocabulary.

--- a/examples/object_detection_demo.py
+++ b/examples/object_detection_demo.py
@@ -1,0 +1,97 @@
+"""Object detection demo — extract OCEL 2.0 objects from id-bearing signals.
+
+Runs as-is, no data files::
+
+    python examples/object_detection_demo.py
+
+Shows the three-step methodology:
+  1. detect objects (batch / serial / coil) from identifier signals,
+  2. infer object-to-object relations (serial part_of batch) from overlap,
+  3. attach the detected objects to a real event detector's output by time —
+     so events gain rich object references with no per-detector code.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+import ts_shape
+from ts_shape.eventlog import (
+    ObjectSpec,
+    attach_objects,
+    detect_objects,
+    to_event_log,
+    to_event_log_ocel,
+)
+from ts_shape.events.production.machine_state import MachineStateEvents
+
+
+def main() -> None:
+    # 1. Synthesize identifier signals on one production line.
+    batch = ts_shape.make_id_signal(
+        "sig:batch", ["B1", "B2"], hold=30, source_uuid="line-1"
+    )
+    serial = ts_shape.make_id_signal(
+        "sig:serial",
+        ["S1", "S2", "S3", "S4", "S5", "S6"],
+        hold=10,
+        source_uuid="line-1",
+    )
+    coil = ts_shape.make_id_signal(
+        "sig:coil", ["C1", "C2"], hold=30, source_uuid="line-1"
+    )
+    df = pd.concat([batch, serial, coil], ignore_index=True)
+
+    specs = [
+        ObjectSpec("sig:batch", "batch", id_template="{type}:{value}"),
+        ObjectSpec("sig:serial", "serial", id_template="{type}:{value}"),
+        # 'coil' is not a standard type — auto-registered, no code needed.
+        ObjectSpec("sig:coil", "coil", id_template="{type}:{value}"),
+    ]
+
+    # 2. Detect objects + object-to-object relations.
+    obj_log = detect_objects(df, specs)
+    print("=" * 70)
+    print("Detected objects")
+    print("=" * 70)
+    print(obj_log.objects.to_string(index=False))
+    print("\nObject-to-object relations (overlap-inferred):")
+    print(obj_log.o2o.to_string(index=False))
+
+    # 3. Attach detected objects to a real event detector's output by time.
+    state = ts_shape.make_id_signal(
+        "sig:state", ["run", "idle", "run", "idle"], hold=15, source_uuid="line-1"
+    )
+    state["value_bool"] = state["value_string"].isin(["run"])
+    legacy = MachineStateEvents(state, run_state_uuid="sig:state").detect_run_idle()
+    legacy["source_uuid"] = "line-1"
+    ev_log = to_event_log(legacy, detector="MachineStateEvents.detect_run_idle")
+
+    enriched = attach_objects(
+        ev_log,
+        df,
+        specs,
+        qualifiers={
+            "batch": "during_batch",
+            "serial": "identified_by",
+            "coil": "made_of",
+        },
+    )
+
+    print("\n" + "=" * 70)
+    print("Events linked to detected objects (E2O relations)")
+    print("=" * 70)
+    print(enriched.relations.to_string(index=False))
+
+    tables = to_event_log_ocel(enriched)
+    print("\nUnified OCEL 2.0 log:")
+    print(f"  events:         {tables.events.shape}")
+    print(f"  objects:        {tables.objects.shape}")
+    print(f"  relations:      {tables.relations.shape}  (event-to-object)")
+    print(f"  o2o:            {tables.o2o.shape}  (object-to-object)")
+    print(f"  object_changes: {tables.object_changes.shape}  (lifecycle/attrs)")
+    print("\nNew object types are added by data/config — never by writing detectors.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/object_detection_demo.py
+++ b/examples/object_detection_demo.py
@@ -49,13 +49,15 @@ def main() -> None:
         ObjectSpec("sig:coil", "coil", id_template="{type}:{value}"),
     ]
 
-    # 2. Detect objects + object-to-object relations.
-    obj_log = detect_objects(df, specs)
+    # 2. Detect objects + object-to-object relations. `part_of` is asserted only
+    #    along a declared hierarchy (a serial belongs to a batch); pure temporal
+    #    overlap is reported honestly as `co_occurs`, never guessed as part_of.
+    obj_log = detect_objects(df, specs, hierarchy={"serial": "batch"})
     print("=" * 70)
     print("Detected objects")
     print("=" * 70)
     print(obj_log.objects.to_string(index=False))
-    print("\nObject-to-object relations (overlap-inferred):")
+    print("\nObject-to-object relations (declared hierarchy → part_of):")
     print(obj_log.o2o.to_string(index=False))
 
     # 3. Attach detected objects to a real event detector's output by time.
@@ -71,6 +73,7 @@ def main() -> None:
         ev_log,
         df,
         specs,
+        hierarchy={"serial": "batch"},
         qualifiers={
             "batch": "during_batch",
             "serial": "identified_by",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Shift Reports & KPIs: guides/reporting.md
   - Event Log (XES & OCEL):
     - Overview: guides/eventlog/index.md
+    - Object Detection: guides/eventlog/objects.md
     - Labelling Standard & Taxonomy: guides/eventlog/taxonomy.md
     - Adapter Anatomy & Custom Adapters: guides/eventlog/adapters.md
   - Event Handling — Visual Overview: guides/event-handling-flow.md

--- a/src/ts_shape/__init__.py
+++ b/src/ts_shape/__init__.py
@@ -130,6 +130,7 @@ _LAZY: dict[str, str] = {
     # -- top-level utilities --------------------------------------------
     "list_detectors": "ts_shape.catalog",
     "make_timeseries": "ts_shape.datasets",
+    "make_id_signal": "ts_shape.datasets",
     "UnitConverter": "ts_shape.transform.calculator.unit_conversion",
     "Pipeline": "ts_shape.pipeline",
 }
@@ -140,6 +141,11 @@ _EVENTLOG_NAMES = (
     "BacktestResult",
     "EventLog",
     "OCEL2Tables",
+    "ObjectSpec",
+    "attach_objects",
+    "detect_objects",
+    "object_intervals",
+    "object_specs_from_metadata",
     "align_columns",
     "LabelRule",
     "LambdaDetector",

--- a/src/ts_shape/datasets.py
+++ b/src/ts_shape/datasets.py
@@ -94,3 +94,61 @@ def make_timeseries(
         frames.append(frame)
 
     return pd.concat(frames, ignore_index=True)
+
+
+def make_id_signal(
+    uuid: str = "object:id",
+    values: Sequence[str] = ("A", "B", "C"),
+    *,
+    hold: int = 10,
+    freq: str = "30s",
+    start: str = "2025-01-01 00:00:00",
+    value_column: str = "value_string",
+    source_uuid: str | None = None,
+) -> pd.DataFrame:
+    """Generate a categorical *identifier* signal in the standard schema.
+
+    Each value in ``values`` is held for ``hold`` consecutive samples, so the
+    signal looks like a real batch / serial / coil / recipe id stream that
+    changes over time. Feed it to :mod:`ts_shape.eventlog.objects` to extract
+    object instances.
+
+    Args:
+        uuid: Signal identifier.
+        values: Ordered id values; each held for ``hold`` samples.
+        hold: Samples each value persists before the next one starts.
+        freq: Pandas offset alias for the sampling interval.
+        start: Timestamp of the first sample.
+        value_column: Which column carries the id (``value_string`` or
+            ``value_integer``).
+        source_uuid: Optional ``source_uuid`` to stamp on every row.
+
+    Returns:
+        DataFrame with the standard ts-shape columns, ``value_column`` filled.
+    """
+    if value_column not in ("value_string", "value_integer"):
+        raise ValueError("value_column must be 'value_string' or 'value_integer'")
+    if hold <= 0:
+        raise ValueError(f"hold must be positive; got {hold}")
+
+    n = len(values) * hold
+    times = pd.date_range(start=start, periods=n, freq=freq)
+    seq = [v for v in values for _ in range(hold)]
+    frame = pd.DataFrame(
+        {
+            "systime": times,
+            "uuid": uuid,
+            "value_bool": pd.NA,
+            "value_integer": pd.NA,
+            "value_double": np.nan,
+            "value_string": pd.NA,
+            "is_delta": False,
+        }
+    )
+    if value_column == "value_integer":
+        frame["value_integer"] = pd.array(seq, dtype="Int64")
+    else:
+        frame["value_string"] = pd.array([str(v) for v in seq], dtype="string")
+    if source_uuid is not None:
+        frame["source_uuid"] = source_uuid
+    return frame

--- a/src/ts_shape/eventlog/__init__.py
+++ b/src/ts_shape/eventlog/__init__.py
@@ -45,6 +45,13 @@ from .lambda_rules import (
 )
 from .model import EventLog
 from .normalizer import to_event_log
+from .objects import (
+    ObjectSpec,
+    attach_objects,
+    detect_objects,
+    object_intervals,
+    object_specs_from_metadata,
+)
 from .ocel import OCEL2Tables, to_event_log_ocel
 from .schema import (
     OCEL_ACTIVITY,
@@ -78,7 +85,12 @@ __all__ = [
     "BacktestResult",
     "EventLog",
     "OCEL2Tables",
+    "ObjectSpec",
     "align_columns",
+    "attach_objects",
+    "detect_objects",
+    "object_intervals",
+    "object_specs_from_metadata",
     "LabelRule",
     "LambdaDetector",
     "REGISTRY",

--- a/src/ts_shape/eventlog/objects.py
+++ b/src/ts_shape/eventlog/objects.py
@@ -8,17 +8,18 @@ events refer to.
 
 It is deliberately **one generic, declarative layer**, not another family of
 detector classes: you describe which signals carry which object type with an
-:class:`ObjectSpec` (or discover them from metadata), and the same run-length
-kernel that powers batch/traceability detection
-(:meth:`ts_shape.features.segment_analysis.segment_extractor.SegmentExtractor.extract_time_ranges`)
+:class:`ObjectSpec` (or discover them from metadata), and a run-length kernel
+(the same value-change segmentation that powers batch/traceability detection)
 extracts every object's presence interval. New object types are added by *data /
 config*, never by code.
 
 Three steps, all feeding the OCEL 2.0 tables on :class:`~ts_shape.eventlog.model.EventLog`:
 
-* :func:`object_intervals` — segment id signals into ``(oid, type, start, end)``.
+* :func:`object_intervals` — segment id signals into ``(oid, type, start, end)``
+  presence intervals (an id is present until the next id on the same signal).
 * :func:`detect_objects` — build the ``objects`` / ``o2o`` / ``object_changes``
-  tables (object-to-object relations inferred from interval overlap).
+  tables. ``part_of`` is asserted only along a declared ``hierarchy`` (it cannot
+  be inferred from time alone); other overlaps are reported as ``co_occurs``.
 * :func:`attach_objects` — link an existing event log's events to the detected
   objects by temporal containment, so the output of *every* event detector gains
   rich object references with no per-detector changes.
@@ -31,7 +32,6 @@ from dataclasses import dataclass, field
 
 import pandas as pd
 
-from ..features.segment_analysis.segment_extractor import SegmentExtractor
 from . import schema
 from .concat import concat
 from .model import EventLog
@@ -49,6 +49,50 @@ def _to_utc(values: object) -> pd.Series:
     if s.dt.tz is None:
         return s.dt.tz_localize("UTC")
     return s.dt.tz_convert("UTC")
+
+
+def _segments(
+    df: pd.DataFrame,
+    segment_uuid: str,
+    *,
+    uuid_column: str,
+    value_column: str,
+    time_column: str,
+    min_duration: str | None,
+) -> pd.DataFrame:
+    """Run-length encode one signal into constant-value segments.
+
+    Returns ``value / start / end`` (observed first/last sample per segment).
+    Unlike a naive ``value.ne(value.shift())`` the first sample always opens a
+    segment, so neither the leading object nor a single-sample object is lost.
+    """
+    sig = df[df[uuid_column] == segment_uuid]
+    cols = ["value", "start", "end"]
+    if sig.empty:
+        return pd.DataFrame(columns=cols)
+
+    sig = sig.sort_values(time_column)
+    times = _to_utc(sig[time_column]).reset_index(drop=True)
+    vals = sig[value_column].ffill().reset_index(drop=True)
+    changed = vals.ne(vals.shift())
+    changed.iloc[0] = True  # the first sample always starts a segment
+    groups = changed.cumsum().to_numpy()
+
+    work = pd.DataFrame(
+        {"value": vals.to_numpy(), "start": times, "end": times, "_g": groups}
+    )
+    agg = work.groupby("_g", sort=True).agg(
+        value=("value", "first"), start=("start", "min"), end=("end", "max")
+    )
+
+    value = agg["value"]
+    blank = value.map(lambda v: isinstance(v, str) and v.strip() == "")
+    agg = agg[value.notna() & ~blank].reset_index(drop=True)
+
+    if min_duration is not None and not agg.empty:
+        keep = (agg["end"] - agg["start"]) >= pd.Timedelta(min_duration)
+        agg = agg[keep].reset_index(drop=True)
+    return agg
 
 
 @dataclass(frozen=True)
@@ -90,17 +134,17 @@ def object_intervals(
     """Extract one presence interval per object instance from id signals.
 
     Returns a tidy frame with columns ``oid``, ``type``, ``start``, ``end`` plus
-    one column per captured attribute. Reuses
-    :meth:`SegmentExtractor.extract_time_ranges` as the run-length kernel.
+    one column per captured attribute. Each id signal is run-length encoded into
+    contiguous constant-value segments.
     """
     frames: list[pd.DataFrame] = []
     for spec in specs:
         if not schema.is_known_object_type(spec.object_type):
             schema.register_object_type(spec.object_type)
 
-        segs = SegmentExtractor.extract_time_ranges(
+        segs = _segments(
             df,
-            segment_uuid=spec.uuid,
+            spec.uuid,
             uuid_column=uuid_column,
             value_column=spec.value_column,
             time_column=time_column,
@@ -109,15 +153,22 @@ def object_intervals(
         if segs.empty:
             continue
 
+        starts = segs["start"].reset_index(drop=True)
+        observed_ends = segs["end"].reset_index(drop=True)
+        # An id is present until the *next* id on the same signal appears, so a
+        # gap between segments (sparse sampling) does not orphan events that land
+        # in it. The final segment keeps its last observed sample as the end.
+        next_starts = starts.shift(-1)
+        ends = next_starts.where(next_starts.notna(), observed_ends)
         out = pd.DataFrame(
             {
                 _OID: [
                     spec.id_template.format(value=v, type=spec.object_type)
-                    for v in segs["segment_value"]
+                    for v in segs["value"]
                 ],
                 _TYPE: spec.object_type,
-                _START: _to_utc(segs["segment_start"].values),
-                _END: _to_utc(segs["segment_end"].values),
+                _START: starts,
+                _END: ends,
             }
         )
         for attr_name, attr_uuid in spec.attributes.items():
@@ -173,22 +224,32 @@ def detect_objects(
     *,
     uuid_column: str = "uuid",
     time_column: str = "systime",
+    hierarchy: Mapping[str, str] | None = None,
     infer_o2o: bool = True,
     validate: bool = True,
 ) -> EventLog:
     """Detect object instances and build their OCEL 2.0 tables.
 
     Produces an :class:`EventLog` with **no events** — only ``objects``, ``o2o``
-    (object-to-object relations inferred from interval overlap), and
-    ``object_changes`` (presence lifecycle + captured attributes). Compose it
-    with event-detector logs via :func:`~ts_shape.eventlog.concat.concat`.
+    (object-to-object relations), and ``object_changes`` (presence lifecycle +
+    captured attributes). Compose it with event-detector logs via
+    :func:`~ts_shape.eventlog.concat.concat`.
+
+    ``hierarchy`` maps a child object type to its parent type
+    (e.g. ``{"serial": "batch", "batch": "work_order"}``). A compositional
+    ``part_of`` relation is asserted **only** along these declared edges, when a
+    child's presence overlaps a parent's — because *part_of cannot be inferred
+    from time alone* (a long-running tool temporally contains every batch
+    without owning it). Without a declared hierarchy, overlapping objects of
+    different types get the honest, symmetric ``co_occurs`` qualifier instead.
+    Set ``infer_o2o=False`` to skip object-to-object relations entirely.
     """
     intervals = object_intervals(
         df, specs, uuid_column=uuid_column, time_column=time_column
     )
     log = EventLog(
         objects=_objects_table(intervals),
-        o2o=_infer_o2o(intervals) if infer_o2o else schema.empty_o2o(),
+        o2o=_infer_o2o(intervals, hierarchy) if infer_o2o else schema.empty_o2o(),
         object_changes=_object_changes(intervals, specs),
     )
     if validate:
@@ -204,6 +265,7 @@ def attach_objects(
     qualifiers: Mapping[str, str] | None = None,
     uuid_column: str = "uuid",
     time_column: str = "systime",
+    hierarchy: Mapping[str, str] | None = None,
     infer_o2o: bool = True,
     validate: bool = True,
 ) -> EventLog:
@@ -212,7 +274,8 @@ def attach_objects(
     For every event, any object whose presence interval contains the event
     timestamp is linked with an event-to-object (E2O) relation. The detected
     objects, ``o2o`` and ``object_changes`` are merged in. This enriches the
-    output of *any* event detector — no per-detector changes required.
+    output of *any* event detector — no per-detector changes required. See
+    :func:`detect_objects` for ``hierarchy`` (declared ``part_of`` edges).
     """
     intervals = object_intervals(
         df, specs, uuid_column=uuid_column, time_column=time_column
@@ -222,6 +285,7 @@ def attach_objects(
         specs,
         uuid_column=uuid_column,
         time_column=time_column,
+        hierarchy=hierarchy,
         infer_o2o=infer_o2o,
         validate=False,
     )
@@ -336,46 +400,76 @@ def _change_row(r: pd.Series, field_name: str, value: object, ts: object) -> dic
     }
 
 
-def _infer_o2o(intervals: pd.DataFrame) -> pd.DataFrame:
+def _infer_o2o(
+    intervals: pd.DataFrame, hierarchy: Mapping[str, str] | None
+) -> pd.DataFrame:
     """Object-to-object relations from interval overlap between distinct types.
 
-    One relation per overlapping pair: strict containment (one interval wholly
-    inside the other) → ``child part_of parent``; any other overlap →
-    ``co_active``. Each unordered type pair is visited once.
+    With a declared ``hierarchy`` (child type -> parent type), a child whose
+    presence overlaps a parent's gets ``part_of`` (child -> parent). Otherwise
+    overlapping objects of different types get the honest symmetric
+    ``co_occurs`` qualifier — ``part_of`` is never guessed from time alone.
     """
     if intervals.empty:
         return schema.empty_o2o()
+    return (
+        _hierarchy_o2o(intervals, hierarchy)
+        if hierarchy
+        else _cooccurrence_o2o(intervals)
+    )
+
+
+def _hierarchy_o2o(
+    intervals: pd.DataFrame, hierarchy: Mapping[str, str]
+) -> pd.DataFrame:
+    rows: list[dict] = []
+    for child_type, parent_type in hierarchy.items():
+        children = _non_degenerate(intervals[intervals[_TYPE] == child_type])
+        parents = _non_degenerate(intervals[intervals[_TYPE] == parent_type])
+        if children.empty or parents.empty:
+            continue
+        pidx = pd.IntervalIndex.from_arrays(
+            parents[_START], parents[_END], closed="left"
+        )
+        for _, c in children.iterrows():
+            c_int = pd.Interval(c[_START], c[_END], closed="left")
+            for pos in _overlapping_positions(pidx, c_int):
+                parent = parents.iloc[pos]
+                if c[_OID] != parent[_OID]:
+                    rows.append(_o2o_row(c[_OID], parent[_OID], "part_of"))
+    return _o2o_frame(rows)
+
+
+def _cooccurrence_o2o(intervals: pd.DataFrame) -> pd.DataFrame:
     types = sorted(pd.unique(intervals[_TYPE]))
-    by_type = {t: intervals[intervals[_TYPE] == t] for t in types}
+    by_type = {t: _non_degenerate(intervals[intervals[_TYPE] == t]) for t in types}
     rows: list[dict] = []
     for i, ta in enumerate(types):
         for tb in types[i + 1 :]:
             b = by_type[tb]
-            if b.empty:
+            if b.empty or by_type[ta].empty:
                 continue
-            bidx = pd.IntervalIndex.from_arrays(b[_START], b[_END], closed="both")
+            bidx = pd.IntervalIndex.from_arrays(b[_START], b[_END], closed="left")
             for _, a in by_type[ta].iterrows():
-                a_int = pd.Interval(a[_START], a[_END], closed="both")
+                a_int = pd.Interval(a[_START], a[_END], closed="left")
                 for pos in _overlapping_positions(bidx, a_int):
                     brow = b.iloc[pos]
-                    if a[_OID] == brow[_OID]:
-                        continue
-                    rows.append(_relate(a, brow))
+                    if a[_OID] != brow[_OID]:
+                        rows.append(_o2o_row(a[_OID], brow[_OID], "co_occurs"))
+    return _o2o_frame(rows)
+
+
+def _non_degenerate(frame: pd.DataFrame) -> pd.DataFrame:
+    """Drop zero-length presence intervals (start == end) — they overlap nothing
+    meaningfully and are invalid for a half-open IntervalIndex."""
+    return frame[frame[_START] < frame[_END]]
+
+
+def _o2o_frame(rows: list[dict]) -> pd.DataFrame:
     if not rows:
         return schema.empty_o2o()
     out = pd.DataFrame(rows).drop_duplicates().reset_index(drop=True)
     return out.astype(schema.empty_o2o().dtypes.to_dict())
-
-
-def _relate(a: pd.Series, b: pd.Series) -> dict:
-    """One O2O row for an overlapping pair (strict containment → part_of)."""
-    a_in_b = b[_START] <= a[_START] and a[_END] <= b[_END]
-    b_in_a = a[_START] <= b[_START] and b[_END] <= a[_END]
-    if a_in_b and not b_in_a:
-        return _o2o_row(a[_OID], b[_OID], "part_of")  # a (child) part_of b
-    if b_in_a and not a_in_b:
-        return _o2o_row(b[_OID], a[_OID], "part_of")  # b (child) part_of a
-    return _o2o_row(a[_OID], b[_OID], "co_active")
 
 
 def _overlapping_positions(index: pd.IntervalIndex, interval: pd.Interval) -> list[int]:

--- a/src/ts_shape/eventlog/objects.py
+++ b/src/ts_shape/eventlog/objects.py
@@ -1,0 +1,420 @@
+"""Object detection — turn identifier-bearing timeseries signals into OCEL 2.0
+objects, relations, and time-varying attributes.
+
+The event packs answer *"what happened?"*. This module answers *"to which
+**things**?"* — the batches, serials, coils, recipes, tools, materials, drums,
+bundles, families, customer part-numbers (and any other object out there) that
+events refer to.
+
+It is deliberately **one generic, declarative layer**, not another family of
+detector classes: you describe which signals carry which object type with an
+:class:`ObjectSpec` (or discover them from metadata), and the same run-length
+kernel that powers batch/traceability detection
+(:meth:`ts_shape.features.segment_analysis.segment_extractor.SegmentExtractor.extract_time_ranges`)
+extracts every object's presence interval. New object types are added by *data /
+config*, never by code.
+
+Three steps, all feeding the OCEL 2.0 tables on :class:`~ts_shape.eventlog.model.EventLog`:
+
+* :func:`object_intervals` — segment id signals into ``(oid, type, start, end)``.
+* :func:`detect_objects` — build the ``objects`` / ``o2o`` / ``object_changes``
+  tables (object-to-object relations inferred from interval overlap).
+* :func:`attach_objects` — link an existing event log's events to the detected
+  objects by temporal containment, so the output of *every* event detector gains
+  rich object references with no per-detector changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from ..features.segment_analysis.segment_extractor import SegmentExtractor
+from . import schema
+from .concat import concat
+from .model import EventLog
+
+# Tidy intermediate columns (used between the three steps).
+_OID = "oid"
+_TYPE = "type"
+_START = "start"
+_END = "end"
+
+
+def _to_utc(values: object) -> pd.Series:
+    """Coerce timestamps to a tz-aware UTC Series (OCEL columns are UTC)."""
+    s = pd.to_datetime(pd.Series(values))
+    if s.dt.tz is None:
+        return s.dt.tz_localize("UTC")
+    return s.dt.tz_convert("UTC")
+
+
+@dataclass(frozen=True)
+class ObjectSpec:
+    """Declares that one signal carries the identity of one object type.
+
+    Attributes:
+        uuid: The signal (``uuid`` value) whose value column is the object id.
+        object_type: OCEL object type, e.g. ``"batch"``, ``"coil"``, ``"serial"``,
+            ``"recipe"``. Auto-registered via
+            :func:`~ts_shape.eventlog.schema.register_object_type` if unknown.
+        value_column: Column carrying the id (``"value_string"`` or
+            ``"value_integer"``).
+        min_duration: Optional minimum presence (e.g. ``"1min"``); shorter blips
+            are dropped.
+        id_template: How to render the object id from the raw value. Supports
+            ``{value}`` and ``{type}`` — default ``"{value}"``; use
+            ``"{type}:{value}"`` to namespace ids across types.
+        attributes: ``{attribute_name: signal_uuid}`` — values captured at each
+            presence start (backward ``merge_asof``) and emitted as
+            ``object_changes``.
+    """
+
+    uuid: str
+    object_type: str
+    value_column: str = "value_string"
+    min_duration: str | None = None
+    id_template: str = "{value}"
+    attributes: Mapping[str, str] = field(default_factory=dict)
+
+
+def object_intervals(
+    df: pd.DataFrame,
+    specs: Sequence[ObjectSpec],
+    *,
+    uuid_column: str = "uuid",
+    time_column: str = "systime",
+) -> pd.DataFrame:
+    """Extract one presence interval per object instance from id signals.
+
+    Returns a tidy frame with columns ``oid``, ``type``, ``start``, ``end`` plus
+    one column per captured attribute. Reuses
+    :meth:`SegmentExtractor.extract_time_ranges` as the run-length kernel.
+    """
+    frames: list[pd.DataFrame] = []
+    for spec in specs:
+        if not schema.is_known_object_type(spec.object_type):
+            schema.register_object_type(spec.object_type)
+
+        segs = SegmentExtractor.extract_time_ranges(
+            df,
+            segment_uuid=spec.uuid,
+            uuid_column=uuid_column,
+            value_column=spec.value_column,
+            time_column=time_column,
+            min_duration=spec.min_duration,
+        )
+        if segs.empty:
+            continue
+
+        out = pd.DataFrame(
+            {
+                _OID: [
+                    spec.id_template.format(value=v, type=spec.object_type)
+                    for v in segs["segment_value"]
+                ],
+                _TYPE: spec.object_type,
+                _START: _to_utc(segs["segment_start"].values),
+                _END: _to_utc(segs["segment_end"].values),
+            }
+        )
+        for attr_name, attr_uuid in spec.attributes.items():
+            out[attr_name] = _capture_attribute(
+                df, attr_uuid, out[_START], uuid_column, time_column, spec.value_column
+            )
+        frames.append(out)
+
+    if not frames:
+        return pd.DataFrame(columns=[_OID, _TYPE, _START, _END])
+    result = pd.concat(frames, ignore_index=True)
+    result[_OID] = result[_OID].astype("string")
+    result[_TYPE] = result[_TYPE].astype("string")
+    return result
+
+
+def _capture_attribute(
+    df: pd.DataFrame,
+    attr_uuid: str,
+    starts: pd.Series,
+    uuid_column: str,
+    time_column: str,
+    value_column: str,
+) -> pd.Series:
+    """Value of ``attr_uuid`` in effect at each presence start (backward asof)."""
+    sig = df[df[uuid_column] == attr_uuid]
+    if sig.empty:
+        return pd.Series([pd.NA] * len(starts))
+    # Pick the first populated value column for the attribute signal.
+    col = next(
+        (
+            c
+            for c in (value_column, "value_string", "value_double", "value_integer")
+            if c in sig.columns and sig[c].notna().any()
+        ),
+        value_column,
+    )
+    sig = sig[[time_column, col]].copy()
+    sig[time_column] = _to_utc(sig[time_column])
+    sig = sig.sort_values(time_column)
+    left = pd.DataFrame({time_column: _to_utc(starts.values)})
+    order = left[time_column].argsort()
+    merged = pd.merge_asof(
+        left.iloc[order.values], sig, on=time_column, direction="backward"
+    )
+    # Restore original (presence) order.
+    return merged[col].iloc[order.argsort().values].reset_index(drop=True)
+
+
+def detect_objects(
+    df: pd.DataFrame,
+    specs: Sequence[ObjectSpec],
+    *,
+    uuid_column: str = "uuid",
+    time_column: str = "systime",
+    infer_o2o: bool = True,
+    validate: bool = True,
+) -> EventLog:
+    """Detect object instances and build their OCEL 2.0 tables.
+
+    Produces an :class:`EventLog` with **no events** — only ``objects``, ``o2o``
+    (object-to-object relations inferred from interval overlap), and
+    ``object_changes`` (presence lifecycle + captured attributes). Compose it
+    with event-detector logs via :func:`~ts_shape.eventlog.concat.concat`.
+    """
+    intervals = object_intervals(
+        df, specs, uuid_column=uuid_column, time_column=time_column
+    )
+    log = EventLog(
+        objects=_objects_table(intervals),
+        o2o=_infer_o2o(intervals) if infer_o2o else schema.empty_o2o(),
+        object_changes=_object_changes(intervals, specs),
+    )
+    if validate:
+        schema.validate(log)
+    return log
+
+
+def attach_objects(
+    event_log: EventLog,
+    df: pd.DataFrame,
+    specs: Sequence[ObjectSpec],
+    *,
+    qualifiers: Mapping[str, str] | None = None,
+    uuid_column: str = "uuid",
+    time_column: str = "systime",
+    infer_o2o: bool = True,
+    validate: bool = True,
+) -> EventLog:
+    """Link an existing event log to detected objects by temporal containment.
+
+    For every event, any object whose presence interval contains the event
+    timestamp is linked with an event-to-object (E2O) relation. The detected
+    objects, ``o2o`` and ``object_changes`` are merged in. This enriches the
+    output of *any* event detector — no per-detector changes required.
+    """
+    intervals = object_intervals(
+        df, specs, uuid_column=uuid_column, time_column=time_column
+    )
+    detected = detect_objects(
+        df,
+        specs,
+        uuid_column=uuid_column,
+        time_column=time_column,
+        infer_o2o=infer_o2o,
+        validate=False,
+    )
+    merged = concat(event_log, detected)
+
+    rels = _contained_relations(event_log.events, intervals, qualifiers or {})
+    if not rels.empty:
+        merged.relations = (
+            pd.concat([merged.relations, rels], ignore_index=True)
+            .drop_duplicates(
+                subset=[schema.OCEL_EID, schema.OCEL_OID, schema.OCEL_TYPE]
+            )
+            .reset_index(drop=True)
+        )
+    if validate:
+        schema.validate(merged)
+    return merged
+
+
+def object_specs_from_metadata(
+    metadata: pd.DataFrame,
+    *,
+    type_field: str = "object_type",
+    value_column_field: str = "object_value_column",
+    uuid_column: str = "uuid",
+) -> list[ObjectSpec]:
+    """Build :class:`ObjectSpec` list from per-signal metadata tags.
+
+    Scans a metadata table (e.g. ``MetadataJsonLoader.to_df()``) for a column
+    naming the object type per signal — so new object types are onboarded by
+    tagging metadata, not by writing code. The uuid may be the index or a
+    column; the type/value-column fields are matched directly or with a
+    ``config_`` / ``config.`` prefix (mkdocs metadata flattening).
+    """
+    md = metadata.reset_index() if metadata.index.name == uuid_column else metadata
+
+    def _col(name: str) -> str | None:
+        for cand in (name, f"config_{name}", f"config.{name}"):
+            if cand in md.columns:
+                return cand
+        return None
+
+    uuid_col = uuid_column if uuid_column in md.columns else None
+    type_col = _col(type_field)
+    if uuid_col is None or type_col is None:
+        return []
+    valcol_col = _col(value_column_field)
+
+    specs: list[ObjectSpec] = []
+    for _, row in md.iterrows():
+        otype = row.get(type_col)
+        if otype is None or pd.isna(otype):
+            continue
+        value_column = "value_string"
+        if valcol_col is not None and not pd.isna(row.get(valcol_col)):
+            value_column = str(row[valcol_col])
+        specs.append(
+            ObjectSpec(
+                uuid=str(row[uuid_col]),
+                object_type=str(otype),
+                value_column=value_column,
+            )
+        )
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Table builders
+# ---------------------------------------------------------------------------
+
+
+def _objects_table(intervals: pd.DataFrame) -> pd.DataFrame:
+    if intervals.empty:
+        return schema.empty_objects()
+    objs = (
+        intervals[[_OID, _TYPE]]
+        .drop_duplicates()
+        .rename(columns={_OID: schema.OCEL_OID, _TYPE: schema.OCEL_TYPE})
+        .reset_index(drop=True)
+    )
+    objs[schema.OCEL_OID] = objs[schema.OCEL_OID].astype("string")
+    objs[schema.OCEL_TYPE] = objs[schema.OCEL_TYPE].astype("string")
+    return objs
+
+
+def _object_changes(
+    intervals: pd.DataFrame, specs: Sequence[ObjectSpec]
+) -> pd.DataFrame:
+    if intervals.empty:
+        return schema.empty_object_changes()
+    attr_cols = [a for spec in specs for a in spec.attributes if a in intervals.columns]
+    rows: list[dict] = []
+    for _, r in intervals.iterrows():
+        # Lifecycle presence as a time-varying attribute.
+        rows.append(_change_row(r, "lifecycle", "active", r[_START]))
+        rows.append(_change_row(r, "lifecycle", "released", r[_END]))
+        for a in attr_cols:
+            val = r.get(a)
+            if val is not None and not pd.isna(val):
+                rows.append(_change_row(r, a, val, r[_START]))
+    out = pd.DataFrame(rows)
+    return out.astype(schema.empty_object_changes().dtypes.to_dict())
+
+
+def _change_row(r: pd.Series, field_name: str, value: object, ts: object) -> dict:
+    return {
+        schema.OCEL_OID: r[_OID],
+        schema.OCEL_TYPE: r[_TYPE],
+        schema.OCEL_FIELD: field_name,
+        schema.OCEL_VALUE: value,
+        schema.OCEL_TIMESTAMP: pd.Timestamp(ts),
+    }
+
+
+def _infer_o2o(intervals: pd.DataFrame) -> pd.DataFrame:
+    """Object-to-object relations from interval overlap between distinct types.
+
+    One relation per overlapping pair: strict containment (one interval wholly
+    inside the other) → ``child part_of parent``; any other overlap →
+    ``co_active``. Each unordered type pair is visited once.
+    """
+    if intervals.empty:
+        return schema.empty_o2o()
+    types = sorted(pd.unique(intervals[_TYPE]))
+    by_type = {t: intervals[intervals[_TYPE] == t] for t in types}
+    rows: list[dict] = []
+    for i, ta in enumerate(types):
+        for tb in types[i + 1 :]:
+            b = by_type[tb]
+            if b.empty:
+                continue
+            bidx = pd.IntervalIndex.from_arrays(b[_START], b[_END], closed="both")
+            for _, a in by_type[ta].iterrows():
+                a_int = pd.Interval(a[_START], a[_END], closed="both")
+                for pos in _overlapping_positions(bidx, a_int):
+                    brow = b.iloc[pos]
+                    if a[_OID] == brow[_OID]:
+                        continue
+                    rows.append(_relate(a, brow))
+    if not rows:
+        return schema.empty_o2o()
+    out = pd.DataFrame(rows).drop_duplicates().reset_index(drop=True)
+    return out.astype(schema.empty_o2o().dtypes.to_dict())
+
+
+def _relate(a: pd.Series, b: pd.Series) -> dict:
+    """One O2O row for an overlapping pair (strict containment → part_of)."""
+    a_in_b = b[_START] <= a[_START] and a[_END] <= b[_END]
+    b_in_a = a[_START] <= b[_START] and b[_END] <= a[_END]
+    if a_in_b and not b_in_a:
+        return _o2o_row(a[_OID], b[_OID], "part_of")  # a (child) part_of b
+    if b_in_a and not a_in_b:
+        return _o2o_row(b[_OID], a[_OID], "part_of")  # b (child) part_of a
+    return _o2o_row(a[_OID], b[_OID], "co_active")
+
+
+def _overlapping_positions(index: pd.IntervalIndex, interval: pd.Interval) -> list[int]:
+    mask = index.overlaps(interval)
+    return [i for i, hit in enumerate(mask) if hit]
+
+
+def _o2o_row(oid: object, oid2: object, qualifier: str) -> dict:
+    return {
+        schema.OCEL_OID: oid,
+        schema.OCEL_OID2: oid2,
+        schema.OCEL_QUALIFIER: qualifier,
+    }
+
+
+def _contained_relations(
+    events: pd.DataFrame,
+    intervals: pd.DataFrame,
+    qualifiers: Mapping[str, str],
+) -> pd.DataFrame:
+    """E2O relations: each event linked to objects whose interval contains it."""
+    if events.empty or intervals.empty:
+        return schema.empty_relations()
+    ts = pd.to_datetime(events[schema.OCEL_TIMESTAMP])
+    rows: list[dict] = []
+    for _, obj in intervals.iterrows():
+        hit = (ts >= obj[_START]) & (ts <= obj[_END])
+        if not hit.any():
+            continue
+        for eid in events.loc[hit, schema.OCEL_EID]:
+            rows.append(
+                {
+                    schema.OCEL_EID: eid,
+                    schema.OCEL_OID: obj[_OID],
+                    schema.OCEL_TYPE: obj[_TYPE],
+                    schema.OCEL_QUALIFIER: qualifiers.get(obj[_TYPE]),
+                }
+            )
+    if not rows:
+        return schema.empty_relations()
+    out = pd.DataFrame(rows)
+    return out.astype(schema.empty_relations().dtypes.to_dict())

--- a/tests/eventlog/test_objects.py
+++ b/tests/eventlog/test_objects.py
@@ -76,16 +76,60 @@ def test_unknown_object_type_is_auto_registered(id_signals):
     assert is_known_object_type("coil")
 
 
-def test_o2o_containment_serial_part_of_batch(id_signals):
+def test_default_o2o_is_co_occurs_not_part_of(id_signals):
+    # part_of must NOT be guessed from temporal overlap alone.
     log = detect_objects(id_signals, SPECS)
-    o2o = log.o2o
-    # Every serial sits inside a batch → part_of.
-    part_of = o2o[o2o[OCEL_QUALIFIER] == "part_of"]
+    assert set(log.o2o[OCEL_QUALIFIER]) == {"co_occurs"}
+    assert "part_of" not in set(log.o2o[OCEL_QUALIFIER])
+
+
+def test_hierarchy_gives_part_of(id_signals):
+    log = detect_objects(id_signals, SPECS, hierarchy={"serial": "batch"})
+    part_of = log.o2o[log.o2o[OCEL_QUALIFIER] == "part_of"]
     pairs = set(zip(part_of[OCEL_OID], part_of[OCEL_OID2]))
     assert ("serial:S1", "batch:B1") in pairs
     assert ("serial:S6", "batch:B2") in pairs
-    # A serial is never reported as part_of a different batch.
+    # A serial is never part_of a different batch...
     assert ("serial:S1", "batch:B2") not in pairs
+    # ...and only the declared edge produces part_of (no serial part_of coil).
+    assert all(parent.startswith("batch:") for _, parent in pairs)
+
+
+def test_long_lived_object_is_not_a_spurious_parent():
+    # A tool spans every batch in time but does NOT own them: time-containment
+    # must not manufacture `batch part_of tool`.
+    batch = make_id_signal("sig:batch", ["B1", "B2"], hold=30, source_uuid="L1")
+    tool = make_id_signal("sig:tool", ["T1"], hold=60, source_uuid="L1")
+    df = pd.concat([batch, tool], ignore_index=True)
+    specs = [
+        ObjectSpec("sig:batch", "batch", id_template="{type}:{value}"),
+        ObjectSpec("sig:tool", "tool", id_template="{type}:{value}"),
+    ]
+    log = detect_objects(df, specs)  # no hierarchy declared
+    assert "part_of" not in set(log.o2o[OCEL_QUALIFIER])
+
+
+def test_single_sample_and_leading_object_not_lost():
+    # The leading object and a single-sample object must both survive, with the
+    # first object starting at its first sample (regression: off-by-one drop).
+    sig = pd.DataFrame(
+        {
+            "systime": pd.to_datetime(
+                ["2025-01-01 00:00", "2025-01-01 00:10"], utc=True
+            ),
+            "uuid": "sig:b",
+            "value_string": pd.array(["BX", "BY"], dtype="string"),
+            "value_bool": pd.NA,
+            "value_integer": pd.NA,
+            "value_double": float("nan"),
+            "is_delta": False,
+        }
+    )
+    iv = object_intervals(sig, [ObjectSpec("sig:b", "batch")])
+    assert set(iv["oid"]) == {"BX", "BY"}
+    assert str(iv.iloc[0]["start"]) == "2025-01-01 00:00:00+00:00"
+    # Gap-fill: BX is present until BY appears (not just its single sample).
+    assert iv.iloc[0]["end"] > iv.iloc[0]["start"]
 
 
 def test_object_changes_record_lifecycle(id_signals):

--- a/tests/eventlog/test_objects.py
+++ b/tests/eventlog/test_objects.py
@@ -1,0 +1,184 @@
+"""Tests for the object-detection layer (ts_shape.eventlog.objects)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ts_shape.datasets import make_id_signal
+from ts_shape.eventlog import (
+    OCEL2Tables,
+    ObjectSpec,
+    attach_objects,
+    concat,
+    detect_objects,
+    object_intervals,
+    object_specs_from_metadata,
+    to_event_log,
+    to_event_log_ocel,
+    to_event_log_xes,
+    validate,
+)
+from ts_shape.eventlog.schema import (
+    OCEL_FIELD,
+    OCEL_OID,
+    OCEL_OID2,
+    OCEL_QUALIFIER,
+    OCEL_TYPE,
+    OCEL_VALUE,
+    is_known_object_type,
+)
+from ts_shape.events.production.machine_state import MachineStateEvents
+
+
+@pytest.fixture()
+def id_signals():
+    """Two batches, six serials (3 per batch), and a coil signal on one line."""
+    batch = make_id_signal("sig:batch", ["B1", "B2"], hold=30, source_uuid="line-1")
+    serial = make_id_signal(
+        "sig:serial",
+        ["S1", "S2", "S3", "S4", "S5", "S6"],
+        hold=10,
+        source_uuid="line-1",
+    )
+    coil = make_id_signal("sig:coil", ["C1", "C2"], hold=30, source_uuid="line-1")
+    return pd.concat([batch, serial, coil], ignore_index=True)
+
+
+SPECS = [
+    ObjectSpec("sig:batch", "batch", id_template="{type}:{value}"),
+    ObjectSpec("sig:serial", "serial", id_template="{type}:{value}"),
+    ObjectSpec("sig:coil", "coil", id_template="{type}:{value}"),  # unregistered type
+]
+
+
+def test_object_intervals_segments_id_signals(id_signals):
+    iv = object_intervals(id_signals, SPECS)
+    # 2 batches + 6 serials + 2 coils = 10 object instances.
+    assert len(iv) == 10
+    assert set(iv["type"]) == {"batch", "serial", "coil"}
+    assert "batch:B1" in set(iv["oid"])
+    # Each interval has a start <= end.
+    assert (iv["start"] <= iv["end"]).all()
+
+
+def test_detect_objects_builds_valid_ocel_tables(id_signals):
+    log = detect_objects(id_signals, SPECS)  # validates internally
+    validate(log)
+    assert len(log.events) == 0  # objects-only log
+    assert len(log.objects) == 10
+    assert set(log.objects[OCEL_TYPE]) == {"batch", "serial", "coil"}
+
+
+def test_unknown_object_type_is_auto_registered(id_signals):
+    assert not is_known_object_type("coil") or True  # may already be registered
+    detect_objects(id_signals, SPECS)
+    assert is_known_object_type("coil")
+
+
+def test_o2o_containment_serial_part_of_batch(id_signals):
+    log = detect_objects(id_signals, SPECS)
+    o2o = log.o2o
+    # Every serial sits inside a batch → part_of.
+    part_of = o2o[o2o[OCEL_QUALIFIER] == "part_of"]
+    pairs = set(zip(part_of[OCEL_OID], part_of[OCEL_OID2]))
+    assert ("serial:S1", "batch:B1") in pairs
+    assert ("serial:S6", "batch:B2") in pairs
+    # A serial is never reported as part_of a different batch.
+    assert ("serial:S1", "batch:B2") not in pairs
+
+
+def test_object_changes_record_lifecycle(id_signals):
+    log = detect_objects(id_signals, SPECS)
+    fields = set(log.object_changes[OCEL_FIELD])
+    assert "lifecycle" in fields
+    # active + released per object instance.
+    lc = log.object_changes[log.object_changes[OCEL_FIELD] == "lifecycle"]
+    assert set(lc[OCEL_VALUE]) >= {"active", "released"}
+
+
+def test_captured_attributes_become_object_changes():
+    batch = make_id_signal("sig:batch", ["B1", "B2"], hold=20, source_uuid="line-1")
+    recipe = make_id_signal(
+        "sig:recipe", ["R-hot", "R-cold"], hold=20, source_uuid="line-1"
+    )
+    df = pd.concat([batch, recipe], ignore_index=True)
+    specs = [
+        ObjectSpec(
+            "sig:batch",
+            "batch",
+            id_template="{type}:{value}",
+            attributes={"recipe": "sig:recipe"},
+        )
+    ]
+    log = detect_objects(df, specs)
+    recipe_changes = log.object_changes[log.object_changes[OCEL_FIELD] == "recipe"]
+    assert not recipe_changes.empty
+    assert "R-hot" in set(recipe_changes[OCEL_VALUE])
+
+
+def test_attach_objects_links_events_by_containment(id_signals):
+    # Build a real event log from a state signal on the same line/time window.
+    state = make_id_signal(
+        "sig:state", ["run", "idle", "run", "idle"], hold=15, source_uuid="line-1"
+    )
+    state["value_bool"] = state["value_string"].isin(["run"])
+    legacy = MachineStateEvents(state, run_state_uuid="sig:state").detect_run_idle()
+    legacy["source_uuid"] = "line-1"
+    ev_log = to_event_log(legacy, detector="MachineStateEvents.detect_run_idle")
+
+    enriched = attach_objects(
+        ev_log,
+        id_signals,
+        SPECS,
+        qualifiers={"batch": "during_batch", "serial": "identified_by"},
+    )
+    validate(enriched)
+    # Events now reference detected objects via E2O relations.
+    assert len(enriched.relations) > len(ev_log.relations)
+    linked_types = set(enriched.relations[OCEL_TYPE])
+    assert {"batch", "serial"} <= linked_types
+    # Qualifiers propagated.
+    assert "during_batch" in set(enriched.relations[OCEL_QUALIFIER].dropna())
+
+    # Full OCEL 2.0 export carries all five tables.
+    tables = to_event_log_ocel(enriched)
+    assert isinstance(tables, OCEL2Tables)
+    assert len(tables.o2o) > 0
+    # XES flattening with the asset case still works.
+    flat = to_event_log_xes(enriched, case_object_type="asset")
+    assert not flat.empty
+
+
+def test_concat_objects_log_with_event_log(id_signals):
+    state = make_id_signal("sig:state", ["run", "idle"], hold=20, source_uuid="line-1")
+    state["value_bool"] = state["value_string"].isin(["run"])
+    legacy = MachineStateEvents(state, run_state_uuid="sig:state").detect_run_idle()
+    legacy["source_uuid"] = "line-1"
+    ev_log = to_event_log(legacy, detector="MachineStateEvents.detect_run_idle")
+    obj_log = detect_objects(id_signals, SPECS)
+
+    merged = concat(ev_log, obj_log)
+    validate(merged)
+    assert len(merged.events) == len(ev_log.events)
+    assert len(merged.objects) >= 10
+
+
+def test_object_specs_from_metadata():
+    metadata = pd.DataFrame(
+        {
+            "uuid": ["sig:batch", "sig:serial", "sig:temp"],
+            "object_type": ["batch", "serial", None],
+            "object_value_column": ["value_string", "value_string", None],
+        }
+    )
+    specs = object_specs_from_metadata(metadata)
+    assert {s.object_type for s in specs} == {"batch", "serial"}
+    assert {s.uuid for s in specs} == {"sig:batch", "sig:serial"}
+
+
+def test_empty_specs_yield_empty_objects(id_signals):
+    log = detect_objects(id_signals, [])
+    assert len(log.objects) == 0
+    assert len(log.o2o) == 0
+    validate(log)


### PR DESCRIPTION
## Summary

Adds a first-class **object-detection** layer to complement the 290+ event detectors. Manufacturing timeseries carry many object identifiers — batch, serial, coil, material, recipe, tool, drum, bundle, family, customer part-number… Until now an object only reached the event log as a side-effect of event detection. This adds a single, generic, **declarative** layer (not another family of detector classes): you describe which signals carry which object type, and the existing OCEL 2.0 object model is populated. **New object types are added by data/config, never by code.**

New module `src/ts_shape/eventlog/objects.py`:

- **`ObjectSpec`** — declares *signal uuid → object type* (+ value column, min duration, id template, captured attributes). Unknown types are auto-registered.
- **`object_intervals()`** — run-length-encodes each id signal into `(oid, type, start, end)` presence intervals.
- **`detect_objects()`** — builds the OCEL 2.0 `objects` / `o2o` / `object_changes` tables. Returns an events-less `EventLog` that composes with any event log via `concat`.
- **`attach_objects()`** — links the events of *any* existing event detector to the detected objects by temporal containment (E2O), with zero per-detector changes.
- **`object_specs_from_metadata()`** — derive specs from per-signal metadata tags, so object types are onboarded by tagging metadata.
- `datasets.make_id_signal()` to synthesize categorical id streams.

## Correctness (this is the important part)

A review of the first cut surfaced three real bugs — all fixed and regression-tested:

- **`part_of` was guessed from temporal overlap, which is invalid.** A long-running `tool`/`shift` temporally contains every batch without owning it. Now `part_of` is asserted **only along a declared `hierarchy`** (child type → parent type); incidental overlap is reported honestly as `co_occurs`.
- **The run-length kernel dropped the first sample of every signal** (nullable `value.ne(value.shift())` → `<NA>` first group → dropped by `groupby`), so the leading object's start was off by one and a single-sample object vanished. Object detection now uses a correct local RLE. (`SegmentExtractor` is left untouched — it's pinned by its own tests.)
- **Presence ended at the last observed sample**, leaving gaps that orphaned events. An id is now present until the next id on the same signal appears.

## Verification

- `python -m pytest -q` → **1280 passed**
- `black --check src/ tests/` and `ruff check src/ tests/` → clean
- `DISABLE_MKDOCS_2_WARNING=true mkdocs build` → clean
- `python examples/object_detection_demo.py` → runs end to end

Docs: new guide `docs/guides/eventlog/objects.md` (wired into nav) and a runnable demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Y3XcAbSZLj4MKA9mSNtLS)_